### PR TITLE
chore: remove local-tools feature flag

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,12 +13,15 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
-  # Frontend checks - fast, runs in parallel
-  check-frontend:
-    runs-on: ubuntu-latest
+  check:
+    runs-on: linux-arm64
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install just
+        uses: extractions/setup-just@v2
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -31,205 +34,43 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
-      - name: Install dependencies
+      - name: Install frontend dependencies
         run: pnpm install
 
-      - name: Run biome check
-        run: pnpm check
-
-      - name: Run typecheck
-        run: pnpm typecheck
-
-  # Rust format check - fast, no compilation needed
-  rustfmt:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: clippy, rustfmt
 
-      - name: Check formatting
-        working-directory: backend
-        run: cargo fmt --check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
 
-  # Detect which Rust crates changed
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      changed-crates: ${{ steps.filter.outputs.changes }}
-      any-rust-changes: ${{ steps.check.outputs.any-changes }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Detect changed crates
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            qbit:
-              - 'backend/crates/qbit/**'
-            qbit-ai:
-              - 'backend/crates/qbit-ai/**'
-            qbit-artifacts:
-              - 'backend/crates/qbit-artifacts/**'
-            qbit-cli-output:
-              - 'backend/crates/qbit-cli-output/**'
-            qbit-context:
-              - 'backend/crates/qbit-context/**'
-            qbit-core:
-              - 'backend/crates/qbit-core/**'
-            qbit-directory-ops:
-              - 'backend/crates/qbit-directory-ops/**'
-            qbit-evals:
-              - 'backend/crates/qbit-evals/**'
-            qbit-file-ops:
-              - 'backend/crates/qbit-file-ops/**'
-            qbit-hitl:
-              - 'backend/crates/qbit-hitl/**'
-            qbit-indexer:
-              - 'backend/crates/qbit-indexer/**'
-            qbit-llm-providers:
-              - 'backend/crates/qbit-llm-providers/**'
-            qbit-loop-detection:
-              - 'backend/crates/qbit-loop-detection/**'
-            qbit-planner:
-              - 'backend/crates/qbit-planner/**'
-            qbit-pty:
-              - 'backend/crates/qbit-pty/**'
-            qbit-runtime:
-              - 'backend/crates/qbit-runtime/**'
-            qbit-session:
-              - 'backend/crates/qbit-session/**'
-            qbit-settings:
-              - 'backend/crates/qbit-settings/**'
-            qbit-shell-exec:
-              - 'backend/crates/qbit-shell-exec/**'
-            qbit-sidecar:
-              - 'backend/crates/qbit-sidecar/**'
-            qbit-sub-agents:
-              - 'backend/crates/qbit-sub-agents/**'
-            qbit-synthesis:
-              - 'backend/crates/qbit-synthesis/**'
-            qbit-tool-policy:
-              - 'backend/crates/qbit-tool-policy/**'
-            qbit-tools:
-              - 'backend/crates/qbit-tools/**'
-            qbit-udiff:
-              - 'backend/crates/qbit-udiff/**'
-            qbit-web:
-              - 'backend/crates/qbit-web/**'
-            qbit-workflow:
-              - 'backend/crates/qbit-workflow/**'
-            rig-anthropic-vertex:
-              - 'backend/crates/rig-anthropic-vertex/**'
-            rig-zai:
-              - 'backend/crates/rig-zai/**'
-            cargo-toml:
-              - 'backend/Cargo.toml'
-              - 'backend/Cargo.lock'
-
-      - name: Check if any Rust files changed
-        id: check
+      - name: Configure sccache
         run: |
-          CHANGES='${{ steps.filter.outputs.changes }}'
-          if [ "$CHANGES" = "[]" ]; then
-            echo "any-changes=false" >> $GITHUB_OUTPUT
+          # Test if sccache is working before enabling it
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          if sccache --start-server 2>/dev/null && sccache --show-stats 2>/dev/null; then
+            echo "sccache is working, enabling RUSTC_WRAPPER"
+            echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           else
-            echo "any-changes=true" >> $GITHUB_OUTPUT
+            echo "sccache not available, building without cache wrapper"
           fi
-
-  # Rust clippy - only on changed crates
-  clippy:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any-rust-changes == 'true'
-    runs-on: linux-arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: backend
+          # Unified key for better cache sharing across workflows
           shared-key: rust-arm64
           cache-targets: true
-          save-if: true
-          cache-on-failure: true
+          # Only save cache on main branch to avoid cache pollution
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config libssl-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
-      - name: Build clippy command for changed crates
-        id: clippy-cmd
-        run: |
-          CHANGES='${{ needs.detect-changes.outputs.changed-crates }}'
-          echo "Changed crates: $CHANGES"
-
-          # If Cargo.toml/lock changed, check all crates
-          if echo "$CHANGES" | grep -q "cargo-toml"; then
-            echo "cmd=cargo clippy --all-targets --features local-tools --no-deps -- -D warnings" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Build -p flags for each changed crate
-          PACKAGES=""
-          for crate in $(echo "$CHANGES" | jq -r '.[]'); do
-            if [ "$crate" != "cargo-toml" ]; then
-              PACKAGES="$PACKAGES -p $crate"
-            fi
-          done
-
-          if [ -z "$PACKAGES" ]; then
-            echo "cmd=echo 'No crates to check'" >> $GITHUB_OUTPUT
-          else
-            echo "cmd=cargo clippy $PACKAGES --all-targets --features local-tools --no-deps -- -D warnings" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Run clippy on changed crates
-        working-directory: backend
-        run: ${{ steps.clippy-cmd.outputs.cmd }}
-
-  # Rust tests - run on all crates if any Rust changed
-  test-rust:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any-rust-changes == 'true'
-    runs-on: linux-arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
-          shared-key: rust-arm64
-          cache-targets: true
-          save-if: true
-          cache-on-failure: true
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libssl-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
-      - name: Run tests
-        working-directory: backend
-        run: cargo nextest run --features local-tools
+      - name: Run checks
+        run: just check

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -73,10 +73,6 @@ jobs:
           VERTEX_AI_LOCATION: ${{ vars.VERTEX_AI_LOCATION || 'us-east5' }}
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/vertex-credentials.json
         run: |
-#          PARALLEL_FLAG=""
-#          if [ "${{ github.event.inputs.parallel }}" = "true" ]; then
-#            PARALLEL_FLAG="--parallel"
-#          fi
           PARALLEL_FLAG="--parallel"
 
           if [ -n "${{ github.event.inputs.scenario }}" ]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -79,7 +79,7 @@ jobs:
           --release
           --target ${{ matrix.rust_target }}
           --no-default-features
-          --features cli,local-tools
+          --features cli
           --bin qbit-cli
 
       - name: Build and upload

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Testing
 - `just test-watch`: Vitest watch.
 - `just test-ui`: Vitest UI.
 - `just test-coverage`: coverage.
-- `just test-rust`: Rust tests (with `local-tools` feature).
+- `just test-rust`: Rust tests.
 - `just test-e2e [args]`: Playwright.
 
 Quality
@@ -55,7 +55,7 @@ Other useful commands: `pnpm install`, `pnpm tauri dev`, `pnpm preview`, `pnpm e
 ## Testing Guidelines
 
 - Frontend: Vitest + React Testing Library + jsdom; name tests `*.test.ts(x)` near the code they cover; setup in `frontend/test/`.
-- Rust: `cargo test` (uses `--features local-tools` in `just test-rust`).
+- Rust: `cargo test` (via `just test-rust`).
 - Evals: Rust-native framework using rig; run via `just eval` (see `docs/rig-evals.md`).
 - E2E: Playwright specs `e2e/*.spec.ts`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ just build            # Production build
 just build-rust       # Rust only (debug)
 
 # CLI Binary (headless mode)
-cargo build -p qbit --features cli,local-tools --no-default-features --bin qbit-cli
+cargo build -p qbit --features cli --no-default-features --bin qbit-cli
 ./target/debug/qbit-cli -e "prompt" --auto-approve
 ```
 
@@ -234,7 +234,6 @@ e2e/                      # End-to-end tests (Playwright)
 |------|-------------|---------|
 | `tauri` | GUI application (Tauri window) | Yes |
 | `cli` | Headless CLI binary | No |
-| `local-tools` | Local tool/session implementations (migration from vtcode-core) | Yes |
 | `local-llm` | Local LLM via mistral.rs (Metal GPU) - **currently disabled** | No |
 | `evals` | Evaluation framework for agent testing | No |
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Qbit includes a headless CLI binary for scripting and automation:
 
 ```bash
 # Build the CLI
-cargo build -p qbit --features cli,local-tools --no-default-features --bin qbit-cli
+cargo build -p qbit --features cli --no-default-features --bin qbit-cli
 
 # Run with a prompt
 ./target/debug/qbit-cli -e "your prompt here" --auto-approve
@@ -218,7 +218,6 @@ cargo build -p qbit --features cli,local-tools --no-default-features --bin qbit-
 |--------------|-------------|
 | `tauri` | GUI application (default) |
 | `cli` | Headless CLI binary |
-| `local-tools` | Local file/shell tools for CLI |
 | `local-llm` | Local LLM via mistral.rs (Metal GPU) |
 
 > **Note:** `tauri` and `cli` flags are mutually exclusive.

--- a/backend/crates/qbit-ai/Cargo.toml
+++ b/backend/crates/qbit-ai/Cargo.toml
@@ -64,7 +64,6 @@ vtcode-core = { workspace = true }
 default = []
 tauri = ["qbit-pty/tauri"]
 cli = ["qbit-pty/cli"]
-local-tools = []
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/backend/crates/qbit/Cargo.toml
+++ b/backend/crates/qbit/Cargo.toml
@@ -130,7 +130,7 @@ toml.workspace = true
 rustls.workspace = true
 
 [features]
-default = ["tauri", "local-tools"]
+default = ["tauri"]
 # Tauri GUI application (mutually exclusive with cli)
 tauri = ["dep:tauri", "dep:tauri-build", "dep:tauri-plugin-dialog", "qbit-runtime/tauri", "qbit-pty/tauri", "qbit-sidecar/tauri", "qbit-ai/tauri"]
 # CLI binary for headless operation (mutually exclusive with tauri)
@@ -139,13 +139,8 @@ cli = ["dep:clap", "dep:atty", "dep:qbit-cli-output", "qbit-runtime/cli", "qbit-
 # TEMPORARILY DISABLED - mistralrs dependency commented out due to resolution conflicts
 # Uncomment mistralrs dependency above and add "dep:mistralrs" to re-enable
 local-llm = []
-# Use local tool/session implementations instead of vtcode-core
-# This enables gradual migration from vtcode-core to local implementations:
-# - Default (no flag): Use vtcode-core's ToolRegistry and session_archive
-# - With flag (--features local-tools): Use local implementations in src/tools/ and src/session/
-local-tools = []
 # Evaluation framework using rig::evals
-evals = ["cli", "local-tools", "dep:qbit-evals"]
+evals = ["cli", "dep:qbit-evals"]
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/backend/crates/qbit/src/compat.rs
+++ b/backend/crates/qbit/src/compat.rs
@@ -1,43 +1,14 @@
 //! Compatibility layer for vtcode-core migration.
 //!
-//! This module provides unified imports that work with either:
-//! - vtcode-core (default) - Uses external crate implementations
-//! - Local implementations (with `local-tools` feature) - Uses modules in this crate
-//!
-//! ## Feature Flag
-//!
-//! The `local-tools` feature flag controls which implementation is used:
-//!
-//! ```bash
-//! # Default: use vtcode-core
-//! cargo build
-//!
-//! # Use local implementations
-//! cargo build --features local-tools
-//! ```
-//!
-//! ## Migration Path
-//!
-//! 1. **Phase 1 (current)**: Create compat layer with feature flags
-//! 2. **Phase 2**: Update AI module imports to use compat layer
-//! 3. **Phase 3**: Test extensively with `local-tools` enabled
-//! 4. **Phase 4**: Enable `local-tools` by default
-//! 5. **Phase 5**: Remove vtcode-core dependency
+//! This module provides unified imports that abstract over the underlying
+//! implementations. Local implementations from qbit_tools and qbit_core are
+//! now the default and only option.
 //!
 //! ## Usage
 //!
-//! Instead of importing directly from vtcode-core:
+//! Import from the compat layer for consistent access:
 //!
 //! ```rust,ignore
-//! // Old way (DON'T do this in new code)
-//! use vtcode_core::tools::ToolRegistry;
-//! use vtcode_core::utils::session_archive::SessionArchive;
-//! ```
-//!
-//! Import from the compat layer:
-//!
-//! ```rust,ignore
-//! // New way (DO this)
 //! use crate::compat::tools::ToolRegistry;
 //! use crate::compat::session::SessionArchive;
 //! ```
@@ -48,12 +19,7 @@
 
 /// Tool registry compatibility module.
 ///
-/// Provides `ToolRegistry` and related types that can come from either:
-/// - `vtcode_core::tools` (default)
-/// - `crate::tools` (with `local-tools` feature)
-///
-///
-/// Always uses qbit_tools which provides a drop-in replacement for vtcode-core's ToolRegistry.
+/// Provides `ToolRegistry` and related types from qbit_tools.
 pub mod tools {
     pub use qbit_tools::{build_function_declarations, FunctionDeclaration, Tool, ToolRegistry};
 }
@@ -65,72 +31,13 @@ pub mod tools {
 /// Session archive compatibility module.
 ///
 /// Provides `SessionArchive`, `SessionMessage`, `MessageRole`, and related
-/// types that can come from either:
-/// - `vtcode_core::utils::session_archive` (default)
-/// - `crate::session` (with `local-tools` feature)
-#[cfg(feature = "local-tools")]
+/// types from qbit_core::session.
 pub mod session {
-    // Local session archive implementation.
-    // Uses the qbit_core::session module which provides a drop-in
-    // replacement for vtcode-core's session_archive.
-
     pub use qbit_core::session::{
         find_session_by_identifier, get_sessions_dir, list_recent_sessions, MessageContent,
         MessageRole, SessionArchive, SessionArchiveMetadata, SessionListing, SessionMessage,
         SessionSnapshot,
     };
-}
-
-#[cfg(not(feature = "local-tools"))]
-pub mod session {
-    //! vtcode-core session archive implementation.
-    //!
-    //! This uses vtcode-core's session_archive module which is the current
-    //! production implementation.
-
-    pub use vtcode_core::llm::provider::MessageRole;
-    pub use vtcode_core::utils::session_archive::{
-        find_session_by_identifier, list_recent_sessions, SessionArchive, SessionArchiveMetadata,
-        SessionListing, SessionMessage, SessionSnapshot,
-    };
-
-    /// Get the sessions directory path.
-    ///
-    /// This function provides compatibility with the local session module's
-    /// `get_sessions_dir()` function. vtcode-core handles this internally
-    /// but we expose it for code that needs explicit access.
-    pub fn get_sessions_dir() -> anyhow::Result<std::path::PathBuf> {
-        let dir = if let Ok(custom) = std::env::var("VT_SESSION_DIR") {
-            std::path::PathBuf::from(custom)
-        } else {
-            dirs::home_dir()
-                .ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?
-                .join(".qbit")
-                .join("sessions")
-        };
-
-        std::fs::create_dir_all(&dir)?;
-        Ok(dir)
-    }
-
-    /// MessageContent compatibility type.
-    ///
-    /// vtcode-core's SessionMessage uses a different content structure.
-    /// This type provides a compatible interface for accessing message content.
-    #[derive(Debug, Clone)]
-    pub struct MessageContent(String);
-
-    impl MessageContent {
-        /// Create a new MessageContent from a string.
-        pub fn new(content: impl Into<String>) -> Self {
-            Self(content.into())
-        }
-
-        /// Extract text content.
-        pub fn as_text(&self) -> &str {
-            &self.0
-        }
-    }
 }
 
 // =============================================================================
@@ -144,39 +51,19 @@ mod tests {
     /// Test that tool module exports are available.
     #[test]
     fn test_tools_exports_available() {
-        // This test verifies that the expected types are exported.
-        // It will fail to compile if any export is missing.
         fn _assert_tool_registry_exists<T: Sized>(_: &T) {}
-
-        // We can't instantiate these without real data, but we can verify
-        // the types exist and are accessible.
         let _: fn() -> Vec<tools::FunctionDeclaration> = tools::build_function_declarations;
-
-        // ToolRegistry should be accessible as a type
         fn _accepts_registry(_: &tools::ToolRegistry) {}
     }
 
     /// Test that session module exports are available.
     #[test]
     fn test_session_exports_available() {
-        // This test verifies that the expected types are exported.
-        // It will fail to compile if any export is missing.
-
-        // MessageRole should be accessible
         fn _accepts_role(_: session::MessageRole) {}
-
-        // Verify get_sessions_dir function exists and has correct signature
         let _: fn() -> anyhow::Result<std::path::PathBuf> = session::get_sessions_dir;
-
-        // Note: find_session_by_identifier and list_recent_sessions are async
-        // functions with different return types between implementations.
-        // Their existence is verified by the integration tests instead.
     }
 
-    /// Test that both implementations expose the same public interface.
-    ///
-    /// This test documents the expected interface and will catch breaking
-    /// changes in either implementation.
+    /// Test that the expected interface is available.
     #[test]
     fn test_interface_compatibility() {
         // Tool interface requirements:
@@ -193,16 +80,5 @@ mod tests {
         // - MessageRole::{User, Assistant, System, Tool}
         // - find_session_by_identifier(id) -> Result<Option<SessionListing>>
         // - list_recent_sessions(limit) -> Result<Vec<SessionListing>>
-
-        // If this compiles, the interfaces are compatible at the type level.
-        // Runtime behavior compatibility is tested separately.
-    }
-
-    /// Verify feature flag behavior.
-    #[test]
-    fn test_feature_flag_configuration() {
-        // When local-tools is enabled, we should be using local implementations.
-        // When local-tools is NOT enabled, we should be using vtcode-core.
-        // This is verified by the fact that this code compiles with the correct imports.
     }
 }

--- a/backend/crates/qbit/tests/compat_layer.rs
+++ b/backend/crates/qbit/tests/compat_layer.rs
@@ -1,28 +1,13 @@
 //! Integration tests for the compatibility layer.
 //!
-//! These tests verify that the compat layer correctly switches between
-//! vtcode-core and local implementations based on the `local-tools` feature flag.
+//! These tests verify that the compat layer correctly provides access to
+//! the local qbit implementations (qbit_tools, qbit_core::session).
 //!
 //! ## Running Tests
 //!
 //! ```bash
-//! # Test with vtcode-core (default)
 //! cargo test --test compat_layer
-//!
-//! # Test with local implementations
-//! cargo test --test compat_layer --features local-tools
 //! ```
-//!
-//! ## Implementation Differences
-//!
-//! Note: There are some interface differences between vtcode-core and local
-//! implementations that these tests account for:
-//!
-//! - vtcode-core's `available_tools()` is async, local is sync
-//! - Session ID access differs between implementations
-//!
-//! The tests use conditional compilation to handle these differences while
-//! verifying core functionality works correctly.
 
 use qbit_lib::compat;
 use serde_json::json;
@@ -35,42 +20,23 @@ use tempfile::TempDir;
 mod tools {
     use super::*;
 
-    /// Verify that ToolRegistry can be created with the current implementation.
     #[tokio::test]
     async fn test_tool_registry_creation() {
         let temp = TempDir::new().expect("Failed to create temp dir");
         let workspace = temp.path().to_path_buf();
-
         let registry = compat::tools::ToolRegistry::new(workspace).await;
-
-        // Registry should be created successfully
-        // (both implementations have the same constructor signature)
         let _ = registry;
     }
 
-    /// Verify that available_tools() returns a list of tool names.
     #[tokio::test]
     async fn test_tool_registry_available_tools() {
         let temp = TempDir::new().expect("Failed to create temp dir");
         let workspace = temp.path().to_path_buf();
-
         let registry = compat::tools::ToolRegistry::new(workspace).await;
-
-        // Note: vtcode-core's available_tools() is async, local is sync
-        // Use conditional compilation to handle the difference
-        #[cfg(feature = "local-tools")]
         let tools = registry.available_tools();
 
-        #[cfg(not(feature = "local-tools"))]
-        let tools = registry.available_tools().await;
+        assert!(!tools.is_empty(), "ToolRegistry should have available tools");
 
-        // Both implementations should return some tools
-        assert!(
-            !tools.is_empty(),
-            "ToolRegistry should have available tools"
-        );
-
-        // Core tools should be available in both implementations
         let expected_tools = ["read_file", "write_file", "run_pty_cmd"];
         for tool in expected_tools {
             assert!(
@@ -81,13 +47,11 @@ mod tools {
         }
     }
 
-    /// Verify that execute_tool() works for a basic read operation.
     #[tokio::test]
     async fn test_tool_registry_execute_read_file() {
         let temp = TempDir::new().expect("Failed to create temp dir");
         let workspace = temp.path().to_path_buf();
 
-        // Create a test file
         let test_content = "Hello, World!";
         std::fs::write(workspace.join("test.txt"), test_content)
             .expect("Failed to create test file");
@@ -97,27 +61,15 @@ mod tools {
             .execute_tool("read_file", json!({"path": "test.txt"}))
             .await;
 
-        // Should succeed
         assert!(result.is_ok(), "read_file should succeed");
-
         let value = result.unwrap();
+        assert!(value.get("error").is_none(), "Successful read should not have error field");
 
-        // Success format: should NOT have "error" field
-        assert!(
-            value.get("error").is_none(),
-            "Successful read should not have error field"
-        );
-
-        // Should have content field with file contents
         let content = value.get("content").and_then(|v| v.as_str());
         assert!(content.is_some(), "Result should have content field");
-        assert!(
-            content.unwrap().contains(test_content),
-            "Content should contain file contents"
-        );
+        assert!(content.unwrap().contains(test_content), "Content should contain file contents");
     }
 
-    /// Verify that execute_tool() returns error format for missing files.
     #[tokio::test]
     async fn test_tool_registry_execute_read_file_not_found() {
         let temp = TempDir::new().expect("Failed to create temp dir");
@@ -128,89 +80,49 @@ mod tools {
             .execute_tool("read_file", json!({"path": "nonexistent.txt"}))
             .await;
 
-        // Should succeed (returns JSON with error, doesn't throw)
-        assert!(
-            result.is_ok(),
-            "execute_tool should return Ok with error JSON"
-        );
-
+        assert!(result.is_ok(), "execute_tool should return Ok with error JSON");
         let value = result.unwrap();
-
-        // Failure format: should have "error" field
-        assert!(
-            value.get("error").is_some(),
-            "Failed read should have error field"
-        );
+        assert!(value.get("error").is_some(), "Failed read should have error field");
     }
 
-    /// Verify that build_function_declarations() returns tool schemas.
     #[test]
     fn test_build_function_declarations() {
         let declarations = compat::tools::build_function_declarations();
-
-        // Should return multiple declarations
         assert!(!declarations.is_empty(), "Should return tool declarations");
 
-        // Each declaration should have name, description, and parameters
         for decl in &declarations {
             assert!(!decl.name.is_empty(), "Declaration should have name");
-            assert!(
-                !decl.description.is_empty(),
-                "Declaration '{}' should have description",
-                decl.name
-            );
+            assert!(!decl.description.is_empty(), "Declaration '{}' should have description", decl.name);
         }
 
-        // Core tools should be declared
         let names: Vec<&str> = declarations.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"read_file"), "Should declare read_file");
         assert!(names.contains(&"write_file"), "Should declare write_file");
         assert!(names.contains(&"edit_file"), "Should declare edit_file");
     }
 
-    /// Verify the success/failure contract for shell commands.
     #[tokio::test]
     async fn test_tool_registry_shell_exit_code_contract() {
         let temp = TempDir::new().expect("Failed to create temp dir");
         let workspace = temp.path().to_path_buf();
-
         let mut registry = compat::tools::ToolRegistry::new(workspace).await;
 
-        // Success case: exit code 0
+        // Success case
         let result = registry
             .execute_tool("run_pty_cmd", json!({"command": "echo hello"}))
             .await;
-
         assert!(result.is_ok(), "run_pty_cmd should succeed");
         let value = result.unwrap();
+        assert_eq!(value.get("exit_code").and_then(|v| v.as_i64()), Some(0));
+        assert!(value.get("error").is_none());
 
-        let exit_code = value.get("exit_code").and_then(|v| v.as_i64());
-        assert_eq!(
-            exit_code,
-            Some(0),
-            "Successful command should have exit_code 0"
-        );
-        assert!(
-            value.get("error").is_none(),
-            "Successful command should not have error field"
-        );
-
-        // Failure case: non-zero exit code
+        // Failure case
         let result = registry
             .execute_tool("run_pty_cmd", json!({"command": "exit 1"}))
             .await;
-
-        assert!(
-            result.is_ok(),
-            "run_pty_cmd should return Ok even for failures"
-        );
+        assert!(result.is_ok());
         let value = result.unwrap();
-
-        let exit_code = value.get("exit_code").and_then(|v| v.as_i64());
-        assert!(
-            exit_code.map(|c| c != 0).unwrap_or(false),
-            "Failed command should have non-zero exit_code"
-        );
+        assert!(value.get("exit_code").and_then(|v| v.as_i64()).map(|c| c != 0).unwrap_or(false));
     }
 }
 
@@ -222,7 +134,6 @@ mod session {
     use super::*;
     use serial_test::serial;
 
-    /// Verify that SessionArchive can be created.
     #[tokio::test]
     #[serial]
     async fn test_session_archive_creation() {
@@ -244,14 +155,12 @@ mod session {
         std::env::remove_var("VT_SESSION_DIR");
     }
 
-    /// Verify that sessions can be finalized and retrieved.
     #[tokio::test]
     #[serial]
     async fn test_session_finalize_and_find() {
         let temp = TempDir::new().expect("Failed to create temp dir");
         std::env::set_var("VT_SESSION_DIR", temp.path());
 
-        // Create and finalize a session
         let metadata = compat::session::SessionArchiveMetadata::new(
             "finalize-test",
             "/tmp/workspace".to_string(),
@@ -261,16 +170,12 @@ mod session {
             "standard",
         );
 
-        // Note: session_id access differs between implementations
-        // Local has it on metadata, vtcode-core has it on the listing
-        #[cfg(feature = "local-tools")]
         let session_id = metadata.session_id.clone();
 
         let archive = compat::session::SessionArchive::new(metadata)
             .await
             .expect("Failed to create archive");
 
-        // Create a test message
         let messages = vec![compat::session::SessionMessage::with_tool_call_id(
             compat::session::MessageRole::User,
             "Test message",
@@ -283,17 +188,6 @@ mod session {
 
         assert!(path.exists(), "Session file should exist after finalize");
 
-        // For vtcode-core, we need to find the session by listing and extracting ID
-        #[cfg(not(feature = "local-tools"))]
-        let session_id = {
-            let sessions = compat::session::list_recent_sessions(1)
-                .await
-                .expect("list should work");
-            assert!(!sessions.is_empty(), "Should have at least one session");
-            sessions[0].identifier()
-        };
-
-        // Find the session
         let found = compat::session::find_session_by_identifier(&session_id)
             .await
             .expect("find_session should succeed");
@@ -303,14 +197,12 @@ mod session {
         std::env::remove_var("VT_SESSION_DIR");
     }
 
-    /// Verify that list_recent_sessions works.
     #[tokio::test]
     #[serial]
     async fn test_list_recent_sessions() {
         let temp = TempDir::new().expect("Failed to create temp dir");
         std::env::set_var("VT_SESSION_DIR", temp.path());
 
-        // Create multiple sessions
         for i in 0..3 {
             let metadata = compat::session::SessionArchiveMetadata::new(
                 &format!("list-test-{}", i),
@@ -331,42 +223,27 @@ mod session {
                 None,
             )];
 
-            archive
-                .finalize(vec![], 1, vec![], messages)
-                .expect("Failed to finalize");
-
-            // Small delay to ensure different timestamps
+            archive.finalize(vec![], 1, vec![], messages).expect("Failed to finalize");
             tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         }
 
-        // List all sessions
-        let sessions = compat::session::list_recent_sessions(0)
-            .await
-            .expect("list should succeed");
-
+        let sessions = compat::session::list_recent_sessions(0).await.expect("list should succeed");
         assert_eq!(sessions.len(), 3, "Should find all 3 sessions");
 
-        // List with limit
-        let limited = compat::session::list_recent_sessions(2)
-            .await
-            .expect("limited list should succeed");
-
+        let limited = compat::session::list_recent_sessions(2).await.expect("limited list should succeed");
         assert_eq!(limited.len(), 2, "Should respect limit");
 
         std::env::remove_var("VT_SESSION_DIR");
     }
 
-    /// Verify MessageRole enum variants.
     #[test]
     fn test_message_role_variants() {
-        // All implementations should have these variants
         let _user = compat::session::MessageRole::User;
         let _assistant = compat::session::MessageRole::Assistant;
         let _system = compat::session::MessageRole::System;
         let _tool = compat::session::MessageRole::Tool;
     }
 
-    /// Verify get_sessions_dir returns a valid path.
     #[test]
     #[serial]
     fn test_get_sessions_dir() {
@@ -374,45 +251,9 @@ mod session {
         std::env::set_var("VT_SESSION_DIR", temp.path());
 
         let dir = compat::session::get_sessions_dir().expect("Should get sessions dir");
-
         assert!(dir.exists(), "Sessions dir should exist");
         assert_eq!(dir, temp.path(), "Should respect VT_SESSION_DIR env var");
 
         std::env::remove_var("VT_SESSION_DIR");
-    }
-}
-
-// =============================================================================
-// Feature Flag Verification
-// =============================================================================
-
-mod feature_flags {
-    /// Document which implementation is being tested.
-    #[test]
-    fn test_report_active_implementation() {
-        #[cfg(feature = "local-tools")]
-        println!("Testing with LOCAL implementations (local-tools feature enabled)");
-
-        #[cfg(not(feature = "local-tools"))]
-        println!("Testing with VTCODE-CORE implementations (default)");
-    }
-
-    /// Verify that both implementations can coexist in the codebase.
-    ///
-    /// This test doesn't actually run both - it verifies that the conditional
-    /// compilation is set up correctly. To test both implementations:
-    ///
-    /// ```bash
-    /// cargo test --test compat_layer
-    /// cargo test --test compat_layer --features local-tools
-    /// ```
-    #[test]
-    fn test_conditional_compilation_setup() {
-        // This test passes if it compiles, which means the feature flag
-        // conditional compilation is set up correctly.
-        //
-        // The actual type being used (ToolRegistry) changes based on the feature flag,
-        // but the interface remains the same and is accessible regardless of which
-        // implementation is active.
     }
 }

--- a/docs/plan/vtcode-core-migration.md
+++ b/docs/plan/vtcode-core-migration.md
@@ -16,7 +16,7 @@ Migrate away from `vtcode-core` external dependency to fully local implementatio
 |-----------|-------------|---------------------|--------|
 | ToolRegistry | `vtcode_core::tools::ToolRegistry` | `qbit_tools::ToolRegistry` | **Done** |
 | Function declarations | `vtcode_core::tools::registry::build_function_declarations` | `qbit_tools::build_function_declarations` | **Done** |
-| Session types | `vtcode_core::utils::session_archive::*` | `qbit_core::session::*` | Done (behind `local-tools` flag) |
+| Session types | `vtcode_core::utils::session_archive::*` | `qbit_core::session::*` | **Done** |
 
 ### Remaining Dependencies
 

--- a/docs/rig-evals.md
+++ b/docs/rig-evals.md
@@ -53,8 +53,6 @@ Settings are resolved in this order:
 
 ### Build Requirements
 
-The evals feature requires the `local-tools` feature (included automatically):
-
 ```bash
 cargo build --no-default-features --features evals --bin qbit-cli
 ```

--- a/justfile
+++ b/justfile
@@ -47,13 +47,12 @@ test-e2e *args:
     pnpm exec playwright test {{args}}
 
 # Run Rust tests
-# Note: compat_layer tests use --features local-tools to avoid vtcode-core's HITL prompts
 test-rust:
-    cd backend && cargo test --features local-tools
+    cd backend && cargo test
 
 # Run Rust tests with output
 test-rust-verbose:
-    cd backend && cargo test --features local-tools -- --nocapture
+    cd backend && cargo test -- --nocapture
 
 # ============================================
 # Building
@@ -61,7 +60,7 @@ test-rust-verbose:
 
 # Build for production
 build:
-    cd backend && cargo build --features cli,local-tools --no-default-features --bin qbit-cli --release
+    cd backend && cargo build --features cli --no-default-features --bin qbit-cli --release
     pnpm tauri build
 
 # Build frontend only
@@ -89,9 +88,8 @@ check-fe:
     pnpm typecheck
 
 # Check Rust (clippy + fmt check)
-# Use --all-targets to compile test targets too, sharing artifacts with cargo test
 check-rust:
-    cd backend && cargo clippy --all-targets --features local-tools -- -D warnings
+    cd backend && cargo clippy -- -D warnings
     cd backend && cargo fmt --check
 
 # Fix frontend issues (biome)


### PR DESCRIPTION
## Summary

- Remove the `local-tools` feature flag from `qbit` and `qbit-ai` crates - migration from vtcode-core to local implementations is complete
- Simplify `compat.rs` by removing conditional compilation - local implementations (qbit_tools, qbit_core::session) are now the only option
- Consolidate CI workflow from multiple jobs to single `just check` invocation

## Test plan

- [ ] Verify `just check` passes locally
- [ ] Verify `just test-rust` passes without `local-tools` flag
- [ ] Verify CLI builds: `cargo build -p qbit --features cli --no-default-features --bin qbit-cli`
- [ ] CI passes on this PR