### PR TITLE
docs(readme): mark OpenRouter as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Currently supports **Anthropic Claude via Vertex AI**. More providers coming soo
 | Provider | Status |
 |----------|--------|
 | Anthropic (Vertex AI) | ✅ Supported |
+| OpenRouter | ✅ Supported |
 | Anthropic (Direct API) | 🚧 In Progress |
 | OpenAI | 🚧 In Progress |
 | Google Gemini | 🚧 In Progress |
-| OpenRouter | 🚧 In Progress |
 
 ### 📦 Modern Terminal Features
 


### PR DESCRIPTION
## Summary
Updates the README provider support table to reflect that OpenRouter is now supported.

## Commits
- `05a7ea4` docs(readme): mark OpenRouter as supported

## Changes
- Marked OpenRouter as ✅ Supported in the provider status table.

## Breaking Changes
None

## Test Plan
- [ ] Not applicable (documentation-only change)

## Related Issues
None

## Release Notes
Docs: The README now lists OpenRouter as a supported provider.

## Checklist
- [x] Conventional commit format followed
- [x] No code changes (tests not required)