### PR TITLE
feat(ui): implement native macOS titlebar with draggable region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ src-tauri/crates/*/target/
 # Tauri
 src-tauri/gen/
 /.env
+
+# Claude Code
+.claude/

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,9 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "core:window:allow-start-dragging"
+  ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,9 @@
       {
         "title": "roxidy",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,7 +204,7 @@ function App() {
     return (
       <div className="h-screen w-screen bg-[#1a1b26] flex flex-col overflow-hidden">
         {/* Skeleton tab bar */}
-        <div className="flex items-center h-9 bg-[#16161e] border-b border-[#27293d] px-2 gap-2">
+        <div className="flex items-center h-9 bg-[#1a1b26] pl-[78px] pr-2 gap-2 titlebar-drag">
           <Skeleton className="h-6 w-24 bg-[#1f2335]" />
           <Skeleton className="h-6 w-6 rounded bg-[#1f2335]" />
         </div>

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -1,3 +1,4 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Bot, Plus, Terminal, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -5,6 +6,15 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { ptyDestroy } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 import { type Session, useStore } from "@/store";
+
+const startDrag = async (e: React.MouseEvent) => {
+  e.preventDefault();
+  try {
+    await getCurrentWindow().startDragging();
+  } catch (err) {
+    console.error("Failed to start dragging:", err);
+  }
+};
 
 interface TabBarProps {
   onNewTab: () => void;
@@ -30,11 +40,15 @@ export function TabBar({ onNewTab }: TabBarProps) {
 
   return (
     <TooltipProvider delayDuration={300}>
-      <div className="flex items-center h-9 bg-[#16161e] border-b border-[#27293d] px-1 gap-1">
+      <div
+        className="flex items-center h-9 bg-[#1a1b26] pl-[78px] pr-1 gap-1"
+        onMouseDown={startDrag}
+      >
         <Tabs
           value={activeSessionId || undefined}
           onValueChange={setActiveSession}
-          className="flex-1 min-w-0"
+          className="min-w-0"
+          onMouseDown={(e) => e.stopPropagation()}
         >
           <TabsList className="h-7 bg-transparent p-0 gap-1 w-full justify-start">
             {sessionList.map((session) => (
@@ -56,6 +70,7 @@ export function TabBar({ onNewTab }: TabBarProps) {
               variant="ghost"
               size="icon"
               onClick={onNewTab}
+              onMouseDown={(e) => e.stopPropagation()}
               className="h-7 w-7 text-[#565f89] hover:text-[#c0caf5] hover:bg-[#1f2335]"
             >
               <Plus className="w-4 h-4" />
@@ -65,6 +80,9 @@ export function TabBar({ onNewTab }: TabBarProps) {
             <p>New tab (⌘T)</p>
           </TooltipContent>
         </Tooltip>
+
+        {/* Drag region - empty space extends to fill remaining width */}
+        <div className="flex-1 h-full min-w-[100px]" />
       </div>
     </TooltipProvider>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -167,3 +167,12 @@
   width: 12px !important;
   height: 12px !important;
 }
+
+/* Custom title bar drag region */
+.titlebar-drag {
+  -webkit-app-region: drag;
+}
+
+.titlebar-no-drag {
+  -webkit-app-region: no-drag;
+}


### PR DESCRIPTION
## Summary
Implements a seamless native titlebar experience for macOS that integrates window controls directly into the application's tab bar, creating a more modern and space-efficient interface.

## Changes
- **Tauri Configuration**: Set titlebar style to `Overlay` with hidden title for seamless integration
- **Window Permissions**: Added `core:window:allow-start-dragging` capability for custom drag behavior
- **TabBar Component**: 
  - Implemented window dragging via `getCurrentWindow().startDragging()` API
  - Added 78px left padding to accommodate macOS traffic light controls
  - Event propagation handling to prevent drag on interactive elements (tabs, buttons)
  - Flex spacer to ensure remaining titlebar area is draggable
- **Styling**: 
  - Added `-webkit-app-region` CSS classes for drag/no-drag regions
  - Updated background colors to match seamless design (#1a1b26)
  - Removed visual border between titlebar and content
- **Skeleton UI**: Updated loading state to match new titlebar layout
- **gitignore**: Added `.claude/` directory

## Breaking Changes
None - This is a visual enhancement that doesn't affect existing functionality or APIs.

## Test Plan
- [x] Build the application: `just build`
- [x] Run on macOS: `just dev`
- [x] Verify window dragging works by clicking/dragging empty titlebar area
- [x] Verify tabs remain clickable and don't trigger window drag
- [x] Verify "New tab" button remains clickable
- [x] Check traffic light buttons (red/yellow/green) are visible and positioned correctly
- [x] Test window minimize, maximize, and close via traffic lights
- [x] Verify tooltips still work on interactive elements

**Manual testing steps:**
```bash
# Start dev server
just dev

# Verify:
# 1. Window can be dragged from empty areas of tab bar
# 2. Clicking tabs switches sessions without dragging window
# 3. Plus button creates new tab without dragging
# 4. macOS traffic lights are positioned at ~78px from left edge
# 5. Visual appearance is seamless (no double titlebar effect)
```

## Related Issues
N/A - Proactive UI/UX improvement

## Release Notes
The macOS app now features a seamless titlebar design that integrates window controls directly into the tab bar, providing a more modern appearance and maximizing vertical space for terminal content. The titlebar area is draggable while keeping all interactive elements (tabs, buttons) fully functional.

## Screenshots/Logs
Before: Traditional titlebar with separate window controls and tab bar
After: Seamless integration with traffic lights overlaying the tab bar area

## Checklist
- [x] Tests pass locally (`just test`)
- [x] Linting passes (`just check`)
- [x] Documentation updated (N/A - UI change only)
- [x] Breaking changes documented (None)
- [x] Conventional commit format followed
- [x] macOS-specific behavior tested
- [x] Interactive elements remain accessible
- [x] Window management (drag/minimize/maximize/close) works correctly