### PR TITLE
fix(ci): enable ad-hoc code signing for macOS builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -86,12 +86,14 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Ad-hoc code signing - prevents "app is damaged" error on macOS
+          APPLE_SIGNING_IDENTITY: "-"
           # Ensure release CI does not attempt to bundle qbit-cli.
           TAURI_CONFIG: '{"bundle":{"externalBin":null}}'
-          # TODO: Apple code signing - uncomment when certificates are configured
+          # TODO: Full Apple code signing - replace APPLE_SIGNING_IDENTITY above with secrets when configured
           # APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           # APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          # APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}  # Replace "-" above with this
           # APPLE_ID: ${{ secrets.APPLE_ID }}
           # APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
## Summary

Enables ad-hoc code signing for macOS release builds to prevent the "app is damaged" error that users see when downloading the .dmg from GitHub releases.

## Commits
- `dd63a26` fix(ci): enable ad-hoc code signing for macOS builds

## Changes
- Added `APPLE_SIGNING_IDENTITY: "-"` environment variable to the Tauri build step
- Updated TODO comments to clarify the path to full Apple Developer certificate signing

## Root Cause

macOS Gatekeeper blocks unsigned applications downloaded from the internet, displaying a misleading "app is damaged" message. This affected the v0.2.3 aarch64 release.

## How It Works

Ad-hoc signing (`codesign -s -`) signs the binary with a special identity that:
- Removes the "damaged" error
- Allows the app to run after users right-click → Open
- Requires no Apple Developer account

## Breaking Changes
None

## Test Plan
- [ ] Trigger a new release and verify the macOS .dmg opens without "damaged" error
- [ ] Confirm users see "unidentified developer" warning (expected) instead of "damaged"
- [ ] Verify both aarch64 and x86_64 builds are signed

## Related Issues
Fixes the reported issue with qbit_0.2.3_aarch64.dmg showing as damaged.

## Release Notes
Fixed macOS app showing "damaged" error when downloaded from GitHub releases. Users may see an "unidentified developer" warning which can be bypassed by right-clicking and selecting Open.

## Workaround for v0.2.3
Until v0.2.4 is released, users can run:
```bash
xattr -cr ~/Downloads/qbit_0.2.3_aarch64.dmg
```

## Checklist
- [x] Conventional commit format followed
- [x] Change is minimal and focused
- [ ] Verified in next release build