### PR TITLE
fix(ci): only run release build when release is created

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
 
   build:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Fixes the release-please workflow so the build job only runs when an actual release is created, not on every push to main.

## Commits

- `402ba93` fix(ci): only run release build when release is created

## Changes

- Changed the `if` condition from `${{ needs.release-please.outputs.releases_created }}` to `${{ needs.release-please.outputs.releases_created == 'true' }}`

## Problem

The build job was running on every push to main (e.g., [run 20671577250](https://github.com/qbit-ai/qbit/actions/runs/20671577250)) because:

1. GitHub Actions outputs are **strings**, not booleans
2. The `if` condition treats any non-empty string as truthy
3. When release-please returns `releases_created: "false"`, that's a non-empty string which evaluates as truthy

## Breaking Changes

None

## Test Plan

- [ ] Merge a regular PR to main and verify the build job is skipped
- [ ] Merge the release-please PR (#79) and verify the build job runs

## Release Notes

Fixed CI workflow to prevent unnecessary release builds on regular commits.

## Checklist

- [x] Conventional commit format followed