### PR TITLE
ci: optimize GitHub Actions caching

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "pnpm"
 
       - name: Install frontend dependencies
         run: pnpm install
@@ -60,13 +61,17 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: backend
-          shared-key: check
+          # Unified key for better cache sharing across workflows
+          shared-key: rust-ubuntu
           cache-targets: true
+          # Only save cache on main branch to avoid cache pollution
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install Tauri system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: Cache apt packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          version: 1.0
 
       - name: Run checks
         run: just check

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,8 +29,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm list @playwright/test --json | jq -r '.[0].devDependencies["@playwright/test"].version // .[0].dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Run Playwright tests
         run: npx playwright test --reporter=list

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -59,9 +59,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: backend
-          # Share cache across branches for evals
-          shared-key: evals
+          # Unified key for better cache sharing across workflows
+          shared-key: rust-ubuntu
           cache-targets: true
+          # Only save cache on main branch to avoid cache pollution
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup Vertex AI credentials
         run: |


### PR DESCRIPTION
## Summary

Optimize caching across all GitHub Actions workflows to reduce CI times.

## Changes

### check.yml
- Add `cache: "pnpm"` to Node.js setup (~30s savings)
- Add `awalsh128/cache-apt-pkgs-action` for Tauri system deps (~10-15s savings)
- Unify `shared-key: rust-ubuntu` for cross-workflow cache sharing
- Add `save-if` condition to only save cache on main branch

### e2e.yml
- Add Playwright browser caching (~60-90s savings)
- Cache key based on Playwright version for automatic invalidation
- Only run full `playwright install --with-deps` on cache miss
- Run `install-deps` only for system dependencies on cache hit

### evals.yml
- Unify `shared-key: rust-ubuntu` for cross-workflow cache sharing
- Add `save-if` condition to only save cache on main branch

## Expected Improvements

| Workflow | Estimated Savings |
|----------|-------------------|
| check | ~40-45s |
| e2e | ~60-90s |
| evals | Better cache hits from unified key |

## Test plan
- [x] Workflow YAML syntax validated
- [ ] CI runs successfully with new caching
- [ ] Cache hit rates improve on subsequent runs