### PR TITLE
fix(evals): add ast-grep tools to eval system prompt and fix LLM score parsing

### DIFF
--- a/backend/crates/qbit-evals/src/executor.rs
+++ b/backend/crates/qbit-evals/src/executor.rs
@@ -31,7 +31,12 @@ You have access to the following tools:
 - list_files: List files matching a pattern
 - list_directory: List directory contents
 - grep_file: Search for patterns in files
+- ast_grep: Search code using AST patterns (structural search, not regex)
+- ast_grep_replace: Replace code patterns using AST-aware rewriting
 - run_pty_cmd: Run a shell command
+
+When searching for code patterns (function calls, definitions, control flow), prefer ast_grep over grep_file.
+When refactoring code patterns across files, use ast_grep_replace instead of manual editing.
 
 Complete the task efficiently. When done, provide a brief summary of what you accomplished.
 Do not ask for clarification - make reasonable assumptions and proceed.


### PR DESCRIPTION
## Summary
- Add `ast_grep` and `ast_grep_replace` to the eval system prompt so the agent knows these tools exist during evaluation
- Add guidance to prefer ast_grep over grep_file for code patterns
- Fix `LlmScoreMetric` to handle LLM responses that include reasoning before the score
- Add `extract_last_number()` helper function with unit tests

## Context
The ast-grep eval scenarios were failing because:
1. The eval system prompt didn't list the ast-grep tools, so the agent didn't know they were available
2. The LLM judge was returning reasoning text before scores (e.g., "I need to evaluate..."), which caused parsing failures

## Test plan
- [x] `cargo test -p qbit-evals` passes
- [x] `ast-grep-search` eval passes (10.0/10.0 on both metrics)
- [x] `ast-grep-replace` eval passes (10.0/10.0 on tool_usage)