### PR TITLE
fix(pty): fall back to home directory when cwd is root

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-cli-output"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "qbit-core",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "rig-core",
@@ -5329,7 +5329,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-directory-ops"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-file-ops"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-hitl"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-indexer"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "reqwest 0.12.24",
  "rig-anthropic-vertex",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-loop-detection"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "serde",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-planner"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "proptest",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-runtime"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "atty",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5515,7 +5515,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5607,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tool-policy"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5641,11 +5641,11 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.1"
+version = "0.2.3"
 
 [[package]]
 name = "qbit-web"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "parking_lot",
@@ -5660,7 +5660,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6270,7 +6270,7 @@ checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -6317,7 +6317,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "async-stream",
  "bytes",

--- a/backend/crates/qbit-pty/src/manager.rs
+++ b/backend/crates/qbit-pty/src/manager.rs
@@ -464,8 +464,14 @@ impl PtyManager {
         } else if let Ok(init_cwd) = std::env::var("INIT_CWD") {
             (PathBuf::from(init_cwd), "INIT_CWD")
         } else if let Ok(cwd) = std::env::current_dir() {
+            // If cwd is root "/", fall through to home_dir - this happens when launched from Finder
+            if cwd.as_os_str() == "/" {
+                (
+                    dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")),
+                    "home_dir (cwd was root)",
+                )
             // If we're in src-tauri, go up to project root
-            if cwd.ends_with("src-tauri") {
+            } else if cwd.ends_with("src-tauri") {
                 if let Some(parent) = cwd.parent() {
                     (parent.to_path_buf(), "current_dir (adjusted)")
                 } else {


### PR DESCRIPTION
## Summary
Fixes an issue where launching Qbit from Finder (or other launchers that set cwd to root) would result in the terminal starting in the root directory "/" instead of a sensible location.

## Commits
- `234d94c` fix(pty): fall back to home directory when cwd is root

## Changes
- Added detection for when `current_dir()` returns "/" (root directory)
- Falls back to user's home directory in this case instead of using root
- Updated debug logging to indicate the fallback source

## Breaking Changes
None

## Test Plan
- [ ] Launch Qbit from Finder (double-click the app bundle)
- [ ] Verify terminal starts in home directory, not "/"
- [ ] Launch from terminal with explicit directory: `just dev ~/Code/project`
- [ ] Verify it respects the specified directory
- [ ] Set `QBIT_WORKSPACE` env var and verify it's still honored

## Related Issues
None

## Release Notes
Fixed terminal starting in root directory when Qbit is launched from Finder or similar launchers.

## Checklist
- [x] Tests pass locally
- [x] Linting passes
- [x] Conventional commit format followed