### PR TITLE
fix(ui): reset input submission state when switching sessions

### DIFF
--- a/src/components/UnifiedInput/UnifiedInput.tsx
+++ b/src/components/UnifiedInput/UnifiedInput.tsx
@@ -143,6 +143,14 @@ export function UnifiedInput({ sessionId, workingDirectory }: UnifiedInputProps)
     prevMessagesLengthRef.current = agentMessages.length;
   }, [agentMessages, isSubmitting]);
 
+  // Reset submission state when switching sessions to prevent input lock across tabs
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally only reset on sessionId change
+  useEffect(() => {
+    setIsSubmitting(false);
+    // Reset ref to 0 so the message length check works correctly for the new session
+    prevMessagesLengthRef.current = 0;
+  }, [sessionId]);
+
   // Auto-focus input when session or mode changes.
   // Defer to the next frame so it isn't immediately overridden by focus management
   // (e.g., Radix Tabs focusing the clicked tab trigger).


### PR DESCRIPTION
## Summary
Fixes a bug where the input field would remain locked when switching between terminal sessions/tabs if an AI request was in progress in another session.

## Commits
- `143aa2e` fix(ui): reset input submission state when switching sessions

## Changes
- Added a `useEffect` hook that triggers on `sessionId` change to:
  - Reset `isSubmitting` state to `false`
  - Reset `prevMessagesLengthRef` to `0` so message completion detection works correctly for the new session

## Breaking Changes
None

## Test Plan
- [ ] Open Qbit and create multiple terminal tabs/sessions
- [ ] In one session, submit an AI request
- [ ] While the request is processing, switch to another tab
- [ ] Verify the input field is enabled and not locked in the new tab
- [ ] Switch back to the original tab and verify it completes normally

## Related Issues
None

## Release Notes
Fixed an issue where the input field would become locked when switching between terminal tabs while an AI request was processing.

## Checklist
- [x] Tests pass locally
- [x] Linting passes
- [x] Conventional commit format followed