### PR TITLE
feat(ai): enable all tools for main agent and fix HITL session bug

### DIFF
--- a/docs/tool-use.md
+++ b/docs/tool-use.md
@@ -1,0 +1,285 @@
+# Tool Use Architecture
+
+This document explains how the AI agent's tool system works in Qbit.
+
+## Overview
+
+The tool system enables the AI agent to interact with the local environment through defined actions like reading files, executing shell commands, and searching the web. Tools flow through three layers:
+
+```
+Tool Definitions (schemas)
+        ↓
+Tool Execution (handlers)
+        ↓
+HITL Approval (safety)
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src-tauri/src/ai/tool_definitions.rs` | Tool schemas and presets |
+| `src-tauri/src/ai/tool_executors.rs` | Tool execution handlers |
+| `src-tauri/src/ai/agentic_loop.rs` | Execution flow and HITL integration |
+| `src-tauri/src/ai/hitl/approval_recorder.rs` | Approval tracking and risk levels |
+
+## Tool Categories
+
+### 1. Standard Tools (from vtcode-core)
+
+Provided by the vtcode-core crate via `build_function_declarations()`:
+
+- **File operations**: `read_file`, `write_file`, `edit_file`, `delete_file`, `create_file`
+- **Search**: `grep_file`, `list_files`
+- **Shell**: `run_command` (wraps `run_pty_cmd` internally)
+- **Web**: `web_fetch`
+- **Code execution**: `execute_code`, `apply_patch`
+
+### 2. Indexer Tools (custom)
+
+Semantic code analysis tools defined in `get_indexer_tool_definitions()`:
+
+- `indexer_search_code` - Regex search in indexed workspace
+- `indexer_search_files` - Glob pattern file search
+- `indexer_analyze_file` - Semantic analysis with tree-sitter
+- `indexer_extract_symbols` - Extract functions, classes, imports
+- `indexer_get_metrics` - Code metrics (LOC, comments, etc.)
+- `indexer_detect_language` - Language detection
+
+### 3. Tavily Tools (custom)
+
+Web search tools defined in `get_tavily_tool_definitions()`:
+
+- `web_search` - Search with result snippets
+- `web_search_answer` - AI-generated answer from search
+- `web_extract` - Extract content from URLs
+
+### 4. Sub-agent Tools (dynamic)
+
+Generated from `SubAgentRegistry` in `get_sub_agent_tool_definitions()`:
+
+- `sub_agent_code_explorer` - Navigate and map codebases
+- `sub_agent_code_analyzer` - Deep semantic analysis
+- `sub_agent_code_writer` - Implement code changes
+- `sub_agent_researcher` - Web research
+- `sub_agent_shell_executor` - Complex command orchestration
+
+### 5. Workflow Tools (custom)
+
+Multi-step AI workflows defined in `get_workflow_tool_definitions()`:
+
+- `run_workflow` - Execute pre-defined task pipelines
+
+## Tool Presets
+
+Three preset levels control default tool availability:
+
+```rust
+pub enum ToolPreset {
+    Minimal,   // read, edit, write, run_command (4 tools)
+    Standard,  // Core development tools (default)
+    Full,      // All vtcode tools
+}
+```
+
+## Tool Configuration
+
+`ToolConfig` provides fine-grained control:
+
+```rust
+pub struct ToolConfig {
+    pub preset: ToolPreset,      // Base preset
+    pub additional: Vec<String>, // Extra tools to enable
+    pub disabled: Vec<String>,   // Tools to disable
+}
+```
+
+The main agent uses `ToolConfig::main_agent()`:
+
+```rust
+pub fn main_agent() -> Self {
+    Self {
+        preset: ToolPreset::Standard,
+        additional: vec![
+            "execute_code".to_string(),
+            "apply_patch".to_string(),
+        ],
+        disabled: vec![],  // All tools enabled
+    }
+}
+```
+
+## Execution Flow
+
+### 1. Tool Request
+
+The LLM receives tool definitions via `CompletionRequest.tools` and returns tool calls in its response.
+
+### 2. HITL Check (`execute_with_hitl`)
+
+Located in `agentic_loop.rs`:
+
+1. **Policy denial check** - Is tool blocked by policy?
+2. **Constraint application** - Apply file patterns, timeouts, etc.
+3. **Policy allow check** - Does policy explicitly allow?
+4. **Auto-approval check** - Should auto-approve based on learned patterns?
+5. **User approval request** - Emit event, wait for response (5-minute timeout)
+
+### 3. Tool Execution (`execute_tool_direct`)
+
+Routes to specialized executors:
+
+```rust
+if is_indexer_tool(tool_name) {
+    return execute_indexer_tool(...);
+}
+if tool_name == "web_fetch" {
+    return execute_web_fetch_tool(...);
+}
+if is_tavily_tool(tool_name) {
+    return execute_tavily_tool(...);
+}
+if tool_name == "run_workflow" {
+    return execute_workflow_tool(...);
+}
+if tool_name.starts_with("sub_agent_") {
+    return execute_sub_agent(...);
+}
+// Fall through to vtcode registry
+registry.execute_tool(tool_name, tool_args).await
+```
+
+## Risk Levels
+
+Defined in `RiskLevel::for_tool()`:
+
+| Level | Tools | Behavior |
+|-------|-------|----------|
+| Low | `read_file`, `grep_file`, `list_files`, indexer tools | Can auto-approve |
+| Medium | `write_file`, `edit_file` | Can auto-approve after learning |
+| High | `run_command`, `run_pty_cmd`, `send_pty_input` | Always requires approval |
+| Critical | `delete_file`, `execute_code` | Always requires approval |
+
+### Auto-Approval Learning
+
+For tools not in `always_require_approval`:
+
+- Minimum 3 approvals required
+- 80% approval rate threshold
+- Pattern matching based on tool name
+
+## Adding a New Tool
+
+### Step 1: Define the Tool
+
+In `tool_definitions.rs`, add to appropriate function:
+
+```rust
+ToolDefinition {
+    name: "my_tool".to_string(),
+    description: "What this tool does".to_string(),
+    parameters: json!({
+        "type": "object",
+        "properties": {
+            "param": {
+                "type": "string",
+                "description": "Parameter description"
+            }
+        },
+        "required": ["param"]
+    }),
+}
+```
+
+### Step 2: Implement the Executor
+
+In `tool_executors.rs`:
+
+```rust
+pub async fn execute_my_tool(
+    tool_name: &str,
+    args: &serde_json::Value,
+) -> ToolResult {
+    let param = args.get("param")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("Missing param"))?;
+
+    // Execute tool logic
+    let result = do_something(param)?;
+
+    Ok((json!({ "result": result }), true))
+}
+```
+
+### Step 3: Route the Executor
+
+In `agentic_loop.rs` `execute_tool_direct()`:
+
+```rust
+if tool_name == "my_tool" {
+    let (value, success) = execute_my_tool(tool_name, tool_args).await?;
+    return Ok(ToolExecutionResult { value, success });
+}
+```
+
+### Step 4: Set Risk Level
+
+In `approval_recorder.rs` `RiskLevel::for_tool()`:
+
+```rust
+"my_tool" => RiskLevel::Medium,
+```
+
+### Step 5: Add to Preset (Optional)
+
+In `ToolPreset::tool_names()` if it should be available by default:
+
+```rust
+ToolPreset::Standard => Some(vec![
+    // existing tools...
+    "my_tool",
+]),
+```
+
+## Frontend Integration
+
+### Events
+
+Tool approval requests emit `AiEvent::ToolApprovalRequest`:
+
+```rust
+AiEvent::ToolApprovalRequest {
+    request_id: String,
+    tool_name: String,
+    args: serde_json::Value,
+    risk_level: RiskLevel,
+    can_learn: bool,
+}
+```
+
+### Approval Response
+
+Frontend calls `respond_to_tool_approval` Tauri command:
+
+```rust
+pub struct ApprovalDecision {
+    pub request_id: String,
+    pub approved: bool,
+    pub reason: Option<String>,
+    pub remember: bool,
+    pub always_allow: bool,
+}
+```
+
+## Testing
+
+Run tool-related tests:
+
+```bash
+# Rust tests
+cargo test -p qbit tool
+
+# Specific module
+cargo test -p qbit tool_definitions
+cargo test -p qbit tool_executors
+```

--- a/src-tauri/src/ai/hitl/approval_recorder.rs
+++ b/src-tauri/src/ai/hitl/approval_recorder.rs
@@ -59,6 +59,7 @@ impl Default for ToolApprovalConfig {
             // Dangerous tools that should always require approval
             always_require_approval: vec![
                 "delete_file".to_string(),
+                "run_command".to_string(),
                 "run_pty_cmd".to_string(),
                 "execute_code".to_string(),
             ],
@@ -122,7 +123,7 @@ impl RiskLevel {
             "save_skill" => RiskLevel::Medium,
 
             // Shell execution
-            "run_pty_cmd" => RiskLevel::High,
+            "run_command" | "run_pty_cmd" => RiskLevel::High,
             "create_pty_session" | "send_pty_input" => RiskLevel::High,
 
             // Destructive operations

--- a/src-tauri/src/ai/system_prompt.rs
+++ b/src-tauri/src/ai/system_prompt.rs
@@ -144,9 +144,9 @@ The `apply_patch` tool uses a specific format. **Malformed patches will corrupt 
 3. **Architectural questions** - "How does X connect to Y?" → `code_explorer` → `code_analyzer`
 4. **Tracing dependencies** - Import chains, call graphs → `code_analyzer`
 5. **Multi-file implementation** - Changes span multiple files → `code_writer`
-6. **Commands/builds/git** - Any shell operation → `shell_executor`
-7. **Web research/APIs** - External docs needed → `researcher`
-8. **Running tests** - Test execution/analysis → `shell_executor`
+6. **Complex shell pipelines** - Multi-step builds, chained git operations → `shell_executor`
+7. **In-depth research** - Multi-source documentation, complex lookups → `researcher`
+8. **Quick commands** - Simple commands like `git status`, `cargo check` → use `run_command` directly
 
 ### Handle Directly When:
 - Single file you've already read
@@ -156,12 +156,14 @@ The `apply_patch` tool uses a specific format. **Malformed patches will corrupt 
 
 ### Agent Selection Priority
 ```
-"How does X work?"     → code_explorer (first) → code_analyzer (if deeper needed)
-"Find where Y is used" → code_explorer
-"Analyze code quality" → code_analyzer
-"Implement feature Z"  → code_writer
-"Run tests/build"      → shell_executor
-"Look up API docs"     → researcher
+"How does X work?"          → code_explorer (first) → code_analyzer (if deeper needed)
+"Find where Y is used"      → code_explorer
+"Analyze code quality"      → code_analyzer
+"Implement feature Z"       → code_writer
+"Run quick command"         → run_command directly
+"Multi-step build pipeline" → shell_executor
+"Quick lookup"              → web_search/web_fetch directly
+"Research documentation"    → researcher
 ```
 
 ## Sub-Agent Specifications
@@ -169,7 +171,7 @@ The `apply_patch` tool uses a specific format. **Malformed patches will corrupt 
 ### code_explorer
 **Purpose**: Navigate and map codebases
 **Use for**: Finding integration points, tracing dependencies, building context maps
-**Tools**: read_file, list_files, list_directory, grep_file, find_files, run_pty_cmd
+**Tools**: read_file, list_files, list_directory, grep_file, find_files, run_command
 **Pattern**: Ideal FIRST step for unfamiliar code
 
 ### code_analyzer
@@ -185,14 +187,14 @@ The `apply_patch` tool uses a specific format. **Malformed patches will corrupt 
 **Pattern**: Best AFTER analysis agents provide insights
 
 ### researcher
-**Purpose**: Web research and documentation
-**Use for**: API docs, library documentation, best practices
-**Pattern**: Delegate ALL web operations here
+**Purpose**: In-depth web research
+**Use for**: Multi-source research, complex API documentation, best practices analysis
+**Pattern**: Delegate research tasks; use web_search/web_fetch directly for quick lookups
 
 ### shell_executor
-**Purpose**: Command execution
-**Use for**: Builds, dependencies, git operations
-**Pattern**: Delegate ALL command execution here
+**Purpose**: Complex command orchestration
+**Use for**: Multi-step builds, chained git operations, long-running pipelines
+**Pattern**: Delegate complex sequences; use run_command directly for simple commands
 
 ## Chaining Patterns
 
@@ -218,6 +220,23 @@ code_explorer → code_analyzer → code_writer
 - Multiple file reads
 - Independent analyses
 - Non-dependent builds
+
+## Direct Tool Access
+
+### Shell (run_command)
+Use directly for:
+- Single commands: `git status`, `cargo check`, `npm run lint`
+- Quick operations that complete in seconds
+
+Delegate to shell_executor for:
+- Multi-step pipelines, chained workflows, long-running operations
+
+### Web (web_search, web_fetch, web_extract)
+Use directly for:
+- Quick lookups, single-page fetches, simple queries
+
+Delegate to researcher for:
+- Multi-source research, complex documentation lookup
 
 ## Security Boundaries
 - **NEVER** expose secrets in logs or output

--- a/src/components/AgentChat/ToolApprovalDialog.tsx
+++ b/src/components/AgentChat/ToolApprovalDialog.tsx
@@ -88,7 +88,7 @@ export function ToolApprovalDialog({ sessionId }: ToolApprovalDialogProps) {
     // and emit a tool_result event when complete. We don't execute here to avoid
     // double execution since execute_with_hitl is waiting for this approval.
     try {
-      await respondToToolApproval({
+      await respondToToolApproval(sessionId, {
         request_id: tool.id,
         approved: true,
         remember: true,
@@ -109,7 +109,7 @@ export function ToolApprovalDialog({ sessionId }: ToolApprovalDialogProps) {
 
     // Send denial decision to backend for pattern learning
     try {
-      await respondToToolApproval({
+      await respondToToolApproval(sessionId, {
         request_id: tool.id,
         approved: false,
         remember: true,

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1002,9 +1002,15 @@ export async function resetApprovalPatterns(): Promise<void> {
 /**
  * Respond to a tool approval request.
  * This is called by the frontend after the user makes a decision in the approval dialog.
+ *
+ * @param sessionId - The session ID where the approval request originated
+ * @param decision - The user's approval decision
  */
-export async function respondToToolApproval(decision: ApprovalDecision): Promise<void> {
-  return invoke("respond_to_tool_approval", { decision });
+export async function respondToToolApproval(
+  sessionId: string,
+  decision: ApprovalDecision
+): Promise<void> {
+  return invoke("respond_to_tool_approval", { sessionId, decision });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Enable all tools for the main agent by clearing the disabled list in `ToolConfig::main_agent()`
- Add `run_command` as a user-friendly wrapper for `run_pty_cmd` (agent sees `run_command`, maps to `run_pty_cmd` internally)
- Update system prompt with hybrid delegation guidelines (direct access for simple ops, sub-agents for complex workflows)
- Fix HITL bug where tool approval responses failed with "AI agent not initialized" on app startup

## Changes

### Tool System
- `tool_definitions.rs`: Added `get_run_command_tool_definition()`, disabled `run_pty_cmd` (hidden behind wrapper)
- `agentic_loop.rs`: Added routing for `run_command` → `run_pty_cmd`
- `approval_recorder.rs`: Added `run_command` to High risk level and always-require-approval list

### HITL Bug Fix
- `hitl.rs`: Updated `respond_to_tool_approval` to accept `session_id` and use session-specific bridge lookup
- `ai.ts`: Updated `respondToToolApproval` to accept `sessionId` parameter
- `ToolApprovalDialog.tsx`: Pass `sessionId` when responding to approval requests

### Documentation
- Added `docs/tool-use.md` explaining the tool system architecture

## Test plan

- [ ] Start the app and verify AI agent initializes without errors
- [ ] Send a prompt that triggers a tool requiring approval (e.g., run_command)
- [ ] Verify approval dialog appears and approve/deny works without "AI agent not initialized" error
- [ ] Run `just test-rust` to verify Rust tests pass
- [ ] Run `pnpm run typecheck` to verify TypeScript compiles