### PR TITLE
refactor(tool-display): replace inline expansion with modal details view

### DIFF
--- a/frontend/components/AgentChat/AgentMessage.tsx
+++ b/frontend/components/AgentChat/AgentMessage.tsx
@@ -1,10 +1,12 @@
 import { memo, useMemo, useState } from "react";
 import { Markdown } from "@/components/Markdown";
+import { CopyButton } from "@/components/Markdown/CopyButton";
 import { SubAgentCard } from "@/components/SubAgentCard";
 import { StaticThinkingBlock } from "@/components/ThinkingBlock";
 import { ToolDetailsModal, ToolGroup, ToolItem } from "@/components/ToolCallDisplay";
 import { UdiffResultBlock } from "@/components/UdiffResultBlock";
 import { WorkflowProgress } from "@/components/WorkflowProgress";
+import { extractMessageText } from "@/lib/messageUtils";
 import type { AnyToolCall, GroupedStreamingBlock } from "@/lib/toolGrouping";
 import { groupConsecutiveTools } from "@/lib/toolGrouping";
 import { cn } from "@/lib/utils";
@@ -91,6 +93,14 @@ export const AgentMessage = memo(function AgentMessage({ message }: AgentMessage
     return { subAgentBlocks, contentBlocks };
   }, [groupedHistory, message.subAgents, hasStreamingHistory]);
 
+  // Extract copyable text for assistant messages
+  const copyableText = useMemo(() => {
+    if (isUser || isSystem) return "";
+    return extractMessageText(message);
+  }, [message, isUser, isSystem]);
+
+  const isAssistant = !isUser && !isSystem;
+
   return (
     <div
       className={cn(
@@ -99,9 +109,16 @@ export const AgentMessage = memo(function AgentMessage({ message }: AgentMessage
           ? "w-full border-l-[3px] border-l-[#484f58] bg-[#1c2128] py-4 px-5 rounded-r-lg"
           : isSystem
             ? "ml-6 rounded-lg bg-[var(--ansi-yellow)]/10 border-l-2 border-l-[var(--ansi-yellow)] p-2"
-            : "ml-6 rounded-lg bg-card/50 p-2"
+            : "ml-6 rounded-lg bg-card/50 p-2 relative group"
       )}
     >
+      {/* Copy button for assistant messages */}
+      {isAssistant && copyableText && (
+        <CopyButton
+          content={copyableText}
+          className="absolute right-2 top-2 opacity-0 group-hover:opacity-100 transition-opacity z-10"
+        />
+      )}
       {/* Thinking content (collapsible) */}
       {message.thinkingContent && <StaticThinkingBlock content={message.thinkingContent} />}
 

--- a/frontend/components/ToolCallDisplay/ToolDetailsModal.tsx
+++ b/frontend/components/ToolCallDisplay/ToolDetailsModal.tsx
@@ -8,13 +8,16 @@ import {
   Shield,
   ShieldCheck,
   Terminal,
+  X,
   XCircle,
 } from "lucide-react";
 import { useState } from "react";
+import { DiffView } from "@/components/DiffView";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogHeader,
@@ -27,6 +30,7 @@ import {
   formatToolResult,
   getRiskLevel,
   isAgentTerminalCommand,
+  isEditFileResult,
 } from "@/lib/tools";
 import { cn } from "@/lib/utils";
 import type { RiskLevel } from "@/store";
@@ -137,7 +141,10 @@ export function ToolDetailsModal({ tool, onClose }: ToolDetailsModalProps) {
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[85vh] flex flex-col p-0 gap-0">
+      <DialogContent
+        showCloseButton={false}
+        className="!w-[calc(100%-2rem)] !h-[calc(100%-4rem)] !max-w-none !max-h-none !top-[calc(50%+1rem)] flex flex-col p-0 gap-0"
+      >
         <DialogHeader className="px-6 pt-6 pb-4 border-b border-border">
           <div className="flex items-start justify-between gap-4">
             <div className="flex items-start gap-3 min-w-0 flex-1">
@@ -168,6 +175,12 @@ export function ToolDetailsModal({ tool, onClose }: ToolDetailsModalProps) {
                 <RiskIcon className="w-3.5 h-3.5 mr-1" />
                 {riskLevel}
               </Badge>
+              <DialogClose asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8 ml-2">
+                  <X className="h-4 w-4" />
+                  <span className="sr-only">Close</span>
+                </Button>
+              </DialogClose>
             </div>
           </div>
         </DialogHeader>
@@ -245,17 +258,25 @@ export function ToolDetailsModal({ tool, onClose }: ToolDetailsModalProps) {
                   <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
                     {tool.status === "error" ? "Error" : "Result"}
                   </h3>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleCopy(resultString, "result")}
-                    className="h-7 text-xs"
-                  >
-                    <Copy className="w-3.5 h-3.5 mr-1" />
-                    {copiedSection === "result" ? "Copied!" : "Copy"}
-                  </Button>
+                  {!(tool.name === "edit_file" && isEditFileResult(tool.result)) && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleCopy(resultString, "result")}
+                      className="h-7 text-xs"
+                    >
+                      <Copy className="w-3.5 h-3.5 mr-1" />
+                      {copiedSection === "result" ? "Copied!" : "Copy"}
+                    </Button>
+                  )}
                 </div>
-                {isTerminalCmd ? (
+                {tool.name === "edit_file" && isEditFileResult(tool.result) ? (
+                  <DiffView
+                    diff={tool.result.diff}
+                    filePath={tool.result.path}
+                    className="border border-border rounded-lg overflow-hidden"
+                  />
+                ) : isTerminalCmd ? (
                   <pre
                     className={cn(
                       "ansi-output bg-background border border-border rounded-lg p-4 overflow-auto text-xs whitespace-pre-wrap break-all",

--- a/frontend/components/UnifiedInput/UnifiedInput.tsx
+++ b/frontend/components/UnifiedInput/UnifiedInput.tsx
@@ -381,8 +381,8 @@ export function UnifiedInput({ sessionId, workingDirectory }: UnifiedInputProps)
         return;
       }
 
-      // Ctrl+R to open history search (terminal mode only)
-      if (e.ctrlKey && e.key === "r" && inputMode === "terminal" && !showHistorySearch) {
+      // Ctrl+R to open history search
+      if (e.ctrlKey && e.key === "r" && !showHistorySearch) {
         e.preventDefault();
         setOriginalInput(input);
         setShowHistorySearch(true);

--- a/frontend/lib/messageUtils.ts
+++ b/frontend/lib/messageUtils.ts
@@ -1,0 +1,106 @@
+/**
+ * Utilities for extracting copyable text from agent messages.
+ */
+
+import type { AgentMessage, FinalizedStreamingBlock, ToolCall } from "@/store";
+import { formatToolName, formatToolResult } from "./tools";
+
+/**
+ * Format a tool call for plain text output.
+ */
+function formatToolCallText(tool: ToolCall): string {
+  const parts: string[] = [];
+
+  // Tool name and primary argument
+  const name = formatToolName(tool.name);
+  parts.push(`[${name}]`);
+
+  // Add key arguments based on tool type
+  if (tool.args) {
+    const args = tool.args;
+    if (args.file_path || args.path) {
+      parts.push(`Path: ${String(args.file_path || args.path)}`);
+    }
+    if (args.command) {
+      parts.push(`Command: ${String(args.command)}`);
+    }
+    if (args.query) {
+      parts.push(`Query: ${String(args.query)}`);
+    }
+  }
+
+  // Add result if available
+  if (tool.result !== undefined) {
+    const resultText = formatToolResult(tool.result);
+    // Truncate very long results
+    const maxLength = 500;
+    if (resultText.length > maxLength) {
+      parts.push(`Result: ${resultText.slice(0, maxLength)}...`);
+    } else {
+      parts.push(`Result: ${resultText}`);
+    }
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Extract plain text content from a streaming block.
+ */
+function extractBlockText(block: FinalizedStreamingBlock): string {
+  switch (block.type) {
+    case "text":
+      return block.content;
+    case "tool":
+      return formatToolCallText(block.toolCall);
+    case "udiff_result":
+      return `[Diff]\n${block.response}`;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Extract all text content from an agent message for copying.
+ * Includes thinking content, text blocks, and formatted tool calls.
+ */
+export function extractMessageText(message: AgentMessage): string {
+  const parts: string[] = [];
+
+  // Include thinking content if present
+  if (message.thinkingContent) {
+    parts.push(`[Thinking]\n${message.thinkingContent}`);
+  }
+
+  // Include workflow summary if present
+  if (message.workflow) {
+    const steps = message.workflow.steps
+      .map((step, i) => `${i + 1}. ${step.name}: ${step.status}`)
+      .join("\n");
+    parts.push(`[Workflow: ${message.workflow.workflowName}]\n${steps}`);
+  }
+
+  // Use streaming history if available (interleaved text + tool calls)
+  if (message.streamingHistory && message.streamingHistory.length > 0) {
+    for (const block of message.streamingHistory) {
+      const text = extractBlockText(block);
+      if (text) {
+        parts.push(text);
+      }
+    }
+  } else {
+    // Fallback to legacy content
+    if (message.content) {
+      parts.push(message.content);
+    }
+
+    // Legacy tool calls
+    if (message.toolCalls && message.toolCalls.length > 0) {
+      for (const tool of message.toolCalls) {
+        parts.push(formatToolCallText(tool));
+      }
+    }
+  }
+
+  return parts.join("\n\n");
+}


### PR DESCRIPTION
## Summary
- Replace collapsible/expandable behavior in ToolCallDisplay and ToolGroup components with click-to-open modal pattern
- Simplify tool item UI by removing inline expansion state management
- Add `messageUtils.ts` with utilities for extracting copyable plain text from agent messages

## Test plan
- [ ] Verify tool items are clickable and open ToolDetailsModal
- [ ] Verify tool details (args, results, diffs) display correctly in modal
- [ ] Verify terminal command tool items render without expandable behavior
- [ ] Verify copy message functionality works with new messageUtils