### PR TITLE
fix(lint): resolve biome warnings in e2e tests and frontend code

### DIFF
--- a/e2e/input-mode-focus.spec.ts
+++ b/e2e/input-mode-focus.spec.ts
@@ -219,11 +219,14 @@ test.describe("Input Mode Focus", () => {
     await expect(secondTab).toBeVisible();
 
     // After creating a new tab, a UnifiedInput textarea should be focused
-    await page.waitForFunction(() => {
-      const activeElement = document.activeElement;
-      if (!activeElement || activeElement.tagName !== "TEXTAREA") return false;
-      return !activeElement.classList.contains("xterm-helper-textarea");
-    }, { timeout: 3000 });
+    await page.waitForFunction(
+      () => {
+        const activeElement = document.activeElement;
+        if (!activeElement || activeElement.tagName !== "TEXTAREA") return false;
+        return !activeElement.classList.contains("xterm-helper-textarea");
+      },
+      { timeout: 3000 }
+    );
     expect(await isUnifiedInputFocused()).toBe(true);
 
     // Verify we have 2 tabs

--- a/e2e/openai-models.spec.ts
+++ b/e2e/openai-models.spec.ts
@@ -117,38 +117,9 @@ async function openSubMenu(page: Page, triggerText: string) {
   await page.waitForTimeout(150);
 
   // Some sub-menus need a click to open reliably
-  // First check if sub-content already appeared
-  const subContent = page.locator('[data-slot="dropdown-menu-sub-content"]');
-  const initialCount = await subContent.count();
-
   // If sub-menu didn't open from hover, try clicking
   await trigger.click();
   await page.waitForTimeout(200);
-}
-
-/**
- * Check if a sub-menu item exists (for nested menus).
- * Handles the 3-level nesting: Family > Model > ReasoningEffort
- */
-async function verifyNestedModel(
-  page: Page,
-  family: string,
-  model?: string,
-  reasoningEffort?: string
-) {
-  // Open the family sub-menu
-  await openSubMenu(page, family);
-
-  if (model) {
-    // Open the model sub-menu
-    await openSubMenu(page, model);
-
-    if (reasoningEffort) {
-      // Verify the reasoning effort option exists
-      const option = page.getByRole("menuitem").filter({ hasText: reasoningEffort });
-      await expect(option.first()).toBeVisible({ timeout: 3000 });
-    }
-  }
 }
 
 /**

--- a/e2e/sub-agent-timeline.spec.ts
+++ b/e2e/sub-agent-timeline.spec.ts
@@ -28,12 +28,38 @@ type AiEventType =
   | { type: "started"; turn_id: string }
   | { type: "text_delta"; delta: string; accumulated: string }
   | { type: "tool_request"; tool_name: string; args: unknown; request_id: string }
-  | { type: "tool_result"; tool_name: string; result: unknown; success: boolean; request_id: string }
-  | { type: "completed"; response: string; tokens_used?: number; duration_ms?: number; input_tokens?: number; output_tokens?: number }
+  | {
+      type: "tool_result";
+      tool_name: string;
+      result: unknown;
+      success: boolean;
+      request_id: string;
+    }
+  | {
+      type: "completed";
+      response: string;
+      tokens_used?: number;
+      duration_ms?: number;
+      input_tokens?: number;
+      output_tokens?: number;
+    }
   | { type: "error"; message: string; error_type: string }
   | { type: "sub_agent_started"; agent_id: string; agent_name: string; task: string; depth: number }
-  | { type: "sub_agent_tool_request"; agent_id: string; tool_name: string; args: unknown; request_id: string }
-  | { type: "sub_agent_tool_result"; agent_id: string; tool_name: string; result: unknown; success: boolean; request_id: string }
+  | {
+      type: "sub_agent_tool_request";
+      agent_id: string;
+      tool_name: string;
+      args: unknown;
+      request_id: string;
+    }
+  | {
+      type: "sub_agent_tool_result";
+      agent_id: string;
+      tool_name: string;
+      result: unknown;
+      success: boolean;
+      request_id: string;
+    }
   | { type: "sub_agent_completed"; agent_id: string; response: string; duration_ms: number }
   | { type: "sub_agent_error"; agent_id: string; error: string };
 
@@ -45,10 +71,7 @@ async function waitForAppReady(page: Page) {
   await page.waitForLoadState("domcontentloaded");
 
   // Wait for the mock browser mode flag to be set
-  await page.waitForFunction(
-    () => window.__MOCK_BROWSER_MODE__ === true,
-    { timeout: 15000 }
-  );
+  await page.waitForFunction(() => window.__MOCK_BROWSER_MODE__ === true, { timeout: 15000 });
 
   // Wait for the status bar to appear (indicates React has rendered)
   await expect(page.locator('[data-testid="status-bar"]')).toBeVisible({
@@ -59,10 +82,9 @@ async function waitForAppReady(page: Page) {
   await expect(page.locator("textarea")).toBeVisible({ timeout: 5000 });
 
   // Ensure mock functions are available
-  await page.waitForFunction(
-    () => typeof window.__MOCK_EMIT_AI_EVENT__ === "function",
-    { timeout: 5000 }
-  );
+  await page.waitForFunction(() => typeof window.__MOCK_EMIT_AI_EVENT__ === "function", {
+    timeout: 5000,
+  });
 }
 
 /**

--- a/frontend/components/UnifiedTimeline/UnifiedTimeline.tsx
+++ b/frontend/components/UnifiedTimeline/UnifiedTimeline.tsx
@@ -128,11 +128,7 @@ export function UnifiedTimeline({ sessionId }: UnifiedTimelineProps) {
     return result;
   }, [groupedBlocks, activeSubAgents]);
 
-  // Throttled scroll with trailing edge - scrolls immediately on first call,
-  // then at most once per interval while updates keep coming
-  const lastScrollTimeRef = useRef<number>(0);
   const pendingScrollRef = useRef<number | null>(null);
-  const SCROLL_THROTTLE_MS = 100;
 
   const scrollToBottom = useCallback(() => {
     if (containerRef.current) {

--- a/frontend/hooks/useAiEvents.ts
+++ b/frontend/hooks/useAiEvents.ts
@@ -237,7 +237,12 @@ export function useAiEvents() {
               }
             : undefined;
 
-          if (content || streamingHistory.length > 0 || workflowForMessage || activeSubAgents.length > 0) {
+          if (
+            content ||
+            streamingHistory.length > 0 ||
+            workflowForMessage ||
+            activeSubAgents.length > 0
+          ) {
             state.addAgentMessage(sessionId, {
               id: crypto.randomUUID(),
               sessionId: sessionId,

--- a/frontend/mocks.ts
+++ b/frontend/mocks.ts
@@ -469,11 +469,31 @@ export type AiEventType =
       success: boolean;
       request_id: string;
     }
-  | { type: "completed"; response: string; tokens_used?: number; duration_ms?: number; input_tokens?: number; output_tokens?: number }
+  | {
+      type: "completed";
+      response: string;
+      tokens_used?: number;
+      duration_ms?: number;
+      input_tokens?: number;
+      output_tokens?: number;
+    }
   | { type: "error"; message: string; error_type: string }
   | { type: "sub_agent_started"; agent_id: string; agent_name: string; task: string; depth: number }
-  | { type: "sub_agent_tool_request"; agent_id: string; tool_name: string; args: unknown; request_id: string }
-  | { type: "sub_agent_tool_result"; agent_id: string; tool_name: string; result: unknown; success: boolean; request_id: string }
+  | {
+      type: "sub_agent_tool_request";
+      agent_id: string;
+      tool_name: string;
+      args: unknown;
+      request_id: string;
+    }
+  | {
+      type: "sub_agent_tool_result";
+      agent_id: string;
+      tool_name: string;
+      result: unknown;
+      success: boolean;
+      request_id: string;
+    }
   | { type: "sub_agent_completed"; agent_id: string; response: string; duration_ms: number }
   | { type: "sub_agent_error"; agent_id: string; error: string };
 
@@ -870,17 +890,23 @@ export function setupMocks(): void {
     ).__MOCK_ORIGINAL_LISTEN__ = originalListen;
 
     // Expose mock event emitters globally for e2e testing
-    (window as unknown as {
-      __MOCK_EMIT_AI_EVENT__?: typeof emitAiEvent;
-      __MOCK_SIMULATE_AI_RESPONSE_WITH_SUB_AGENT__?: typeof simulateAiResponseWithSubAgent;
-      __MOCK_SIMULATE_AI_RESPONSE__?: typeof simulateAiResponse;
-    }).__MOCK_EMIT_AI_EVENT__ = emitAiEvent;
-    (window as unknown as {
-      __MOCK_SIMULATE_AI_RESPONSE_WITH_SUB_AGENT__?: typeof simulateAiResponseWithSubAgent;
-    }).__MOCK_SIMULATE_AI_RESPONSE_WITH_SUB_AGENT__ = simulateAiResponseWithSubAgent;
-    (window as unknown as {
-      __MOCK_SIMULATE_AI_RESPONSE__?: typeof simulateAiResponse;
-    }).__MOCK_SIMULATE_AI_RESPONSE__ = simulateAiResponse;
+    (
+      window as unknown as {
+        __MOCK_EMIT_AI_EVENT__?: typeof emitAiEvent;
+        __MOCK_SIMULATE_AI_RESPONSE_WITH_SUB_AGENT__?: typeof simulateAiResponseWithSubAgent;
+        __MOCK_SIMULATE_AI_RESPONSE__?: typeof simulateAiResponse;
+      }
+    ).__MOCK_EMIT_AI_EVENT__ = emitAiEvent;
+    (
+      window as unknown as {
+        __MOCK_SIMULATE_AI_RESPONSE_WITH_SUB_AGENT__?: typeof simulateAiResponseWithSubAgent;
+      }
+    ).__MOCK_SIMULATE_AI_RESPONSE_WITH_SUB_AGENT__ = simulateAiResponseWithSubAgent;
+    (
+      window as unknown as {
+        __MOCK_SIMULATE_AI_RESPONSE__?: typeof simulateAiResponse;
+      }
+    ).__MOCK_SIMULATE_AI_RESPONSE__ = simulateAiResponse;
   } catch (error) {
     console.error("[Mocks] Error during initial setup:", error);
   }


### PR DESCRIPTION
## Summary
Fixes all 12 biome lint warnings across E2E tests and frontend code to maintain code quality standards.

## Commits
- `a168571` fix(lint): resolve biome warnings in e2e tests and frontend code

## Changes
- **e2e/openai-models.spec.ts**: Removed unused `initialCount` variable and unused `verifyNestedModel` function
- **e2e/terminal-portal-architecture.spec.ts**: 
  - Removed unused `getPortalTargetCount` function
  - Removed unused `hiddenPortal` variable
  - Replaced 7 non-null assertions (`!`) with proper null checks using `if (!x) throw new Error(...)`
  - Removed unused `sessionId` parameter from `page.evaluate` callback
- **e2e/input-mode-focus.spec.ts**: Applied biome formatting fixes
- **e2e/sub-agent-timeline.spec.ts**: Applied biome formatting to type definitions
- **frontend/components/UnifiedTimeline/UnifiedTimeline.tsx**: Removed unused `lastScrollTimeRef` and `SCROLL_THROTTLE_MS`
- **frontend/hooks/useAiEvents.ts**: Applied biome formatting fixes
- **frontend/mocks.ts**: Applied biome formatting to type definitions and window assignments

## Breaking Changes
None

## Test Plan
- [x] Run `pnpm biome check .` - passes with no warnings
- [ ] Run `just test-fe` to verify frontend tests pass
- [ ] Run `just test-e2e` to verify E2E tests pass

## Related Issues
None

## Release Notes
Code quality improvements: resolved biome lint warnings across E2E tests and frontend code.

## Checklist
- [x] Linting passes (`pnpm biome check .`)
- [x] Conventional commit format followed
- [ ] Tests pass locally