### PR TITLE
fix(ci): configure Tauri action project path for release builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,6 +77,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Ensure release CI does not attempt to bundle qbit-cli.
+          TAURI_CONFIG: '{"bundle":{"externalBin":null}}'
           # TODO: Apple code signing - uncomment when certificates are configured
           # APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           # APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -87,5 +89,6 @@ jobs:
         with:
           tagName: ${{ needs.release-please.outputs.tag_name }}
           releaseName: ${{ needs.release-please.outputs.tag_name }}
-          tauriScript: pnpm tauri
+          projectPath: backend/crates/qbit
+          tauriScript: pnpm --dir ../../.. tauri
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions release workflow by configuring the correct project path for the Tauri action. The Tauri configuration lives in `backend/crates/qbit` rather than the repository root, which was causing build failures.

## Commits

- `955fcb7` fix(ci): configure Tauri action project path for release builds

## Changes

- Added `projectPath: backend/crates/qbit` to point Tauri action to the correct location
- Updated `tauriScript` to `pnpm --dir ../../.. tauri` to run pnpm from the repo root where `package.json` lives
- Added `TAURI_CONFIG` environment variable to disable `externalBin` bundling, preventing the release CI from attempting to bundle `qbit-cli`

## Breaking Changes

None

## Test Plan

- [ ] Verify the next release build succeeds on GitHub Actions
- [ ] Confirm macOS ARM64 and x86_64 builds complete without errors
- [ ] Verify release artifacts are properly uploaded to the GitHub release

## Related Issues

None

## Release Notes

Fixed release builds by properly configuring the Tauri action to find the project configuration in its nested location.

## Checklist

- [x] Conventional commit format followed
- [ ] Release build verified (will be tested when next release is triggered)