### PR TITLE
Simplify codebase with concurrent exploration

### DIFF
--- a/backend/src/ai/agent_mode.rs
+++ b/backend/src/ai/agent_mode.rs
@@ -29,6 +29,11 @@ pub enum AgentMode {
 }
 
 impl AgentMode {
+    /// Returns true if this is the default mode.
+    pub fn is_default(&self) -> bool {
+        matches!(self, AgentMode::Default)
+    }
+
     /// Returns true if this mode auto-approves all tools.
     pub fn is_auto_approve(&self) -> bool {
         matches!(self, AgentMode::AutoApprove)


### PR DESCRIPTION
Simplify agent_bridge.rs by extracting repeated code from 8 provider execution methods into reusable helper methods:

- build_system_prompt_with_context(): System prompt building with session context
- prepare_session_and_sidecar(): Session persistence and sidecar capture setup
- prepare_history(): Conversation history initialization
- build_loop_context(): AgenticLoopContext construction
- finalize_execution(): Response persistence and completion event emission
- execute_with_generic_model(): Generic execution for non-Vertex providers

This reduces agent_bridge.rs from 2016 lines to 1224 lines (-792 lines, 39% reduction) while maintaining all existing functionality.

Also adds docs/codebase-simplification.md documenting additional simplification opportunities across the codebase.