### PR TITLE
fix(evals): improve LLM judge reliability and prompt composition tests

### DIFF
--- a/backend/crates/qbit-evals/src/config.rs
+++ b/backend/crates/qbit-evals/src/config.rs
@@ -212,8 +212,7 @@ mod tests {
         let settings = QbitSettings::default();
         // Don't set any env vars, project_id should be None
 
-        let result =
-            EvalConfig::from_settings_for_provider(&settings, EvalProvider::VertexClaude);
+        let result = EvalConfig::from_settings_for_provider(&settings, EvalProvider::VertexClaude);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/backend/crates/qbit-evals/src/executor.rs
+++ b/backend/crates/qbit-evals/src/executor.rs
@@ -109,8 +109,14 @@ pub async fn execute_eval_prompt(
     prompt: &str,
     verbose_config: &VerboseConfig,
 ) -> Result<AgentOutput> {
-    execute_eval_prompt_with_options(workspace, prompt, None, verbose_config, EvalProvider::default())
-        .await
+    execute_eval_prompt_with_options(
+        workspace,
+        prompt,
+        None,
+        verbose_config,
+        EvalProvider::default(),
+    )
+    .await
 }
 
 /// Execute a prompt with a custom system prompt.
@@ -123,8 +129,14 @@ pub async fn execute_eval_prompt_with_system(
     system_prompt: Option<&str>,
     verbose_config: &VerboseConfig,
 ) -> Result<AgentOutput> {
-    execute_eval_prompt_with_options(workspace, prompt, system_prompt, verbose_config, EvalProvider::default())
-        .await
+    execute_eval_prompt_with_options(
+        workspace,
+        prompt,
+        system_prompt,
+        verbose_config,
+        EvalProvider::default(),
+    )
+    .await
 }
 
 /// Execute a prompt against the agent using a specific provider.
@@ -150,9 +162,12 @@ pub async fn execute_eval_prompt_with_options(
 
     match provider {
         EvalProvider::VertexClaude => {
-            execute_with_vertex_claude(workspace, prompt, system_prompt, verbose_config, &config).await
+            execute_with_vertex_claude(workspace, prompt, system_prompt, verbose_config, &config)
+                .await
         }
-        EvalProvider::Zai => execute_with_zai(workspace, prompt, system_prompt, verbose_config, &config).await,
+        EvalProvider::Zai => {
+            execute_with_zai(workspace, prompt, system_prompt, verbose_config, &config).await
+        }
     }
 }
 
@@ -173,14 +188,26 @@ async fn execute_with_vertex_claude(
 
     // Create client using service account credentials if available, otherwise fall back to ADC
     let client = if let Some(ref creds_path) = vertex_config.credentials_path {
-        Client::from_service_account(creds_path, &vertex_config.project_id, &vertex_config.location)
-            .await?
+        Client::from_service_account(
+            creds_path,
+            &vertex_config.project_id,
+            &vertex_config.location,
+        )
+        .await?
     } else {
         Client::from_env(&vertex_config.project_id, &vertex_config.location).await?
     };
     let model = client.completion_model(models::CLAUDE_SONNET_4_5);
 
-    execute_with_model(workspace, prompt, system_prompt, verbose_config, model, "Claude Sonnet 4.5").await
+    execute_with_model(
+        workspace,
+        prompt,
+        system_prompt,
+        verbose_config,
+        model,
+        "Claude Sonnet 4.5",
+    )
+    .await
 }
 
 /// Execute with Z.AI GLM.
@@ -201,7 +228,15 @@ async fn execute_with_zai(
     let client = rig_zai::Client::new(&zai_config.api_key);
     let model = client.completion_model(rig_zai::GLM_4_7);
 
-    execute_with_model(workspace, prompt, system_prompt, verbose_config, model, "GLM-4.7").await
+    execute_with_model(
+        workspace,
+        prompt,
+        system_prompt,
+        verbose_config,
+        model,
+        "GLM-4.7",
+    )
+    .await
 }
 
 /// Generic execution with any model implementing CompletionModel.

--- a/backend/crates/qbit-evals/src/runner.rs
+++ b/backend/crates/qbit-evals/src/runner.rs
@@ -122,11 +122,7 @@ impl EvalRunner {
 
     /// Create a new eval runner with a specific provider.
     pub fn new_with_provider(provider: EvalProvider) -> Result<Self> {
-        Self::with_config_and_provider(
-            EvalRunConfig::default(),
-            VerboseConfig::default(),
-            provider,
-        )
+        Self::with_config_and_provider(EvalRunConfig::default(), VerboseConfig::default(), provider)
     }
 
     /// Create a new eval runner with verbose output and a specific provider.

--- a/backend/crates/qbit/src/bin/qbit-cli.rs
+++ b/backend/crates/qbit/src/bin/qbit-cli.rs
@@ -48,8 +48,8 @@ async fn main() -> Result<()> {
 
     #[cfg(feature = "evals")]
     if args.eval {
-        use std::str::FromStr;
         use qbit_evals::EvalProvider;
+        use std::str::FromStr;
 
         // Parse provider from args (defaults to Vertex Claude)
         let provider = if let Some(ref provider_str) = args.eval_provider {


### PR DESCRIPTION
## Summary
- Add structured response parsing with YAML format for consistent judge output
- Implement tool-based judge that can explore workspace for better context
- Fix config access to use nested vertex config structure
- Update prompt composition scenarios with clearer evaluation criteria

## Test Results
All 14 eval scenarios passing (100%)