### PR TITLE
Review eval framework against main agent

### DIFF
--- a/docs/eval-framework-code-paths.md
+++ b/docs/eval-framework-code-paths.md
@@ -1,0 +1,578 @@
+# Eval Framework: Code Path Analysis
+
+This document provides a technical deep-dive into the exact code paths used by the eval framework vs. production agent.
+
+## Entry Points
+
+### Production Agent Entry
+
+**Tauri GUI** (`backend/crates/qbit/src/ai/commands/run_agent.rs`):
+```rust
+#[tauri::command]
+pub async fn ai_execute_prompt(
+    state: State<'_, AgentBridgeState>,
+    prompt: String,
+) -> Result<String, String> {
+    let bridge = state.bridge.lock().await;
+    bridge.execute(&prompt).await
+}
+```
+
+**CLI** (`backend/crates/qbit/src/cli/runner.rs`):
+```rust
+pub async fn execute_once(ctx: &mut CliContext, prompt: &str) -> Result<()> {
+    let bridge = ctx.bridge().await;
+    bridge.execute(prompt).await
+}
+```
+
+### Eval Framework Entry
+
+**CLI Eval Mode** (`backend/crates/qbit/src/cli/eval.rs`):
+```rust
+pub async fn run_evals(
+    scenario_filter: Option<&str>,
+    // ...
+) -> Result<()> {
+    // Does NOT use AgentBridge
+    // Directly invokes qbit_evals::runner::EvalRunner
+    let runner = EvalRunner::new_verbose_with_provider(verbose, provider)?;
+
+    for scenario in scenarios {
+        let report = scenario.run(&runner).await?;
+    }
+}
+```
+
+**Key Difference**: Production uses `AgentBridge`, evals use `EvalRunner` directly.
+
+---
+
+## AgentBridge Initialization
+
+### Production (`llm_client.rs:69-102`)
+
+```rust
+pub async fn create_shared_components(
+    workspace: &std::path::Path,
+    model_name: &str,
+    context_config: Option<ContextManagerConfig>,
+) -> Result<SharedAgentComponents> {
+    // 1. Full tool registry
+    let tool_registry = Arc::new(RwLock::new(ToolRegistry::new(workspace)));
+
+    // 2. Sub-agents REGISTERED
+    let mut sub_agent_registry = SubAgentRegistry::new();
+    sub_agent_registry.register_multiple(create_default_sub_agents());
+
+    // 3. Context manager ENABLED
+    let context_manager = Arc::new(ContextManager::with_config(
+        model_name,
+        context_config.unwrap_or_default(),  // Enabled by default
+    ));
+
+    // 4. Approval recorder with persistent directory
+    let approval_recorder = Arc::new(
+        ApprovalRecorder::new(dirs::home_dir().unwrap().join(".qbit"))
+    );
+
+    // 5. Loop detector
+    let loop_detector = Arc::new(RwLock::new(LoopDetector::with_defaults()));
+
+    Ok(SharedAgentComponents { /* ... */ })
+}
+```
+
+### Eval Framework (`eval_support.rs:150-222`)
+
+```rust
+pub async fn run_eval_agentic_loop<M>(
+    model: &M,
+    system_prompt: &str,
+    user_prompt: &str,
+    config: AiEvalConfig,
+) -> Result<EvalAgentOutput>
+where M: rig::completion::CompletionModel + Sync
+{
+    // 1. Standard tool registry
+    let tool_registry = Arc::new(RwLock::new(ToolRegistry::new(&config.workspace)));
+
+    // 2. Sub-agents EMPTY
+    let sub_agent_registry = Arc::new(RwLock::new(SubAgentRegistry::new()));
+    // ^^^ No agents registered
+
+    // 3. Context manager DISABLED
+    let context_manager = Arc::new(ContextManager::with_config(
+        &config.model_name,
+        ContextManagerConfig {
+            enabled: false,  // <-- DISABLED
+            ..Default::default()
+        },
+    ));
+
+    // 4. Approval recorder (temp directory)
+    let approval_recorder = Arc::new(
+        ApprovalRecorder::new(std::env::temp_dir().join("qbit-eval"))
+    );
+
+    // 5. Loop detector (same defaults)
+    let loop_detector = Arc::new(RwLock::new(LoopDetector::with_defaults()));
+
+    // ...
+}
+```
+
+---
+
+## Tool Configuration
+
+### Production (`tool_definitions.rs:97-127`)
+
+```rust
+impl ToolConfig {
+    /// Main agent gets Standard + execute_code + apply_patch
+    pub fn main_agent() -> Self {
+        Self {
+            preset: ToolPreset::Standard,
+            additional: vec![
+                "execute_code".to_string(),
+                "apply_patch".to_string(),
+            ],
+            disabled: vec![],
+        }
+    }
+}
+```
+
+### Eval Framework (`eval_support.rs:199`)
+
+```rust
+// Uses default which is Standard preset with no additions
+let tool_config = ToolConfig::default();
+// Equivalent to:
+// ToolConfig {
+//     preset: ToolPreset::Standard,
+//     additional: vec![],
+//     disabled: vec![],
+// }
+```
+
+---
+
+## Agent Mode
+
+### Production (`agent_bridge.rs:163-166`)
+
+```rust
+// Default mode - requires HITL
+pub(crate) agent_mode: Arc<RwLock<AgentMode>>,
+
+// Initialized as Default
+agent_mode: Arc::new(RwLock::new(AgentMode::Default)),
+```
+
+### Eval Framework (`eval_support.rs:184-185`)
+
+```rust
+// Auto-approve mode - bypasses HITL
+let agent_mode = Arc::new(RwLock::new(AgentMode::AutoApprove));
+```
+
+---
+
+## AgenticLoopContext Construction
+
+### Production (passed from `AgentBridge::execute()`)
+
+```rust
+let ctx = AgenticLoopContext {
+    event_tx: &loop_event_tx,
+    tool_registry: &self.tool_registry,
+    sub_agent_registry: &self.sub_agent_registry,  // With 5 agents
+    indexer_state: self.indexer_state.as_ref(),    // Optional, often Some
+    tavily_state: self.tavily_state.as_ref(),      // Optional, often Some
+    workspace: &self.workspace,
+    client: &self.client,
+    approval_recorder: &self.approval_recorder,
+    pending_approvals: &self.pending_approvals,
+    tool_policy_manager: &self.tool_policy_manager,
+    context_manager: &self.context_manager,        // Enabled
+    loop_detector: &self.loop_detector,
+    tool_config: &self.tool_config,                // main_agent()
+    sidecar_state: self.sidecar_state.as_ref(),    // Optional, often Some
+    runtime: self.runtime.as_ref(),                // Tauri or CLI runtime
+    agent_mode: &self.agent_mode,                  // Default
+    plan_manager: &self.plan_manager,
+    provider_name: &self.provider_name,
+    model_name: &self.model_name,
+    openai_web_search_config: self.openai_web_search_config.as_ref(),
+};
+```
+
+### Eval Framework (`eval_support.rs:227-250`)
+
+```rust
+let ctx = AgenticLoopContext {
+    event_tx: &event_tx,
+    tool_registry: &tool_registry,
+    sub_agent_registry: &sub_agent_registry,       // Empty
+    indexer_state: None,                           // Disabled
+    tavily_state: None,                            // Disabled
+    workspace: &workspace_arc,
+    client: &client,
+    approval_recorder: &approval_recorder,
+    pending_approvals: &pending_approvals,
+    tool_policy_manager: &tool_policy_manager,
+    context_manager: &context_manager,             // Disabled
+    loop_detector: &loop_detector,
+    tool_config: &tool_config,                     // default()
+    sidecar_state: None,                           // Disabled
+    runtime: None,                                 // None
+    agent_mode: &agent_mode,                       // AutoApprove
+    plan_manager: &plan_manager,
+    provider_name: &config.provider_name,
+    model_name: &config.model_name,
+    openai_web_search_config: None,
+};
+```
+
+---
+
+## Agentic Loop Entry
+
+Both paths converge at the same function:
+
+### `run_agentic_loop_unified()` (`agentic_loop.rs:764-1428`)
+
+```rust
+pub async fn run_agentic_loop_unified<M>(
+    model: &M,
+    system_prompt: &str,
+    initial_history: Vec<Message>,
+    sub_agent_context: SubAgentContext,
+    ctx: &AgenticLoopContext<'_>,
+    config: AgenticLoopConfig,
+) -> Result<(String, Vec<Message>, Option<TokenUsage>)>
+```
+
+**Production Path**:
+```
+AgentBridge::execute()
+  → prepare_execution_context()
+  → run_agentic_loop() or run_agentic_loop_generic()
+    → run_agentic_loop_unified()
+```
+
+**Eval Path**:
+```
+run_eval_agentic_loop()
+  → run_agentic_loop_unified()  // Direct call
+```
+
+---
+
+## Tool Execution Path
+
+### Shared: `execute_with_hitl_generic()` (`agentic_loop.rs:384-621`)
+
+```rust
+pub async fn execute_with_hitl_generic<M>(
+    tool_name: &str,
+    tool_args: &serde_json::Value,
+    tool_id: &str,
+    ctx: &AgenticLoopContext<'_>,
+    // ...
+) -> Result<ToolExecutionResult> {
+    // STEP 0: Check agent mode for planning mode
+    let agent_mode = *ctx.agent_mode.read().await;
+    if agent_mode.is_planning() {
+        // Deny non-read tools
+    }
+
+    // STEP 1: Check policy denial
+    if ctx.tool_policy_manager.is_denied(tool_name).await {
+        return deny;
+    }
+
+    // STEP 2: Apply constraints
+    let (effective_args, _) = ctx.tool_policy_manager.apply_constraints(...);
+
+    // STEP 3: Check ALLOW_TOOLS
+    if policy == ToolPolicy::Allow {
+        return execute_tool_direct_generic(...);
+    }
+
+    // STEP 4: Check learned patterns
+    if ctx.approval_recorder.should_auto_approve(tool_name).await {
+        return execute_tool_direct_generic(...);
+    }
+
+    // STEP 4.4: Check agent mode (AutoApprove)
+    if agent_mode.is_auto_approve() {
+        // ^^^ THIS is where evals diverge
+        return execute_tool_direct_generic(...);
+    }
+
+    // STEP 4.5: Check runtime flag
+    if runtime.auto_approve() {
+        return execute_tool_direct_generic(...);
+    }
+
+    // STEP 5: Request approval (production only reaches here)
+    // ... emit ToolApprovalRequest, wait for response
+}
+```
+
+**Production**: May reach STEP 5 (HITL approval).
+**Evals**: Always exits at STEP 4.4 (AutoApprove mode).
+
+---
+
+## Sub-Agent Tool Availability
+
+### Production (`agentic_loop.rs:825-830`)
+
+```rust
+// Add sub-agent tools if not at max depth
+if sub_agent_context.depth < MAX_AGENT_DEPTH - 1 {
+    let registry = ctx.sub_agent_registry.read().await;
+    tools.extend(get_sub_agent_tool_definitions(&registry).await);
+    // ^^^ Adds sub_agent_coder, sub_agent_analyzer, etc.
+}
+```
+
+### Eval Framework
+
+Same code executes, but:
+```rust
+let registry = ctx.sub_agent_registry.read().await;
+// registry is EMPTY, so:
+get_sub_agent_tool_definitions(&registry)  // Returns empty vec
+```
+
+No sub-agent tools are added because registry is empty.
+
+---
+
+## Context Enforcement
+
+### Production (`agentic_loop.rs:834-880`)
+
+```rust
+// Update context manager with current conversation
+{
+    let manager = ctx.context_manager;
+    manager.update(/* message info */);
+
+    if manager.is_enabled() {  // TRUE for production
+        let enforcement = manager.enforce_context_window(&chat_history).await;
+
+        if enforcement.pruned {
+            // Emit ContextPruned event
+            chat_history = enforcement.pruned_messages;
+        }
+        if enforcement.warning {
+            // Emit ContextWarning event
+        }
+    }
+}
+```
+
+### Eval Framework
+
+Same code executes, but:
+```rust
+if manager.is_enabled() {  // FALSE for evals
+    // This block is SKIPPED
+}
+// No pruning, no warnings
+```
+
+---
+
+## Event Capture
+
+### Production
+
+```rust
+// Events go to frontend and sidecar
+ctx.event_tx.send(event)?;
+
+// Sidecar captures if available
+if let Some(sidecar) = ctx.sidecar_state {
+    sidecar.capture(event);
+}
+```
+
+### Eval Framework
+
+```rust
+// Events go to temp channel
+ctx.event_tx.send(event)?;
+
+// sidecar_state is None, so no capture
+```
+
+Events are collected in `EvalAgentOutput::events` vector instead.
+
+---
+
+## Multi-Turn Differences
+
+### Production (implicit, via UI)
+
+```rust
+// Each turn:
+// 1. User message added to conversation_history
+// 2. execute() called with current history
+// 3. Response added to conversation_history
+// 4. Session saved
+
+// History persists across bridge.execute() calls
+```
+
+### Eval Framework (`eval_support.rs:263-320`)
+
+```rust
+pub async fn run_multi_turn_eval<M>(
+    model: &M,
+    system_prompt: &str,
+    user_prompts: &[&str],
+    config: AiEvalConfig,
+) -> Result<MultiTurnEvalOutput> {
+    // SHARED resources across turns
+    let tool_registry = Arc::new(RwLock::new(ToolRegistry::new(&config.workspace)));
+    let sub_agent_registry = Arc::new(RwLock::new(SubAgentRegistry::new()));
+    let approval_recorder = Arc::new(ApprovalRecorder::new(...));
+    let loop_detector = Arc::new(RwLock::new(LoopDetector::with_defaults()));
+
+    // MANUAL history accumulation
+    let mut current_history: Vec<Message> = Vec::new();
+    let mut turns = Vec::new();
+
+    for user_prompt in user_prompts {
+        // Add user message
+        current_history.push(Message::User {
+            content: OneOrMany::one(UserContent::Text(Text {
+                text: user_prompt.to_string(),
+            })),
+        });
+
+        // Run loop with accumulated history
+        let (response, new_history, tokens) = run_agentic_loop_unified(
+            model,
+            system_prompt,
+            current_history.clone(),  // Pass current history
+            /* ctx */,
+        ).await?;
+
+        // Update history for next turn
+        current_history = new_history;
+
+        turns.push(/* turn output */);
+    }
+
+    Ok(MultiTurnEvalOutput { turns, /* ... */ })
+}
+```
+
+**Key Difference**: Evals explicitly manage history; production relies on `AgentBridge::conversation_history`.
+
+---
+
+## System Prompt Construction
+
+### Production (`system_prompt.rs:54-256`)
+
+```rust
+pub fn build_system_prompt_with_contributions(
+    workspace_path: &Path,
+    agent_mode: AgentMode,
+    memory_file_path: Option<&Path>,
+    registry: Option<&PromptContributorRegistry>,
+    context: Option<&PromptContext>,
+) -> String {
+    let mut prompt = String::new();
+
+    // Identity block
+    prompt.push_str("<identity>...");
+
+    // Environment block (workspace, date)
+    prompt.push_str("<environment>...");
+
+    // Style block
+    prompt.push_str("<style>...");
+
+    // Workflow block (5 phases)
+    prompt.push_str("<workflow>...");
+
+    // Tool documentation
+    prompt.push_str("## Tools\n...");
+
+    // Security constraints
+    prompt.push_str("<security>...");
+
+    // Project instructions (CLAUDE.md)
+    if let Some(memory_path) = memory_file_path {
+        prompt.push_str(&load_memory_file(memory_path));
+    }
+
+    // Dynamic contributions (sub-agents, provider tools)
+    if let Some(reg) = registry {
+        for section in reg.collect_contributions(context) {
+            prompt.push_str(&section.content);
+        }
+    }
+
+    // Agent mode specific instructions
+    prompt.push_str(&get_mode_instructions(agent_mode));
+
+    prompt
+}
+```
+
+### Eval Framework (`executor.rs:23-38`)
+
+```rust
+const EVAL_SYSTEM_PROMPT: &str = r#"
+You are an AI coding assistant.
+
+You have access to these tools:
+- read_file: Read a file's contents
+- write_file: Write or overwrite a file
+- create_file: Create a new file
+- edit_file: Edit an existing file
+- delete_file: Delete a file
+- list_files: List files matching a pattern
+- list_directory: List directory contents
+- grep_file: Search for patterns in files
+- run_pty_cmd: Run a shell command
+
+Complete the task efficiently. When done, provide a summary.
+Do not ask for clarification - make reasonable assumptions.
+"#;
+```
+
+**Key Differences**:
+- No identity/workflow/security blocks in evals
+- No project instructions (CLAUDE.md)
+- No dynamic contributions
+- No agent mode instructions
+- Focused, minimal prompt
+
+---
+
+## Summary: Divergence Points
+
+| Code Location | Production | Evals |
+|---------------|-----------|-------|
+| `sub_agent_registry.register_multiple()` | Called | Skipped |
+| `ContextManagerConfig.enabled` | `true` | `false` |
+| `AgentMode` | `Default` | `AutoApprove` |
+| `ToolConfig` | `main_agent()` | `default()` |
+| `indexer_state` | `Some(...)` | `None` |
+| `tavily_state` | `Some(...)` | `None` |
+| `sidecar_state` | `Some(...)` | `None` |
+| `runtime` | `Some(TauriRuntime/CliRuntime)` | `None` |
+| System prompt | Full composition | Minimal constant |
+| Session persistence | `QbitSessionManager` | In-memory only |

--- a/docs/eval-framework-gaps.md
+++ b/docs/eval-framework-gaps.md
@@ -1,0 +1,472 @@
+# Eval Framework: Identified Gaps and Recommendations
+
+This document identifies gaps between the eval framework and production agent, and provides recommendations for improving evaluation coverage.
+
+## Gap Analysis
+
+### 1. Missing Tool Coverage
+
+**Gap**: Evals use `ToolConfig::default()` instead of `ToolConfig::main_agent()`.
+
+**Missing Tools**:
+- `execute_code` - Code execution for complex operations
+- `apply_patch` - Patch-based editing
+
+**Impact**: Cannot test scenarios requiring:
+- Complex code execution with multiple steps
+- Patch-based file modifications
+- Advanced edit workflows
+
+**Recommendation**:
+```rust
+// Option A: Add ToolPreset::Evaluation with execute_code
+pub enum ToolPreset {
+    Minimal,
+    Standard,
+    Evaluation,  // Standard + execute_code
+    Full,
+}
+
+// Option B: Make tool config per-scenario
+trait Scenario {
+    fn tool_config(&self) -> ToolConfig {
+        ToolConfig::default()  // Override for specific scenarios
+    }
+}
+```
+
+---
+
+### 2. Sub-Agent Testing Disabled
+
+**Gap**: Sub-agent registry is empty in evals.
+
+**Code Location**: `eval_support.rs:158-159`
+```rust
+let sub_agent_registry = Arc::new(RwLock::new(SubAgentRegistry::new()));
+```
+
+**Impact**: Cannot test:
+- Delegation decisions (when agent should delegate)
+- Sub-agent execution quality
+- Depth limiting behavior
+- Cross-agent coordination
+
+**Recommendation**:
+```rust
+// Option A: Optional sub-agent registration
+pub struct EvalConfig {
+    pub enable_sub_agents: bool,
+    // ...
+}
+
+if config.enable_sub_agents {
+    sub_agent_registry.register_multiple(create_default_sub_agents());
+}
+
+// Option B: Sub-agent-specific scenarios
+pub struct SubAgentEvalScenario {
+    expected_delegations: Vec<&str>,  // ["coder", "explorer"]
+}
+```
+
+---
+
+### 3. Context Management Disabled
+
+**Gap**: Context pruning is disabled in evals.
+
+**Code Location**: `eval_support.rs:175-182`
+```rust
+let context_manager = Arc::new(ContextManager::with_config(
+    &config.model_name,
+    ContextManagerConfig {
+        enabled: false,  // DISABLED
+        ..Default::default()
+    },
+));
+```
+
+**Impact**:
+- No testing of context window behavior
+- Long conversations may exceed limits
+- Cannot validate pruning correctness
+- No alert/warning testing
+
+**Recommendation**:
+```rust
+// Option A: Configurable per scenario
+trait Scenario {
+    fn context_config(&self) -> ContextManagerConfig {
+        ContextManagerConfig::disabled()  // Default
+    }
+}
+
+// Option B: Context-specific eval scenarios
+pub struct ContextOverflowScenario {
+    // Specifically tests context management
+    target_utilization: f32,  // e.g., 0.9 to trigger pruning
+}
+```
+
+---
+
+### 4. No HITL Flow Testing
+
+**Gap**: AutoApprove mode bypasses all approval steps.
+
+**Code Location**: `eval_support.rs:184-185`
+```rust
+let agent_mode = Arc::new(RwLock::new(AgentMode::AutoApprove));
+```
+
+**Impact**: Cannot test:
+- Approval request generation
+- Risk level classification
+- Approval pattern learning
+- Timeout handling
+- User denial scenarios
+
+**Recommendation**:
+```rust
+// Add mock HITL runtime for testing
+pub struct MockHitlRuntime {
+    approval_responses: Vec<ApprovalDecision>,
+    delay_ms: u64,
+}
+
+impl QbitRuntime for MockHitlRuntime {
+    async fn request_approval(&self, ...) -> ApprovalResult {
+        // Return pre-configured responses
+    }
+}
+
+// Scenario with expected approvals
+pub struct HitlTestScenario {
+    expected_approval_requests: Vec<ExpectedApproval>,
+}
+```
+
+---
+
+### 5. Indexer Integration Missing
+
+**Gap**: `indexer_state = None` in evals.
+
+**Code Location**: `eval_support.rs:241`
+```rust
+indexer_state: None,
+```
+
+**Impact**: Cannot test:
+- Code search quality (`indexer_search_code`)
+- File discovery (`indexer_search_files`)
+- Symbol extraction (`indexer_extract_symbols`)
+- Language detection accuracy
+
+**Recommendation**:
+```rust
+// Option A: Optional indexer initialization
+pub struct EvalConfig {
+    pub enable_indexer: bool,
+}
+
+if config.enable_indexer {
+    let indexer_state = initialize_indexer(&workspace).await?;
+}
+
+// Option B: Pre-indexed testbeds
+// Embed index data with testbed files
+fn testbed_with_index() -> (Vec<(String, String)>, IndexerState) {
+    // ...
+}
+```
+
+---
+
+### 6. Tavily Web Search Fallback Missing
+
+**Gap**: `tavily_state = None` in evals.
+
+**Code Location**: `eval_support.rs:242`
+```rust
+tavily_state: None,
+```
+
+**Impact**:
+- Native web search works (provider-specific)
+- Tavily fallback unavailable
+- Cannot test `web_search_answer`, `web_extract`
+
+**Recommendation**:
+```rust
+// Check if Tavily API key available
+if std::env::var("TAVILY_API_KEY").is_ok() {
+    tavily_state = Some(initialize_tavily()?);
+}
+
+// Or mock Tavily for deterministic testing
+pub struct MockTavilyState {
+    responses: HashMap<String, SearchResult>,
+}
+```
+
+---
+
+### 7. Session Persistence for Recovery
+
+**Gap**: Evals don't persist sessions.
+
+**Impact**:
+- Cannot resume failed evals
+- No session trail for debugging
+- Cannot analyze decision patterns post-hoc
+
+**Recommendation**:
+```rust
+// Option A: Optional session recording
+pub struct EvalConfig {
+    pub persist_sessions: bool,
+    pub session_dir: Option<PathBuf>,
+}
+
+// Option B: Always persist to temp dir, optionally save on failure
+impl EvalRunner {
+    pub fn save_failed_session(&self, report: &EvalReport) -> PathBuf {
+        // Copy temp session to permanent location
+    }
+}
+```
+
+---
+
+### 8. Sidecar Context Capture
+
+**Gap**: `sidecar_state = None` in evals.
+
+**Impact**:
+- No decision pattern capture
+- Cannot analyze reasoning traces
+- No correlation with file operations
+
+**Recommendation**:
+```rust
+// Lightweight capture for debugging
+pub struct EvalCaptureContext {
+    tool_calls: Vec<CapturedToolCall>,
+    reasoning_traces: Vec<String>,
+    file_operations: Vec<FileOp>,
+}
+
+// Attach to AgenticLoopContext
+sidecar_state: Some(Arc::new(EvalCaptureContext::new())),
+```
+
+---
+
+### 9. Multi-Turn History Fragility
+
+**Gap**: Manual history management in multi-turn evals.
+
+**Code Pattern**:
+```rust
+let mut current_history = Vec::new();
+for prompt in prompts {
+    current_history.push(user_msg);
+    let (_, new_history, _) = run_agentic_loop_unified(...);
+    current_history = new_history;  // Manual update
+}
+```
+
+**Risks**:
+- History corruption if loop fails mid-execution
+- No checkpoint/recovery
+- Relies on correct history passing
+
+**Recommendation**:
+```rust
+// Add explicit history manager for multi-turn
+pub struct MultiTurnSession {
+    history: Vec<Message>,
+    checkpoints: Vec<usize>,  // History length at each turn
+}
+
+impl MultiTurnSession {
+    pub fn add_turn(&mut self, user_prompt: &str);
+    pub fn apply_response(&mut self, new_history: Vec<Message>);
+    pub fn rollback_to(&mut self, turn: usize);
+}
+```
+
+---
+
+### 10. Provider-Specific Testing Gaps
+
+**Gap**: Some provider-specific behaviors not isolated for testing.
+
+**Examples**:
+- OpenAI Responses API reasoning ID preservation
+- Anthropic extended thinking format
+- Gemini grounding source handling
+
+**Recommendation**:
+```rust
+// Provider-specific scenario traits
+pub trait OpenAiScenario: Scenario {
+    fn validate_reasoning_ids(&self, output: &AgentOutput) -> bool;
+}
+
+pub trait AnthropicScenario: Scenario {
+    fn validate_thinking_format(&self, output: &AgentOutput) -> bool;
+}
+
+// Provider-aware metrics
+pub struct ReasoningIdMetric;  // For OpenAI
+pub struct ThinkingBlockMetric;  // For Anthropic
+```
+
+---
+
+## Implementation Priority
+
+### High Priority (Core Functionality)
+
+| Gap | Effort | Value |
+|-----|--------|-------|
+| Sub-agent testing | Medium | High |
+| Context management testing | Medium | High |
+| Execute_code tool | Low | Medium |
+
+### Medium Priority (Enhanced Coverage)
+
+| Gap | Effort | Value |
+|-----|--------|-------|
+| Indexer integration | Medium | Medium |
+| Session persistence | Low | Medium |
+| HITL mock runtime | High | Medium |
+
+### Lower Priority (Nice to Have)
+
+| Gap | Effort | Value |
+|-----|--------|-------|
+| Tavily fallback | Low | Low |
+| Sidecar capture | Medium | Low |
+| Multi-turn checkpoints | Low | Low |
+
+---
+
+## Proposed Architecture Changes
+
+### 1. EvalConfig Enhancement
+
+```rust
+pub struct EvalConfig {
+    // Existing
+    pub provider: EvalProvider,
+    pub verbose: bool,
+
+    // Proposed additions
+    pub tool_preset: ToolPreset,
+    pub enable_sub_agents: bool,
+    pub enable_context_management: bool,
+    pub enable_indexer: bool,
+    pub enable_tavily: bool,
+    pub persist_sessions: bool,
+    pub hitl_mode: HitlMode,
+}
+
+pub enum HitlMode {
+    AutoApprove,           // Current behavior
+    MockResponses(Vec<ApprovalDecision>),
+    Interactive,           // For manual testing
+}
+```
+
+### 2. Scenario Configuration
+
+```rust
+pub trait Scenario: Send + Sync {
+    // Existing
+    fn name(&self) -> &str;
+    fn prompt(&self) -> &str;
+    fn metrics(&self) -> Vec<Box<dyn Metric>>;
+
+    // Proposed additions
+    fn tool_config(&self) -> ToolConfig {
+        ToolConfig::default()
+    }
+
+    fn requires_sub_agents(&self) -> bool {
+        false
+    }
+
+    fn requires_indexer(&self) -> bool {
+        false
+    }
+
+    fn context_config(&self) -> ContextManagerConfig {
+        ContextManagerConfig::disabled()
+    }
+}
+```
+
+### 3. Enhanced AgentOutput
+
+```rust
+pub struct AgentOutput {
+    // Existing
+    pub response: String,
+    pub tool_calls: Vec<ToolCall>,
+    pub files_modified: Vec<PathBuf>,
+    pub duration_ms: u64,
+    pub tokens_used: Option<u32>,
+
+    // Proposed additions
+    pub sub_agent_delegations: Vec<SubAgentCall>,
+    pub context_events: Vec<ContextEvent>,
+    pub approval_requests: Vec<ApprovalRequest>,
+    pub reasoning_traces: Vec<ReasoningBlock>,
+}
+```
+
+---
+
+## Migration Path
+
+### Phase 1: Non-Breaking Additions
+
+1. Add optional config fields with defaults
+2. Add new scenario trait methods with default implementations
+3. Add new metrics without changing existing ones
+
+### Phase 2: Optional Feature Activation
+
+1. Add feature flags for sub-agents, indexer, context
+2. Test with selected scenarios
+3. Document new capabilities
+
+### Phase 3: Full Integration
+
+1. Create sub-agent eval scenarios
+2. Create context management eval scenarios
+3. Add provider-specific test suites
+4. Document best practices
+
+---
+
+## Testing the Gaps
+
+To validate these gaps exist, run:
+
+```bash
+# Verify sub-agents missing
+cargo test --features evals -- test_sub_agent_unavailable
+
+# Verify context pruning disabled
+cargo test --features evals -- test_context_not_pruned
+
+# Verify indexer unavailable
+cargo test --features evals -- test_indexer_tools_missing
+```
+
+These tests should pass, confirming the documented behavior.

--- a/docs/eval-framework-overview.md
+++ b/docs/eval-framework-overview.md
@@ -1,0 +1,251 @@
+# Eval Framework Overview
+
+The qbit-evals crate is a Rust-native evaluation framework for end-to-end testing of the Qbit AI agent. It tests actual production code paths using isolated testbeds and structured metrics.
+
+## Architecture
+
+```
+qbit-evals/
+├── Cargo.toml
+└── src/
+    ├── lib.rs                    # Module exports
+    ├── config.rs                 # Provider configuration loading
+    ├── runner.rs                 # EvalRunner: testbed orchestration
+    ├── executor.rs               # Agent executor for evals
+    ├── outcome.rs                # Report types & formatting
+    ├── metrics/
+    │   ├── mod.rs                # Metric trait definition
+    │   ├── code_correctness.rs   # Cargo check/test metrics
+    │   ├── file_state.rs         # File existence/content checks
+    │   ├── llm_judge.rs          # LLM-based judgment metrics
+    │   └── token_tracking.rs     # Token usage metrics
+    └── scenarios/
+        ├── mod.rs                # Scenario trait & registry
+        ├── bug_fix.rs            # Fix compile error scenario
+        ├── feature_impl.rs       # Implement new feature scenario
+        ├── refactor.rs           # Extract function scenario
+        ├── code_understanding.rs # Explain code scenario
+        ├── multi_step.rs         # Complex workflow scenario
+        ├── web_search.rs         # Web search scenario
+        ├── multi_turn.rs         # Multi-turn conversation tests
+        └── prompt_composition.rs # System prompt instruction tests
+```
+
+## Key Concepts
+
+### Scenarios
+
+A scenario defines a complete evaluation case:
+
+```rust
+pub trait Scenario: Send + Sync {
+    fn name(&self) -> &str;                    // Unique identifier
+    fn description(&self) -> &str;             // Human-readable description
+    fn testbed(&self) -> &str;                 // Embedded testbed name
+    fn prompt(&self) -> &str;                  // Task prompt for agent
+    fn metrics(&self) -> Vec<Box<dyn Metric>>; // Evaluation metrics
+    fn system_prompt(&self) -> Option<&str>;   // Optional custom system prompt
+
+    async fn run(&self, runner: &EvalRunner) -> Result<EvalReport>;
+}
+```
+
+### Metrics
+
+Metrics evaluate agent performance:
+
+| Metric Type | Purpose |
+|-------------|---------|
+| `CodeCorrectnessMetric` | Runs `cargo check/test`, checks exit code |
+| `FileStateMetric` | Verifies file existence, content, modifications |
+| `LlmJudgeMetric` | Uses LLM to judge if criteria met (pass/fail) |
+| `LlmScoreMetric` | Uses LLM to score on numeric scale |
+| `TokenTrackingMetric` | Validates token usage patterns |
+
+### Testbeds
+
+Testbeds are embedded project templates copied to temp directories:
+
+- `rust-bug-fix` - Rust project with type error
+- `rust-feature` - Feature implementation task
+- `rust-refactor` - Refactoring task
+- `rust-understanding` - Code understanding task
+- `rust-multi-step` - Multi-step task
+- `minimal` - Minimal testbed for web search
+
+## Execution Flow
+
+```
+1. CLI invokes `run_evals(scenario_filter, options)`
+   ↓
+2. EvalRunner created with temp workspace
+   ↓
+3. For each scenario:
+   a. Setup testbed (copy embedded files to temp dir)
+   b. Execute agent via qbit-ai's unified agentic loop
+   c. Collect AgentOutput (response, tool_calls, files_modified)
+   d. Run metrics against EvalContext
+   e. Generate EvalReport
+   ↓
+4. Aggregate into EvalSummary
+   ↓
+5. Output results (terminal or JSON)
+```
+
+## CLI Usage
+
+```bash
+# Run all default scenarios
+cargo run --features evals,cli --bin qbit-cli -- --eval
+
+# Run specific scenario
+cargo run --features evals,cli --bin qbit-cli -- --eval --scenario bug-fix
+
+# List available scenarios
+cargo run --features evals,cli --bin qbit-cli -- --list-scenarios
+
+# Parallel execution with verbose output
+cargo run --features evals,cli --bin qbit-cli -- --eval --parallel --verbose
+
+# JSON output for CI
+cargo run --features evals,cli --bin qbit-cli -- --eval --json
+
+# Specific provider
+cargo run --features evals,cli --bin qbit-cli -- --eval --provider openai
+```
+
+## Provider Support
+
+| Provider | Model | Web Search |
+|----------|-------|------------|
+| `vertex-claude` (default) | Claude Sonnet 4.5 | `web_search_20250305` |
+| `zai` | GLM-4.7 | Tavily fallback |
+| `openai` | GPT-5.1 (Responses API) | `web_search_preview` |
+
+## Available Scenarios
+
+### Core Scenarios (default)
+
+| Scenario | Description | Metrics |
+|----------|-------------|---------|
+| `bug-fix` | Fix type mismatch error | cargo_check, file_modified, fix_quality |
+| `feature-impl` | Implement StringUtils::reverse() | cargo_check, has_method, correctness |
+| `refactor` | Extract validation logic | cargo_test, extracted_function, quality |
+| `code-understanding` | Explain binary heap | response_quality |
+| `multi-step` | Create module, function, tests | multiple file/code checks |
+| `web-search` | Use web search tool | response_quality, sources_cited |
+
+### Prompt Composition Scenarios
+
+| Scenario | Tests |
+|----------|-------|
+| `prompt-output-format` | JSON output format compliance |
+| `prompt-coding-conventions` | Coding standards (snake_case, docs) |
+| `prompt-tool-preference` | Tool selection based on instructions |
+| `prompt-brevity-instruction` | Response conciseness |
+| `prompt-sub-agent-awareness` | Sub-agent capability awareness |
+| `prompt-provider-context` | Provider-specific feature usage |
+| `prompt-conflicting-instructions` | Priority handling |
+
+### Optional Scenarios
+
+| Scenario | Purpose |
+|----------|---------|
+| `openai-web-search` | OpenAI-specific web search |
+| `multi-turn-file` | Multi-turn file operations |
+| `multi-turn-reasoning` | Reasoning ID preservation (OpenAI) |
+
+## Output Format
+
+### Terminal Output
+
+```
+✓ bug-fix (11122ms)
+  ✓ cargo_check: Pass
+  ✓ lib_modified: Pass
+  ✓ fix_quality: Pass
+
+Results: 5/5 passed (100%)
+Duration: 89275ms
+```
+
+### JSON Output
+
+```json
+{
+  "total": 5,
+  "passed": 5,
+  "failed": 0,
+  "pass_rate": 1.0,
+  "total_duration_ms": 89275,
+  "scenarios": [
+    {
+      "scenario": "bug-fix",
+      "passed": true,
+      "duration_ms": 11122,
+      "metrics": [
+        {"name": "cargo_check", "status": "pass"},
+        {"name": "lib_modified", "status": "pass"},
+        {"name": "fix_quality", "status": "pass"}
+      ]
+    }
+  ]
+}
+```
+
+## Adding New Scenarios
+
+1. Create scenario file in `scenarios/`:
+   ```rust
+   pub struct MyScenario;
+
+   impl Scenario for MyScenario {
+       fn name(&self) -> &str { "my-scenario" }
+       fn description(&self) -> &str { "Tests something specific" }
+       fn testbed(&self) -> &str { "my-testbed" }
+       fn prompt(&self) -> &str { "Do the thing" }
+
+       fn metrics(&self) -> Vec<Box<dyn Metric>> {
+           vec![
+               Box::new(CodeCorrectnessMetric::cargo_check()),
+               Box::new(FileStateMetric::modified("file_modified", "src/lib.rs")),
+           ]
+       }
+   }
+
+   pub fn testbed_files() -> Vec<(String, String)> {
+       vec![
+           ("Cargo.toml".to_string(), r#"[package]..."#.to_string()),
+           ("src/lib.rs".to_string(), r#"// code..."#.to_string()),
+       ]
+   }
+   ```
+
+2. Register in `scenarios/mod.rs`:
+   ```rust
+   pub fn default_scenarios() -> Vec<Box<dyn Scenario>> {
+       vec![
+           // ...existing scenarios...
+           Box::new(my_scenario::MyScenario),
+       ]
+   }
+   ```
+
+3. Add testbed dispatch in `runner.rs`:
+   ```rust
+   fn get_testbed_content(name: &str) -> Result<Vec<(String, String)>> {
+       match name {
+           // ...existing testbeds...
+           "my-testbed" => Ok(my_scenario::testbed_files()),
+       }
+   }
+   ```
+
+## Design Principles
+
+1. **Test production code paths** - Uses same unified agentic loop as main agent
+2. **Provider-agnostic** - Same scenarios run on Vertex, OpenAI, Z.AI
+3. **Isolated execution** - Temp directories, no environment pollution
+4. **Rich metrics** - Binary, scored, and LLM-judged evaluations
+5. **CI-friendly** - JSON output, exit codes, parallel execution
+6. **Extensible** - Simple trait-based scenario definition

--- a/docs/eval-vs-production-differences.md
+++ b/docs/eval-vs-production-differences.md
@@ -1,0 +1,458 @@
+# Eval Framework vs Production Agent: Detailed Differences
+
+This document provides a comprehensive comparison between the eval framework and the production agent implementation.
+
+## Executive Summary
+
+The eval framework uses the **same unified agentic loop** (`run_agentic_loop_unified`) as production, ensuring evaluations test real agent behavior. However, several features are intentionally disabled or simplified for unattended, deterministic test execution.
+
+## Architecture Comparison
+
+### Shared Components
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Unified Agentic Loop | ✅ Same | `run_agentic_loop_unified()` |
+| Tool Registry | ✅ Same | vtcode-core tools |
+| Loop Detection | ✅ Same | Same defaults (100 iterations, 5 repeats) |
+| Token Tracking | ✅ Same | Both track usage |
+| Streaming | ✅ Same | Same stream processing |
+| LLM Providers | ✅ Same | Vertex, OpenAI, Z.AI |
+
+### Disabled/Different Components
+
+| Component | Production | Evals |
+|-----------|-----------|-------|
+| HITL Approval | Full 8-step flow | Bypassed (AutoApprove) |
+| Context Pruning | Enabled | Disabled |
+| Sub-Agents | 5 registered | Empty registry |
+| Session Persistence | Full | In-memory only |
+| Sidecar Capture | Optional | Disabled |
+| Indexer State | Optional | Disabled |
+| Tavily State | Optional | Disabled |
+| Runtime | Tauri/CLI | None |
+
+---
+
+## 1. Tool Availability
+
+### Production Agent Tools
+
+```
+Standard Preset:
+├── grep_file, list_files        # Search/Discovery
+├── read_file, create_file       # File Operations
+├── edit_file, write_file        # File Operations
+├── delete_file                  # File Operations
+├── run_pty_cmd (run_command)    # Shell
+├── web_fetch                    # Web
+└── update_plan                  # Planning
+
+Main Agent Additions:
+├── execute_code                 # Code execution
+└── apply_patch                  # Patch-based editing
+
+Indexer Tools (6):
+├── indexer_search_code
+├── indexer_search_files
+├── indexer_analyze_file
+├── indexer_extract_symbols
+├── indexer_get_metrics
+└── indexer_detect_language
+
+Web Search (conditional):
+├── web_search (native or Tavily)
+├── web_search_answer (Tavily)
+└── web_extract (Tavily)
+
+Sub-Agent Tools (5):
+├── sub_agent_coder
+├── sub_agent_analyzer
+├── sub_agent_explorer
+├── sub_agent_researcher
+└── sub_agent_executor
+```
+
+### Eval Framework Tools
+
+```
+Standard Preset Only:
+├── grep_file, list_files
+├── read_file, create_file
+├── edit_file, write_file
+├── delete_file
+├── run_pty_cmd
+├── web_fetch
+└── update_plan
+
+Indexer Tools: DISABLED (indexer_state = None)
+Tavily Tools: DISABLED (tavily_state = None)
+Sub-Agent Tools: DISABLED (empty registry)
+
+Native Web Search: ENABLED (provider-specific)
+├── web_search_20250305 (Claude)
+├── web_search_preview (OpenAI)
+└── Google grounding (Gemini)
+```
+
+### Missing Tools in Evals
+
+| Tool | Why Missing |
+|------|-------------|
+| `execute_code` | Not in standard preset |
+| `apply_patch` | Not in standard preset |
+| `indexer_*` | indexer_state = None |
+| `web_search_answer` | tavily_state = None |
+| `web_extract` | tavily_state = None |
+| `sub_agent_*` | Empty registry |
+
+---
+
+## 2. HITL Approval Flow
+
+### Production Agent (8-step hierarchy)
+
+```
+1. Agent Mode Check → Planning mode denies writes
+         ↓
+2. Policy Denial → Tool explicitly denied
+         ↓
+3. Constraint Violations → Policy constraints violated
+         ↓
+4. Policy Allow → ALLOW_TOOLS list (auto-approve)
+         ↓
+5. Learned Patterns → Previously approved pattern
+         ↓
+6. Agent Mode Auto-approve → AgentMode::AutoApprove
+         ↓
+7. Runtime Flag → --auto-approve CLI flag
+         ↓
+8. HITL Prompt → User approval (300s timeout)
+```
+
+### Eval Framework
+
+```
+Setup:
+  agent_mode = AgentMode::AutoApprove  // Forces step 6
+
+Flow:
+  Step 1-5: Checked but irrelevant
+  Step 6: AutoApprove triggers → ALL tools approved
+  Step 7-8: Never reached
+```
+
+**Key Code** (`eval_support.rs:184-185`):
+```rust
+let agent_mode = Arc::new(RwLock::new(AgentMode::AutoApprove));
+```
+
+---
+
+## 3. Context Management
+
+### Production Agent
+
+```rust
+ContextManagerConfig {
+    enabled: true,              // Enforced
+    compaction_threshold: 0.80, // Prune at 80%
+    protected_turns: 2,         // Protect recent turns
+    cooldown_seconds: 60,       // Throttle pruning
+}
+```
+
+Features:
+- Per-component token tracking (system, user, assistant, tool)
+- Semantic scoring (System=950, User=850, Tool=600, Assistant=500)
+- Protected recent turns (last 2 by default)
+- Alert levels (Warning@75%, Alert@85%, Critical@100%+)
+- Tool response truncation (25k tokens max)
+- Event emission (ContextWarning, ContextPruned)
+
+### Eval Framework
+
+```rust
+ContextManagerConfig {
+    enabled: false,  // DISABLED
+    ..Default::default()
+}
+```
+
+Implications:
+- No token budget tracking
+- No message pruning
+- Full history sent to LLM every turn
+- No protection against context overflow
+- Assumes test scenarios stay within limits
+
+---
+
+## 4. Session Management
+
+### Production Agent
+
+| Feature | Implementation |
+|---------|----------------|
+| Persistence | `~/.qbit/sessions/{session_id}/` |
+| Format | JSON with metadata, transcript, messages |
+| Saving | Incremental saves during conversation |
+| Finalization | One-shot archive creation |
+| Tool Tracking | Distinct tools used per session |
+| Token Tracking | Optional total tokens field |
+
+### Eval Framework
+
+| Feature | Implementation |
+|---------|----------------|
+| Persistence | None (in-memory only) |
+| Format | `EvalAgentOutput` struct |
+| Saving | N/A |
+| Multi-turn | Manual history accumulation |
+| Recovery | Cannot resume failed evals |
+
+**Multi-turn History Management** (`eval_support.rs`):
+```rust
+// Manual accumulation between turns
+let mut current_history: Vec<Message> = Vec::new();
+
+for user_prompt in prompts {
+    current_history.push(user_message);
+    let (response, new_history, tokens) = run_agentic_loop_unified(...);
+    current_history = new_history;  // Update for next turn
+}
+```
+
+---
+
+## 5. Sub-Agent System
+
+### Production Agent
+
+```
+SubAgentRegistry:
+├── coder: Surgical code edits via unified diffs
+├── analyzer: Deep code analysis via indexer
+├── explorer: Codebase navigation and mapping
+├── researcher: Web search and documentation
+└── executor: Complex shell operations
+
+Depth Limiting:
+├── MAX_AGENT_DEPTH = 5
+├── Tools hidden at depth ≥ 4
+└── Each call increments depth
+
+Prompt Contribution:
+├── SubAgentPromptContributor adds docs
+└── "## Available Sub-Agents" section
+```
+
+### Eval Framework
+
+```
+SubAgentRegistry: EMPTY (no agents registered)
+
+No sub-agent tools available
+No sub-agent documentation in prompt
+No depth tracking needed
+```
+
+**Key Code** (`eval_support.rs:158-159`):
+```rust
+// Create empty sub-agent registry (no sub-agents in evals)
+let sub_agent_registry = Arc::new(RwLock::new(SubAgentRegistry::new()));
+```
+
+---
+
+## 6. Sidecar Context Capture
+
+### Production Agent
+
+| Feature | Implementation |
+|---------|----------------|
+| State Tracking | `SidecarState` with session file ops |
+| Event Processing | Captures ToolRequest, ToolResult, Reasoning |
+| Storage | `~/.qbit/sessions/{id}/state.md` |
+| Artifacts | Tracks patches, diffs, file changes |
+| Limits | Tool output: 2000 chars, Diffs: 4000 chars |
+
+### Eval Framework
+
+```rust
+sidecar_state: None  // DISABLED
+```
+
+Implications:
+- No context capture during evals
+- No session state.md files
+- No artifact tracking
+- No decision pattern analysis
+- Evals are "transparent" to sidecar
+
+---
+
+## 7. System Prompt
+
+### Production Agent
+
+```
+build_system_prompt_with_contributions():
+├── <identity> block (Qbit description)
+├── <environment> block (workspace, date)
+├── <style> block (concise, direct)
+├── <workflow> block (5 phases with gates)
+├── Tool documentation tables
+├── Delegation guidelines
+├── Security constraints
+├── Project instructions (CLAUDE.md)
+└── Dynamic contributions:
+    ├── SubAgentPromptContributor
+    └── ProviderBuiltinToolsContributor
+```
+
+### Eval Framework
+
+**Default** (`executor.rs:EVAL_SYSTEM_PROMPT`):
+```
+Minimal, focused prompt:
+- Lists available tools
+- Direct task completion
+- No preambles
+- Auto-approved execution
+```
+
+**Scenario Override**:
+```rust
+fn system_prompt(&self) -> Option<&str> {
+    Some(r#"
+    You are an AI coding assistant.
+    Complete the task efficiently.
+    ...
+    "#)
+}
+```
+
+---
+
+## 8. Loop Detection
+
+### Both Paths (Identical)
+
+| Setting | Value |
+|---------|-------|
+| `max_tool_loops` | 100 |
+| `max_repeated_tool_calls` | 5 |
+| `warning_threshold` | 0.6 (warn at 3/5) |
+| Detector Reset | Per turn |
+| Blocking | Same behavior |
+
+**No differences** - both use identical loop detection configuration.
+
+---
+
+## 9. LLM Client Configuration
+
+### Production Agent
+
+```rust
+// Full configuration with all features
+let completion_model = vertex_client
+    .completion_model(model)
+    .with_default_thinking()  // Extended thinking
+    .with_web_search();       // Native web search
+
+// All provider features available
+let client = LlmClient::VertexAnthropic(completion_model);
+```
+
+### Eval Framework
+
+```rust
+// Same configuration
+let completion_model = vertex_client
+    .completion_model(model)
+    .with_default_thinking()
+    .with_web_search();
+
+// Identical client creation per provider
+```
+
+**No differences** in LLM configuration.
+
+---
+
+## 10. Event Handling
+
+### Production Agent
+
+```
+Event Flow:
+  AgenticLoop → event_tx → TauriRuntime → Frontend
+                        → SidecarState → state.md
+                        → ApprovalRecorder → patterns
+
+Event Types:
+  Started, TextDelta, Reasoning, ToolRequest,
+  ToolApprovalRequest, ToolAutoApproved, ToolResult,
+  ContextWarning, ContextPruned, LoopWarning,
+  Completed, Error
+```
+
+### Eval Framework
+
+```
+Event Flow:
+  AgenticLoop → event_tx → EvalAgentOutput.events
+                        → (optionally to temp dir logs)
+
+No sidecar, no frontend, no persistent capture
+```
+
+---
+
+## Summary Table
+
+| Feature | Production | Evals | Impact |
+|---------|-----------|-------|--------|
+| Agentic Loop | Unified | Same | ✅ Same behavior |
+| Tool Set | Full + extras | Standard only | ⚠️ Some tools missing |
+| HITL | 8-step | Bypassed | ⚠️ No approval testing |
+| Context Pruning | Enabled | Disabled | ⚠️ No overflow protection |
+| Sub-Agents | 5 registered | None | ❌ Cannot test delegation |
+| Session Persistence | Full | None | ⚠️ No recovery |
+| Sidecar | Optional | Disabled | ⚠️ No context capture |
+| Indexer | Optional | Disabled | ⚠️ No code analysis tools |
+| Tavily | Optional | Disabled | ⚠️ Fallback search unavailable |
+| Loop Detection | Same | Same | ✅ Same protection |
+| Token Tracking | Same | Same | ✅ Same tracking |
+
+---
+
+## Implications for Testing
+
+### What Evals CAN Test
+
+1. Core agent reasoning and response quality
+2. Tool usage patterns (standard tools)
+3. File operations (read, write, edit)
+4. Shell command execution
+5. Native web search (provider-specific)
+6. Multi-turn conversation continuity
+7. Reasoning ID preservation (OpenAI)
+8. System prompt instruction following
+
+### What Evals CANNOT Test
+
+1. Sub-agent delegation behavior
+2. HITL approval flow
+3. Context window management
+4. Approval pattern learning
+5. Indexer-based code analysis
+6. Tavily web search fallback
+7. `execute_code` and `apply_patch` tools
+8. Sidecar context capture
+
+### Recommendations
+
+See [Eval Framework Gaps](eval-framework-gaps.md) for identified gaps and potential improvements.


### PR DESCRIPTION
Add four documentation files analyzing the eval framework:

- eval-framework-overview.md: High-level architecture, scenarios, metrics, and CLI usage guide
- eval-vs-production-differences.md: Detailed comparison of eval vs production agent covering tools, HITL, context, sessions, sub-agents
- eval-framework-gaps.md: Identified gaps with recommendations for improving evaluation coverage (sub-agents, context, HITL testing)
- eval-framework-code-paths.md: Technical deep-dive showing exact code divergence points between production and eval paths

Key findings:
- Evals use same unified agentic loop but with AutoApprove mode
- Context pruning disabled, sub-agents empty, indexer/tavily/sidecar None
- Missing tools: execute_code, apply_patch
- Recommendations for enhancing eval coverage documented