### PR TITLE
feat(ui): add terminal mode indicator to status bar

### DIFF
--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -126,39 +126,46 @@ export function StatusBar({ sessionId }: StatusBarProps) {
           </button>
         </div>
 
-        {/* Model selector badge */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2.5 gap-1.5 text-sm font-normal rounded-md bg-[#bb9af7]/10 text-[#bb9af7] hover:bg-[#bb9af7]/20 hover:text-[#bb9af7]"
-            >
-              <Cpu className="w-4 h-4" />
-              <span>{formatModel(model)}</span>
-              <ChevronDown className="w-4 h-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="start"
-            className="bg-[#1f2335] border-[#3b4261] min-w-[180px]"
-          >
-            {AVAILABLE_MODELS.map((m) => (
-              <DropdownMenuItem
-                key={m.id}
-                onClick={() => handleModelSelect(m.id)}
-                className={cn(
-                  "text-sm cursor-pointer",
-                  model === m.id
-                    ? "text-[#bb9af7] bg-[#bb9af7]/10"
-                    : "text-[#c0caf5] hover:text-[#bb9af7]"
-                )}
+        {/* Model selector badge or Terminal Mode indicator */}
+        {inputMode === "terminal" ? (
+          <div className="h-7 px-2.5 gap-1.5 text-sm font-normal rounded-md bg-[#7aa2f7]/10 text-[#7aa2f7] flex items-center">
+            <Terminal className="w-4 h-4" />
+            <span>Terminal Mode</span>
+          </div>
+        ) : (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2.5 gap-1.5 text-sm font-normal rounded-md bg-[#bb9af7]/10 text-[#bb9af7] hover:bg-[#bb9af7]/20 hover:text-[#bb9af7]"
               >
-                {m.name}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+                <Cpu className="w-4 h-4" />
+                <span>{formatModel(model)}</span>
+                <ChevronDown className="w-4 h-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="start"
+              className="bg-[#1f2335] border-[#3b4261] min-w-[180px]"
+            >
+              {AVAILABLE_MODELS.map((m) => (
+                <DropdownMenuItem
+                  key={m.id}
+                  onClick={() => handleModelSelect(m.id)}
+                  className={cn(
+                    "text-sm cursor-pointer",
+                    model === m.id
+                      ? "text-[#bb9af7] bg-[#bb9af7]/10"
+                      : "text-[#c0caf5] hover:text-[#bb9af7]"
+                  )}
+                >
+                  {m.name}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
 
       {/* Right side - Provider */}


### PR DESCRIPTION
## Summary
Adds a "Terminal Mode" indicator to the status bar that replaces the model selector dropdown when the input mode is set to terminal, providing clearer visual feedback about the current mode.

## Changes
- Added conditional rendering in StatusBar component based on `inputMode` state
- Display Terminal icon with "Terminal Mode" text when in terminal mode
- Maintain existing model selector dropdown functionality when in agent mode
- Applied consistent Tokyo Night theme styling (`bg-[#7aa2f7]/10 text-[#7aa2f7]`)

## Breaking Changes
None

## Test Plan
- [x] Run the app with `just dev`
- [x] Toggle between terminal and agent modes using the input mode selector
- [x] Verify "Terminal Mode" indicator appears in terminal mode
- [x] Verify model selector dropdown appears and functions correctly in agent mode
- [x] Confirm styling matches the Tokyo Night color scheme
- [x] Test that model selection still works when switching back to agent mode

## Related Issues
None

## Release Notes
The status bar now displays a "Terminal Mode" indicator when using terminal mode, making it clearer which input mode is active and preventing confusion about when the AI model selector applies.

## Screenshots/Logs
The Terminal Mode indicator appears as a badge with a terminal icon, similar in style to the model selector but non-interactive and colored blue (#7aa2f7) to distinguish it from the purple (#bb9af7) model selector.

## Checklist
- [x] Conventional commit format followed
- [x] Code follows existing patterns in StatusBar component
- [x] Styling consistent with Tokyo Night theme
- [x] No breaking changes introduced