### PR TITLE
fix(build): specify mainBinaryName to fix macOS release bundling

### DIFF
--- a/backend/crates/qbit/tauri.conf.json
+++ b/backend/crates/qbit/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "qbit",
+  "mainBinaryName": "qbit",
   "identifier": "com.qbit.terminal",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Fixes the macOS ARM64 and x86_64 release builds by adding explicit `mainBinaryName` configuration to `tauri.conf.json`. This prevents Tauri from attempting to bundle the non-existent `qbit-cli` binary during release builds.

## Commits

- `6d75d59` fix(build): specify mainBinaryName to fix macOS release bundling

## Changes

- Added `"mainBinaryName": "qbit"` to `backend/crates/qbit/tauri.conf.json`

## Root Cause

The `Cargo.toml` defines two binaries:
- `qbit` (requires `tauri` feature) - GUI application ✅
- `qbit-cli` (requires `cli` feature) - headless CLI ❌

During Tauri builds with default features (`tauri`), only the `qbit` binary is built. However, Tauri was scanning all `[[bin]]` entries in Cargo.toml and attempting to bundle both binaries, resulting in:

```
Built application at: .../release/qbit
failed to bundle project Failed to copy binary from ".../release/qbit-cli": does not exist
```

## Breaking Changes

None

## Test Plan

- [ ] Verify release-please workflow succeeds for macOS ARM64
- [ ] Verify release-please workflow succeeds for macOS x86_64
- [ ] Confirm `just dev` still works locally
- [ ] Confirm `just build` still works locally

## Related Issues

Fixes Build (macOS-ARM64) job failure: https://github.com/qbit-ai/qbit/actions/runs/20590382700/job/59134397356

## Release Notes

Fixed macOS release builds by explicitly configuring the main binary name in Tauri configuration.

## Checklist

- [x] Minimal change (single line addition)
- [x] Follows Tauri 2 configuration schema
- [x] Conventional commit format followed