### PR TITLE
chore: unify version management with Cargo.toml as source of truth

### DIFF
--- a/backend/crates/qbit/tauri.conf.json
+++ b/backend/crates/qbit/tauri.conf.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "qbit",
-  "version": "0.1.0",
   "identifier": "com.qbit.terminal",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,12 +7,13 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "tauri.conf.json",
+          "path": "../package.json",
           "jsonpath": "$.version"
         }
       ]
     }
   },
+  "plugins": ["cargo-workspace"],
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
Simplifies version management by using Cargo.toml as the single source of truth for the application version. This eliminates version drift between Cargo.toml and tauri.conf.json, and ensures package.json stays synchronized during releases.

## Commits
- `ee0bbfd` chore: unify version management with Cargo.toml as source of truth

## Changes
- Removed hardcoded `version` from `tauri.conf.json` (Tauri 2.x reads version from Cargo.toml automatically)
- Added `cargo-workspace` plugin to release-please for proper Rust workspace version handling
- Updated `extra-files` to sync `package.json` version instead of the now-removed `tauri.conf.json` version

## Breaking Changes
None

## Test Plan
- [ ] Run `just dev` to verify Tauri still reads version correctly from Cargo.toml
- [ ] Run `just build` to verify production build works
- [ ] Verify release-please can still process releases (will be validated on next release)

## Related Issues
None

## Release Notes
Internal improvement to version management - no user-facing changes.

## Checklist
- [x] Tests pass locally
- [x] Conventional commit format followed
- [x] No breaking changes