### PR TITLE
feat(ai): add OpenAI Responses API support and standardize temperature

### DIFF
--- a/backend/crates/qbit-ai/src/agent_bridge.rs
+++ b/backend/crates/qbit-ai/src/agent_bridge.rs
@@ -804,6 +804,13 @@ impl AgentBridge {
                 self.execute_with_openai_model(&openai_model, prompt, start_time, context)
                     .await
             }
+            LlmClient::RigOpenAiResponses(openai_model) => {
+                let openai_model = openai_model.clone();
+                drop(client);
+
+                self.execute_with_openai_responses_model(&openai_model, prompt, start_time, context)
+                    .await
+            }
             LlmClient::RigAnthropic(anthropic_model) => {
                 let anthropic_model = anthropic_model.clone();
                 drop(client);
@@ -1165,6 +1172,151 @@ impl AgentBridge {
     async fn execute_with_openai_model(
         &self,
         model: &rig_openai::completion::CompletionModel,
+        initial_prompt: &str,
+        start_time: std::time::Instant,
+        context: SubAgentContext,
+    ) -> Result<String> {
+        // Build system prompt with current agent mode
+        let workspace_path = self.workspace.read().await;
+        let agent_mode = *self.agent_mode.read().await;
+        let memory_file_path = self.get_memory_file_path_dynamic().await;
+        let mut system_prompt =
+            build_system_prompt(&workspace_path, agent_mode, memory_file_path.as_deref());
+        drop(workspace_path);
+
+        // Inject Layer 1 session context if available
+        if let Some(session_context) = self.get_session_context().await {
+            if !session_context.is_empty() {
+                tracing::debug!(
+                    "[agent] Injecting Layer 1 session context ({} chars)",
+                    session_context.len()
+                );
+                system_prompt.push_str("\n\n");
+                system_prompt.push_str(&session_context);
+            }
+        }
+
+        // Start session for persistence
+        self.start_session().await;
+        self.record_user_message(initial_prompt).await;
+
+        // Capture user prompt in sidecar session
+        if let Some(ref sidecar) = self.sidecar_state {
+            use qbit_sidecar::events::SessionEvent;
+
+            let session_id = if let Some(existing_id) = sidecar.current_session_id() {
+                tracing::debug!("Reusing existing sidecar session: {}", existing_id);
+                Some(existing_id)
+            } else {
+                match sidecar.start_session(initial_prompt) {
+                    Ok(new_id) => {
+                        tracing::info!("Started new sidecar session: {}", new_id);
+                        Some(new_id)
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to start sidecar session: {}", e);
+                        None
+                    }
+                }
+            };
+
+            if let Some(sid) = session_id {
+                let prompt_event = SessionEvent::user_prompt(sid, initial_prompt);
+                sidecar.capture(prompt_event);
+            }
+        }
+
+        // Prepare initial history with user message
+        let mut history_guard = self.conversation_history.write().await;
+        history_guard.push(Message::User {
+            content: OneOrMany::one(UserContent::Text(Text {
+                text: initial_prompt.to_string(),
+            })),
+        });
+        let initial_history = history_guard.clone();
+        drop(history_guard);
+
+        // Get or create event channel for the agentic loop
+        let loop_event_tx = self.get_or_create_event_tx();
+
+        // Build agentic loop context
+        let loop_ctx = AgenticLoopContext {
+            event_tx: &loop_event_tx,
+            tool_registry: &self.tool_registry,
+            sub_agent_registry: &self.sub_agent_registry,
+            indexer_state: self.indexer_state.as_ref(),
+            tavily_state: self.tavily_state.as_ref(),
+            workspace: &self.workspace,
+            client: &self.client,
+            approval_recorder: &self.approval_recorder,
+            pending_approvals: &self.pending_approvals,
+            tool_policy_manager: &self.tool_policy_manager,
+            context_manager: &self.context_manager,
+            loop_detector: &self.loop_detector,
+            tool_config: &self.tool_config,
+            sidecar_state: self.sidecar_state.as_ref(),
+            runtime: self.runtime.as_ref(),
+            agent_mode: &self.agent_mode,
+            plan_manager: &self.plan_manager,
+        };
+
+        // Run the generic agentic loop (works with any rig CompletionModel)
+        let (accumulated_response, _final_history, token_usage) =
+            run_agentic_loop_generic(model, &system_prompt, initial_history, context, &loop_ctx)
+                .await?;
+
+        let duration_ms = start_time.elapsed().as_millis() as u64;
+
+        // Persist the assistant response
+        if !accumulated_response.is_empty() {
+            let mut history_guard = self.conversation_history.write().await;
+            history_guard.push(Message::Assistant {
+                id: None,
+                content: OneOrMany::one(AssistantContent::Text(Text {
+                    text: accumulated_response.clone(),
+                })),
+            });
+        }
+
+        // Record and save session
+        if !accumulated_response.is_empty() {
+            self.record_assistant_message(&accumulated_response).await;
+            self.save_session().await;
+        }
+
+        // Capture AI response in sidecar session
+        if let Some(ref sidecar) = self.sidecar_state {
+            use qbit_sidecar::events::SessionEvent;
+
+            if let Some(session_id) = sidecar.current_session_id() {
+                if !accumulated_response.is_empty() {
+                    let response_event =
+                        SessionEvent::ai_response(session_id, &accumulated_response);
+                    sidecar.capture(response_event);
+                    tracing::debug!(
+                        "[agent] Captured AI response in sidecar ({} chars)",
+                        accumulated_response.len()
+                    );
+                }
+            }
+        }
+
+        // Emit completion event
+        self.emit_event(AiEvent::Completed {
+            response: accumulated_response.clone(),
+            input_tokens: token_usage.as_ref().map(|u| u.input_tokens as u32),
+            output_tokens: token_usage.as_ref().map(|u| u.output_tokens as u32),
+            duration_ms: Some(duration_ms),
+        });
+
+        Ok(accumulated_response)
+    }
+
+    /// Execute with OpenAI Responses API model using the generic agentic loop.
+    /// This uses the Responses API which has better tool support than the Chat Completions API.
+    async fn execute_with_openai_responses_model(
+        &self,
+        model: &rig_openai::responses_api::ResponsesCompletionModel,
         initial_prompt: &str,
         start_time: std::time::Instant,
         context: SubAgentContext,

--- a/backend/crates/qbit-ai/src/llm_client.rs
+++ b/backend/crates/qbit-ai/src/llm_client.rs
@@ -190,13 +190,11 @@ pub async fn create_openai_components(
     // Create OpenAI client
     let openai_client = rig_openai::Client::new(config.api_key);
 
-    // Create the completion model using Chat Completions API (not Responses API)
-    // The Chat Completions API has better compatibility with GPT-5.x models
-    // Note: reasoning_effort is stored in config but applied at request time if needed
-    let completion_model = openai_client
-        .completion_model(config.model)
-        .completions_api();
-    let client = LlmClient::RigOpenAi(completion_model);
+    // Create the completion model using Responses API (default)
+    // The Responses API has better tool support. Our sanitize_schema function handles
+    // strict mode compatibility by making optional parameters nullable.
+    let completion_model = openai_client.completion_model(config.model);
+    let client = LlmClient::RigOpenAiResponses(completion_model);
 
     let shared = create_shared_components(&config.workspace, config.model, context_config).await;
 

--- a/backend/crates/qbit-ai/src/tool_definitions.rs
+++ b/backend/crates/qbit-ai/src/tool_definitions.rs
@@ -181,7 +181,7 @@ pub fn get_indexer_tool_definitions() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "indexer_search_code".to_string(),
             description: "Search for code patterns using regex in the indexed workspace. Returns matching lines with file paths and line numbers.".to_string(),
-            parameters: json!({
+            parameters: sanitize_schema(json!({
                 "type": "object",
                 "properties": {
                     "pattern": {
@@ -194,12 +194,12 @@ pub fn get_indexer_tool_definitions() -> Vec<ToolDefinition> {
                     }
                 },
                 "required": ["pattern"]
-            }),
+            })),
         },
         ToolDefinition {
             name: "indexer_search_files".to_string(),
             description: "Find files by name pattern (glob-style) in the indexed workspace.".to_string(),
-            parameters: json!({
+            parameters: sanitize_schema(json!({
                 "type": "object",
                 "properties": {
                     "pattern": {
@@ -208,12 +208,12 @@ pub fn get_indexer_tool_definitions() -> Vec<ToolDefinition> {
                     }
                 },
                 "required": ["pattern"]
-            }),
+            })),
         },
         ToolDefinition {
             name: "indexer_analyze_file".to_string(),
             description: "Get semantic analysis of a file using tree-sitter. Returns symbols, code metrics, and dependencies.".to_string(),
-            parameters: json!({
+            parameters: sanitize_schema(json!({
                 "type": "object",
                 "properties": {
                     "file_path": {
@@ -222,12 +222,12 @@ pub fn get_indexer_tool_definitions() -> Vec<ToolDefinition> {
                     }
                 },
                 "required": ["file_path"]
-            }),
+            })),
         },
         ToolDefinition {
             name: "indexer_extract_symbols".to_string(),
             description: "Extract all symbols (functions, classes, structs, variables, imports) from a file.".to_string(),
-            parameters: json!({
+            parameters: sanitize_schema(json!({
                 "type": "object",
                 "properties": {
                     "file_path": {
@@ -236,12 +236,12 @@ pub fn get_indexer_tool_definitions() -> Vec<ToolDefinition> {
                     }
                 },
                 "required": ["file_path"]
-            }),
+            })),
         },
         ToolDefinition {
             name: "indexer_get_metrics".to_string(),
             description: "Get code metrics for a file: lines of code, comment lines, blank lines, function count, class count, etc.".to_string(),
-            parameters: json!({
+            parameters: sanitize_schema(json!({
                 "type": "object",
                 "properties": {
                     "file_path": {
@@ -250,12 +250,12 @@ pub fn get_indexer_tool_definitions() -> Vec<ToolDefinition> {
                     }
                 },
                 "required": ["file_path"]
-            }),
+            })),
         },
         ToolDefinition {
             name: "indexer_detect_language".to_string(),
             description: "Detect the programming language of a file based on its extension and content.".to_string(),
-            parameters: json!({
+            parameters: sanitize_schema(json!({
                 "type": "object",
                 "properties": {
                     "file_path": {
@@ -264,7 +264,7 @@ pub fn get_indexer_tool_definitions() -> Vec<ToolDefinition> {
                     }
                 },
                 "required": ["file_path"]
-            }),
+            })),
         },
     ]
 }
@@ -277,7 +277,7 @@ pub fn get_tavily_tool_definitions(tavily_state: Option<&Arc<TavilyState>>) -> V
             ToolDefinition {
                 name: "web_search".to_string(),
                 description: "Search the web for information. Returns relevant results with titles, URLs, and content snippets. Use this when you need current information, news, documentation, or facts beyond your training data.".to_string(),
-                parameters: json!({
+                parameters: sanitize_schema(json!({
                     "type": "object",
                     "properties": {
                         "query": {
@@ -290,12 +290,12 @@ pub fn get_tavily_tool_definitions(tavily_state: Option<&Arc<TavilyState>>) -> V
                         }
                     },
                     "required": ["query"]
-                }),
+                })),
             },
             ToolDefinition {
                 name: "web_search_answer".to_string(),
                 description: "Get an AI-generated answer from web search results. Best for direct questions that need a synthesized answer from multiple sources.".to_string(),
-                parameters: json!({
+                parameters: sanitize_schema(json!({
                     "type": "object",
                     "properties": {
                         "query": {
@@ -304,12 +304,12 @@ pub fn get_tavily_tool_definitions(tavily_state: Option<&Arc<TavilyState>>) -> V
                         }
                     },
                     "required": ["query"]
-                }),
+                })),
             },
             ToolDefinition {
                 name: "web_extract".to_string(),
                 description: "Extract and parse content from specific URLs. Use this to get the full content of web pages for deeper analysis.".to_string(),
-                parameters: json!({
+                parameters: sanitize_schema(json!({
                     "type": "object",
                     "properties": {
                         "urls": {
@@ -321,7 +321,7 @@ pub fn get_tavily_tool_definitions(tavily_state: Option<&Arc<TavilyState>>) -> V
                         }
                     },
                     "required": ["urls"]
-                }),
+                })),
             },
         ]
     } else {
@@ -337,7 +337,7 @@ pub fn get_run_command_tool_definition() -> ToolDefinition {
     ToolDefinition {
         name: "run_command".to_string(),
         description: "Execute a shell command and return the output. Use for running builds, tests, git operations, and other CLI commands. The command runs in a shell environment with access to common tools.".to_string(),
-        parameters: json!({
+        parameters: sanitize_schema(json!({
             "type": "object",
             "properties": {
                 "command": {
@@ -354,7 +354,7 @@ pub fn get_run_command_tool_definition() -> ToolDefinition {
                 }
             },
             "required": ["command"]
-        }),
+        })),
     }
 }
 
@@ -368,7 +368,7 @@ pub async fn get_sub_agent_tool_definitions(registry: &SubAgentRegistry) -> Vec<
                 "[{}] {}",
                 agent.name, agent.description
             ),
-            parameters: json!({
+            parameters: sanitize_schema(json!({
                 "type": "object",
                 "properties": {
                     "task": {
@@ -381,7 +381,7 @@ pub async fn get_sub_agent_tool_definitions(registry: &SubAgentRegistry) -> Vec<
                     }
                 },
                 "required": ["task"]
-            }),
+            })),
         })
         .collect()
 }
@@ -414,7 +414,7 @@ pub fn get_workflow_tool_definitions(
              Available workflows:\n{}",
             workflows_list
         ),
-        parameters: json!({
+        parameters: sanitize_schema(json!({
             "type": "object",
             "properties": {
                 "workflow_name": {
@@ -427,7 +427,7 @@ pub fn get_workflow_tool_definitions(
                 }
             },
             "required": ["workflow_name", "input"]
-        }),
+        })),
     }]
 }
 
@@ -463,26 +463,70 @@ pub fn filter_tools_by_allowed(
     }
 }
 
-/// Remove anyOf, allOf, oneOf from JSON schema as Anthropic doesn't support them.
-/// Also simplifies nested oneOf in properties to just use the first option.
-pub fn sanitize_schema(mut schema: serde_json::Value) -> serde_json::Value {
+/// Sanitize JSON schema for LLM provider compatibility.
+///
+/// This function recursively:
+/// - Removes anyOf, allOf, oneOf (Anthropic doesn't support them)
+/// - Simplifies nested oneOf in properties to use the first option
+/// - For OpenAI Responses API strict mode: adds `additionalProperties: false`,
+///   makes optional properties nullable, and includes all properties in `required`
+pub fn sanitize_schema(schema: serde_json::Value) -> serde_json::Value {
+    sanitize_schema_recursive(schema, &HashSet::new())
+}
+
+/// Internal recursive schema sanitization with context about which properties are required.
+fn sanitize_schema_recursive(
+    mut schema: serde_json::Value,
+    _parent_required: &HashSet<String>,
+) -> serde_json::Value {
     if let Some(obj) = schema.as_object_mut() {
         // Remove top-level anyOf/allOf/oneOf
         obj.remove("anyOf");
         obj.remove("allOf");
         obj.remove("oneOf");
 
-        // Recursively sanitize properties
+        // Check if this is an object type schema
+        let is_object_type = obj
+            .get("type")
+            .map(|t| {
+                t == "object" || (t.is_array() && t.as_array().unwrap().contains(&json!("object")))
+            })
+            .unwrap_or(false);
+
+        // Add additionalProperties: false for object types (OpenAI strict mode)
+        if is_object_type || obj.contains_key("properties") {
+            obj.insert(
+                "additionalProperties".to_string(),
+                serde_json::Value::Bool(false),
+            );
+        }
+
+        // Get the set of originally required properties at this level
+        let originally_required: HashSet<String> = obj
+            .get("required")
+            .and_then(|r| r.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Collect all property keys
+        let mut all_property_keys: Vec<String> = Vec::new();
+
+        // Recursively sanitize properties and make optional ones nullable
         if let Some(props) = obj.get_mut("properties") {
             if let Some(props_obj) = props.as_object_mut() {
-                for (_key, prop_value) in props_obj.iter_mut() {
+                all_property_keys = props_obj.keys().cloned().collect();
+
+                for (key, prop_value) in props_obj.iter_mut() {
+                    // First, handle oneOf simplification
                     if let Some(prop_obj) = prop_value.as_object_mut() {
-                        // If property has oneOf, replace with first option or simplify to string
                         if prop_obj.contains_key("oneOf") {
                             if let Some(one_of) = prop_obj.remove("oneOf") {
                                 if let Some(arr) = one_of.as_array() {
                                     if let Some(first) = arr.first() {
-                                        // Merge the first oneOf option into this property
                                         if let Some(first_obj) = first.as_object() {
                                             for (k, v) in first_obj {
                                                 prop_obj.insert(k.clone(), v.clone());
@@ -492,12 +536,53 @@ pub fn sanitize_schema(mut schema: serde_json::Value) -> serde_json::Value {
                                 }
                             }
                         }
-                        // Remove anyOf/allOf from properties too
                         prop_obj.remove("anyOf");
                         prop_obj.remove("allOf");
                     }
+
+                    // Recursively sanitize nested schemas
+                    *prop_value =
+                        sanitize_schema_recursive(prop_value.take(), &originally_required);
+
+                    // For optional properties (not in original required array),
+                    // make them nullable by adding "null" to the type
+                    if !originally_required.contains(key) {
+                        if let Some(prop_obj) = prop_value.as_object_mut() {
+                            if let Some(type_val) = prop_obj.get_mut("type") {
+                                if let Some(type_str) = type_val.as_str() {
+                                    *type_val = json!([type_str, "null"]);
+                                } else if let Some(type_arr) = type_val.as_array_mut() {
+                                    if !type_arr.iter().any(|v| v == "null") {
+                                        type_arr.push(json!("null"));
+                                    }
+                                }
+                            } else if !prop_obj.contains_key("properties")
+                                && !prop_obj.contains_key("items")
+                            {
+                                // Only add default type if not a complex nested schema
+                                prop_obj.insert("type".to_string(), json!(["string", "null"]));
+                            }
+                        }
+                    }
                 }
             }
+        }
+
+        // Handle array items schema
+        if let Some(items) = obj.get_mut("items") {
+            *items = sanitize_schema_recursive(items.take(), &HashSet::new());
+        }
+
+        // Set all properties as required (OpenAI Responses API strict mode)
+        if !all_property_keys.is_empty() {
+            let required_array: Vec<serde_json::Value> = all_property_keys
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect();
+            obj.insert(
+                "required".to_string(),
+                serde_json::Value::Array(required_array),
+            );
         }
     }
     schema
@@ -534,7 +619,8 @@ mod tests {
                         {"type": "number"}
                     ]
                 }
-            }
+            },
+            "required": ["value"]  // Make it required so type stays as-is
         });
 
         let sanitized = sanitize_schema(schema);
@@ -544,10 +630,111 @@ mod tests {
             .and_then(|p| p.get("value"))
             .unwrap();
         assert!(value_prop.get("oneOf").is_none());
+        // Should have type from first oneOf option
         assert_eq!(
             value_prop.get("type").and_then(|t| t.as_str()),
             Some("string")
         );
+    }
+
+    #[test]
+    fn test_sanitize_schema_strict_mode_compatibility() {
+        // Schema with required and optional properties
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string", "description": "Required file path"},
+                "line_start": {"type": "integer", "description": "Optional start line"},
+                "line_end": {"type": "integer", "description": "Optional end line"}
+            },
+            "required": ["file_path"]
+        });
+
+        let sanitized = sanitize_schema(schema);
+
+        // Should have additionalProperties: false
+        assert_eq!(
+            sanitized.get("additionalProperties"),
+            Some(&serde_json::Value::Bool(false))
+        );
+
+        // All properties should be in required array
+        let required = sanitized
+            .get("required")
+            .and_then(|r| r.as_array())
+            .unwrap();
+        assert!(required.contains(&json!("file_path")));
+        assert!(required.contains(&json!("line_start")));
+        assert!(required.contains(&json!("line_end")));
+
+        // Originally required property should keep its type
+        let file_path = sanitized
+            .get("properties")
+            .and_then(|p| p.get("file_path"))
+            .unwrap();
+        assert_eq!(file_path.get("type"), Some(&json!("string")));
+
+        // Optional properties should be nullable (type becomes array with null)
+        let line_start = sanitized
+            .get("properties")
+            .and_then(|p| p.get("line_start"))
+            .unwrap();
+        let line_start_type = line_start.get("type").unwrap();
+        assert!(line_start_type.is_array());
+        let type_arr = line_start_type.as_array().unwrap();
+        assert!(type_arr.contains(&json!("integer")));
+        assert!(type_arr.contains(&json!("null")));
+    }
+
+    #[test]
+    fn test_sanitize_schema_nested_objects() {
+        // Schema with nested array of objects (like update_plan)
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "task": {"type": "string"},
+                            "status": {"type": "string"}
+                        },
+                        "required": ["task"]
+                    }
+                }
+            },
+            "required": ["plan"]
+        });
+
+        let sanitized = sanitize_schema(schema);
+
+        // Check nested items schema
+        let items = sanitized
+            .get("properties")
+            .and_then(|p| p.get("plan"))
+            .and_then(|p| p.get("items"))
+            .unwrap();
+
+        // Items should have additionalProperties: false
+        assert_eq!(
+            items.get("additionalProperties"),
+            Some(&serde_json::Value::Bool(false))
+        );
+
+        // Items should have all properties in required
+        let items_required = items.get("required").and_then(|r| r.as_array()).unwrap();
+        assert!(items_required.contains(&json!("task")));
+        assert!(items_required.contains(&json!("status")));
+
+        // Status should be nullable (was optional)
+        let status = items
+            .get("properties")
+            .and_then(|p| p.get("status"))
+            .unwrap();
+        let status_type = status.get("type").unwrap();
+        assert!(status_type.is_array());
+        assert!(status_type.as_array().unwrap().contains(&json!("null")));
     }
 
     #[test]

--- a/backend/crates/qbit-evals/src/executor.rs
+++ b/backend/crates/qbit-evals/src/executor.rs
@@ -3,7 +3,7 @@
 //! Provides a minimal agent execution loop without the heavyweight features
 //! of the main agentic loop (HITL, loop detection, context management, etc.).
 //!
-//! Uses Vertex Claude Haiku for fast, cost-effective eval runs.
+//! Uses Vertex Claude Sonnet for eval runs.
 
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -96,7 +96,7 @@ Do not ask for clarification - make reasonable assumptions and proceed.
 /// Execute a prompt against the agent in the given workspace.
 ///
 /// This is a lightweight executor that:
-/// - Uses Vertex Claude Haiku for speed
+/// - Uses Vertex Claude Sonnet
 /// - Has a minimal set of tools
 /// - Runs an agentic loop until completion
 /// - Auto-approves all tool calls (no HITL)
@@ -122,7 +122,7 @@ pub async fn execute_eval_prompt(
     } else {
         Client::from_env(&config.project_id, &config.location).await?
     };
-    let model = client.completion_model(models::CLAUDE_HAIKU_4_5);
+    let model = client.completion_model(models::CLAUDE_SONNET_4_5);
 
     // Create tool registry for the workspace
     let mut registry = ToolRegistry::new(workspace.to_path_buf()).await;
@@ -172,7 +172,7 @@ pub async fn execute_eval_prompt(
                 .unwrap_or_else(|_| OneOrMany::one(chat_history[0].clone())),
             documents: vec![],
             tools: tools.clone(),
-            temperature: Some(0.0), // Zero temperature for deterministic evals
+            temperature: Some(0.3), // Low temperature for consistent but not rigid evals
             max_tokens: Some(4096),
             tool_choice: None,
             additional_params: None,

--- a/backend/crates/qbit-evals/src/metrics/llm_judge.rs
+++ b/backend/crates/qbit-evals/src/metrics/llm_judge.rs
@@ -1,6 +1,6 @@
 //! LLM-based evaluation metrics.
 //!
-//! Uses Vertex Claude Haiku to evaluate agent outputs against criteria.
+//! Uses Vertex Claude Sonnet to evaluate agent outputs against criteria.
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -33,7 +33,7 @@ async fn create_judge_client() -> Result<rig_anthropic_vertex::CompletionModel> 
     } else {
         Client::from_env(&config.project_id, &config.location).await?
     };
-    Ok(client.completion_model(models::CLAUDE_HAIKU_4_5))
+    Ok(client.completion_model(models::CLAUDE_SONNET_4_5))
 }
 
 /// Metric that uses an LLM to judge whether output meets criteria.

--- a/backend/crates/qbit-evals/src/runner.rs
+++ b/backend/crates/qbit-evals/src/runner.rs
@@ -50,7 +50,7 @@ pub struct EvalRunConfig {
 impl Default for EvalRunConfig {
     fn default() -> Self {
         Self {
-            model: "claude-haiku-4-5@20251001".to_string(),
+            model: "claude-sonnet-4-5@20250929".to_string(),
             timeout_secs: 120,
             auto_approve: true,
         }
@@ -155,7 +155,7 @@ impl EvalRunner {
 
     /// Run a prompt against the agent in the specified workspace.
     ///
-    /// Uses the lightweight eval executor with Vertex Claude Haiku.
+    /// Uses the lightweight eval executor with Vertex Claude Sonnet.
     ///
     /// # Arguments
     /// * `workspace` - The workspace directory where the agent should operate

--- a/backend/crates/qbit-llm-providers/src/lib.rs
+++ b/backend/crates/qbit-llm-providers/src/lib.rs
@@ -34,8 +34,10 @@ pub enum LlmClient {
     VertexAnthropic(rig_anthropic_vertex::CompletionModel),
     /// OpenRouter via rig-core (supports tools and system prompts)
     RigOpenRouter(rig_openrouter::CompletionModel),
-    /// OpenAI via rig-core (uses Chat Completions API for better compatibility)
+    /// OpenAI via rig-core (uses Chat Completions API - may have tool issues)
     RigOpenAi(rig_openai::completion::CompletionModel),
+    /// OpenAI via rig-core (uses Responses API - better tool support)
+    RigOpenAiResponses(rig_openai::responses_api::ResponsesCompletionModel),
     /// Direct Anthropic API via rig-core
     RigAnthropic(rig_anthropic::completion::CompletionModel),
     /// Ollama local inference via rig-core

--- a/backend/crates/qbit/src/ai/commands/workflow.rs
+++ b/backend/crates/qbit/src/ai/commands/workflow.rs
@@ -158,7 +158,7 @@ impl WorkflowLlmExecutor for BridgeLlmExecutor {
                 .unwrap_or_else(|_| OneOrMany::one(chat_history[0].clone())),
             documents: vec![],
             tools: vec![], // No tools for workflow tasks
-            temperature: Some(0.7),
+            temperature: Some(0.3),
             max_tokens: Some(8192),
             tool_choice: None,
             additional_params: None,
@@ -188,6 +188,16 @@ impl WorkflowLlmExecutor for BridgeLlmExecutor {
                 text
             }
             LlmClient::RigOpenAi(model) => {
+                let response = model.completion(request).await?;
+                let mut text = String::new();
+                for content in response.choice.iter() {
+                    if let rig::completion::AssistantContent::Text(t) = content {
+                        text.push_str(&t.text);
+                    }
+                }
+                text
+            }
+            LlmClient::RigOpenAiResponses(model) => {
                 let response = model.completion(request).await?;
                 let mut text = String::new();
                 for content in response.choice.iter() {
@@ -361,7 +371,7 @@ impl WorkflowLlmExecutor for BridgeLlmExecutor {
                     .unwrap_or_else(|_| OneOrMany::one(chat_history[0].clone())),
                 documents: vec![],
                 tools: tool_defs.clone(),
-                temperature: config.temperature.map(|t| t as f64).or(Some(0.7)),
+                temperature: config.temperature.map(|t| t as f64).or(Some(0.3)),
                 max_tokens: Some(8192),
                 tool_choice: None,
                 additional_params: None,
@@ -379,6 +389,10 @@ impl WorkflowLlmExecutor for BridgeLlmExecutor {
                     response.choice
                 }
                 LlmClient::RigOpenAi(model) => {
+                    let response = model.completion(request).await?;
+                    response.choice
+                }
+                LlmClient::RigOpenAiResponses(model) => {
                     let response = model.completion(request).await?;
                     response.choice
                 }


### PR DESCRIPTION
## Summary

- Adds OpenAI Responses API integration for better tool support (replaces Chat Completions API)
- Enables sub-agent execution for generic models (OpenAI, Anthropic, etc.)
- Standardizes temperature to 0.3 across all LLM calls for consistent behavior
- Updates schema sanitization for OpenAI strict mode compatibility

## Changes

### Temperature Standardization
| Component | Before | After |
|-----------|--------|-------|
| Main agent loop | 0.5 | 0.3 |
| Sub-agents | 0.7 | 0.3 |
| Workflows | 0.7 | 0.3 |
| Evals executor | 0.0 | 0.3 |
| LLM judge metrics | 0.0 | 0.0 (unchanged) |

### OpenAI Responses API
- Switch from Chat Completions API to Responses API for OpenAI models
- Add `execute_with_openai_responses_model` in agent bridge
- Schema sanitization handles strict mode requirements (additionalProperties, nullable optionals)

### Generic Model Sub-agent Support
- Make `execute_sub_agent` generic over any `CompletionModel`
- Enable sub-agent calls in `run_agentic_loop_generic`
- Remove "not supported" restriction for generic models

### Evals
- Update eval executor to use Claude Sonnet instead of Haiku

## Test plan

- [ ] Run evals with `cargo run --features evals --bin qbit-cli -- --eval`
- [ ] Test OpenAI model with tool calls
- [ ] Test sub-agent delegation with non-Vertex models