### PR TITLE
fix(settings): resolve fullscreen dialog layout and overflow issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -437,7 +437,7 @@ function App() {
   return (
     <div className="h-screen w-screen bg-background flex flex-col overflow-hidden app-bg-layered">
       {/* Tab bar */}
-      <TabBar onNewTab={handleNewTab} />
+      <TabBar onNewTab={handleNewTab} onOpenSettings={() => setSettingsOpen(true)} />
 
       {/* Main content area with sidebar */}
       <div className="flex-1 min-h-0 min-w-0 flex overflow-hidden">

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -145,7 +145,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="!max-w-none !top-0 !left-0 !right-0 !bottom-0 !translate-x-0 !translate-y-0 !w-full !h-full p-0 bg-[#1a1b26] border-0 rounded-none text-[#c0caf5] flex flex-col"
+        className="!max-w-none !inset-0 !translate-x-0 !translate-y-0 !w-screen !h-screen p-0 bg-[#1a1b26] border-0 rounded-none text-[#c0caf5] flex flex-col overflow-hidden"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-[#3b4261] flex-shrink-0">
@@ -164,7 +164,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
             <Loader2 className="w-6 h-6 text-[#565f89] animate-spin" />
           </div>
         ) : settings ? (
-          <div className="flex-1 flex min-h-0">
+          <div className="flex-1 flex min-h-0 overflow-hidden">
             {/* Sidebar Navigation */}
             <nav className="w-64 border-r border-[#3b4261] flex flex-col flex-shrink-0">
               <div className="flex-1 py-2">
@@ -195,8 +195,8 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
             </nav>
 
             {/* Main Content */}
-            <div className="flex-1 flex flex-col min-w-0">
-              <ScrollArea className="flex-1">
+            <div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
+              <ScrollArea className="h-full">
                 <div className="p-6 max-w-3xl">{renderContent()}</div>
               </ScrollArea>
             </div>


### PR DESCRIPTION
## Summary
Fixes layout and overflow issues with the settings dialog that prevented it from properly displaying as a fullscreen modal.

## Changes
- Replace individual positional CSS properties (`!top-0 !left-0 !right-0 !bottom-0`) with `!inset-0` for cleaner fullscreen positioning
- Change dimensions from `!w-full !h-full` to `!w-screen !h-screen` to ensure true viewport coverage
- Add `overflow-hidden` class to dialog content, flex container, and content wrapper to prevent scroll bleed-through
- Fix ScrollArea to use `h-full` instead of `flex-1` for proper scroll behavior within content area
- Pass `onOpenSettings` callback to TabBar component to enable settings access from the header

## Breaking Changes
None

## Test Plan
- [ ] Open the settings dialog via TabBar
- [ ] Verify the dialog fills the entire screen without gaps
- [ ] Navigate between settings sections and confirm scrolling works correctly within content area
- [ ] Ensure no unexpected scrollbars appear on the dialog container
- [ ] Test on different viewport sizes

## Related Issues
None

## Release Notes
Fixed settings dialog layout issues where the fullscreen modal would not properly fill the viewport and could exhibit unwanted scrollbar behavior.

## Checklist
- [x] Tests pass locally
- [x] Linting passes
- [x] Conventional commit format followed