### PR TITLE
fix(ui): extend tool cards to full width like thinking cards

### DIFF
--- a/src/components/ToolCallDisplay/ToolCallDisplay.tsx
+++ b/src/components/ToolCallDisplay/ToolCallDisplay.tsx
@@ -120,7 +120,7 @@ export const ToolItem = memo(function ToolItem({
     <Collapsible open={isOpen} onOpenChange={canExpand ? setIsOpen : undefined}>
       <div
         className={cn(
-          "border-l-[3px] border-r-0 border-t-0 border-b-0 overflow-hidden rounded-l-lg max-w-3xl shadow-sm",
+          "border-l-[3px] border-r-0 border-t-0 border-b-0 overflow-hidden rounded-l-lg shadow-sm",
           isTerminalCmd
             ? "border-l-accent bg-[var(--accent-dim)]"
             : cn(status.borderColor, "bg-muted/50"),

--- a/src/components/ToolCallDisplay/ToolGroup.tsx
+++ b/src/components/ToolCallDisplay/ToolGroup.tsx
@@ -159,7 +159,7 @@ export const ToolGroup = memo(function ToolGroup({ group, compact = false }: Too
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <div
         className={cn(
-          "border-l-[3px] border-r-0 border-t-0 border-b-0 overflow-hidden rounded-l-lg max-w-3xl shadow-sm",
+          "border-l-[3px] border-r-0 border-t-0 border-b-0 overflow-hidden rounded-l-lg shadow-sm",
           compact ? "bg-muted" : "bg-muted/50",
           status.borderColor
         )}


### PR DESCRIPTION
## Summary

Remove `max-w-3xl` constraint from tool call cards so they extend to the same width as thinking cards.

## Changes

- `ToolCallDisplay.tsx`: Remove max-width constraint
- `ToolGroup.tsx`: Remove max-width constraint

## Before/After

Before: Tool cards were constrained to `max-w-3xl` (768px) while thinking cards extended full width.

After: Both tool cards and thinking cards extend to full width consistently.