### PR TITLE
fix(ui): align streaming and completed agent response font styles

### DIFF
--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -67,7 +67,7 @@ function CodeBlock({
 /** Lightweight renderer for streaming content - minimal parsing overhead */
 function StreamingMarkdown({ content }: { content: string }) {
   return (
-    <div className="space-y-3 text-foreground break-words leading-relaxed">
+    <div className="space-y-3 text-[14px] font-medium text-foreground/85 break-words leading-relaxed">
       {content.split("\n\n").map((paragraph, idx) => {
         // Detect code blocks (triple backticks)
         if (paragraph.trim().startsWith("```") && paragraph.trim().endsWith("```")) {
@@ -99,7 +99,7 @@ function StreamingMarkdown({ content }: { content: string }) {
             <p
               // biome-ignore lint/suspicious/noArrayIndexKey: paragraphs are in fixed order
               key={idx}
-              className="text-foreground leading-relaxed"
+              className="leading-relaxed"
             >
               {paragraph}
             </p>

--- a/src/components/UnifiedTimeline/UnifiedTimeline.tsx
+++ b/src/components/UnifiedTimeline/UnifiedTimeline.tsx
@@ -186,7 +186,7 @@ export function UnifiedTimeline({ sessionId }: UnifiedTimelineProps) {
               return (
                 // biome-ignore lint/suspicious/noArrayIndexKey: blocks are appended and never reordered
                 <div key={`text-${blockIndex}`}>
-                  <Markdown content={block.content} className="text-sm" streaming />
+                  <Markdown content={block.content} className="text-[14px] font-medium leading-relaxed text-foreground/85" streaming />
                   {isLast && (
                     <span className="inline-block w-2 h-4 bg-[var(--ansi-magenta)] animate-pulse ml-0.5 align-middle" />
                   )}


### PR DESCRIPTION
## Summary
- Fixes inconsistent font styling between streaming and completed agent responses
- Streaming text now uses same typography: 14px size, medium weight, relaxed line-height, 85% foreground opacity

## Test plan
- [ ] Run `just dev` and start an agent conversation
- [ ] Observe streaming text as agent responds
- [ ] Verify font size/weight matches after response completes