### PR TITLE
fix(timeline): auto-scroll when new commands execute

### DIFF
--- a/backend/crates/qbit-ai/src/system_prompt.rs
+++ b/backend/crates/qbit-ai/src/system_prompt.rs
@@ -78,9 +78,35 @@ Date: {date}
 </environment>
 
 <style>
-- Direct answers. No preambles ("I'll help you...") or postambles ("Let me know if...")
-- Concise explanations. Show reasoning only when it aids understanding
-- Code over prose. When explaining changes, show the code
+## Communication Rules
+
+**Between tool calls**: Minimal or silent. DO NOT narrate your actions.
+
+❌ WRONG:
+- "Let me investigate the git status and staging logic:"
+- "Let me check how the frontend maps status entries:"
+- "I see a potential issue!"
+- "Now I understand the bug. In Git's porcelain format..."
+- "Let me fix the mapStatusEntries function:"
+
+✅ RIGHT:
+- [tool call] → [tool call] → [tool call] (silent investigation)
+- "The bug: `splitChanges` treats files as either staged OR unstaged, but Git allows both (e.g., `MM`)." → [tool call to fix]
+- Brief insight only when it changes your approach
+
+**When to speak**:
+- Asking a clarifying question
+- Explaining a non-obvious finding that affects your approach
+- Reporting a blocker or error
+- Final summary (keep under 3 sentences unless complex)
+
+**Summaries**: State what changed and what the user should verify. Skip implementation details they can see in the diff.
+
+❌ WRONG:
+"I fixed the mapStatusEntries function in frontend/lib/git.ts. The issue was that Git's status format allows a file to have both staged and unstaged changes (e.g., MM means staged modifications plus additional unstaged modifications). The old code only created one entry per file, so it would either show as staged OR unstaged, not both. The new code: creates separate entries for staged and unstaged changes..."
+
+✅ RIGHT:
+"Fixed: `mapStatusEntries` now handles files with both staged AND unstaged changes (e.g., `MM` status). Verify by staging a file, modifying it again, then checking the UI shows it in both sections."
 </style>
 
 # Workflow
@@ -313,6 +339,14 @@ When calling `sub_agent_coder`, structure your `task` parameter using this XML f
       Example from src/other.rs:42 shows the project uses `anyhow::Result` with `.context()`
     </pattern>
   </patterns>
+  
+  <project_conventions>
+    <!-- IMPORTANT: Extract relevant rules from Project Instructions (CLAUDE.md/AGENTS.md) -->
+    <!-- Sub-agents do NOT see the full project instructions—you must relay what's relevant -->
+    - Use `thiserror` for error types, not `anyhow` in library code
+    - All public functions must have doc comments
+    - Test files go in `tests/` not alongside source
+  </project_conventions>
   
   <constraints>
     <!-- Any constraints the coder must respect -->

--- a/frontend/components/CommandBlock/CommandBlock.tsx
+++ b/frontend/components/CommandBlock/CommandBlock.tsx
@@ -43,6 +43,7 @@ export function CommandBlock({ block, onToggleCollapse }: CommandBlockProps) {
       >
         {/* Command */}
         <code className="text-foreground font-mono text-sm flex-1 truncate">
+          <span className="text-[var(--ansi-green)]">$ </span>
           {block.command || "(empty command)"}
         </code>
 

--- a/frontend/components/PaneContainer/PaneLeaf.tsx
+++ b/frontend/components/PaneContainer/PaneLeaf.tsx
@@ -83,7 +83,7 @@ export function PaneLeaf({ paneId, sessionId, tabId, onOpenGitPanel }: PaneLeafP
       {renderMode !== "fullterm" && (
         // Timeline mode with unified input
         <>
-          <div className="flex-1 min-h-0 min-w-0 overflow-auto">
+          <div className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
             <UnifiedTimeline sessionId={sessionId} />
           </div>
           <UnifiedInput

--- a/frontend/mocks.ts
+++ b/frontend/mocks.ts
@@ -884,6 +884,9 @@ export function setupMocks(): void {
     // Hooks can check for this when the module patch doesn't work
     (window as unknown as { __MOCK_LISTEN__?: typeof mockListen }).__MOCK_LISTEN__ = mockListen;
 
+    // Expose mock event listeners for debugging in e2e tests
+    (window as unknown as { __MOCK_EVENT_LISTENERS__?: typeof mockEventListeners }).__MOCK_EVENT_LISTENERS__ = mockEventListeners;
+
     // Store reference to original for cleanup
     (
       window as unknown as { __MOCK_ORIGINAL_LISTEN__?: typeof originalListen }
@@ -907,6 +910,25 @@ export function setupMocks(): void {
         __MOCK_SIMULATE_AI_RESPONSE__?: typeof simulateAiResponse;
       }
     ).__MOCK_SIMULATE_AI_RESPONSE__ = simulateAiResponse;
+
+    // Expose command simulation functions for e2e testing
+    (
+      window as unknown as {
+        __MOCK_SIMULATE_COMMAND__?: typeof simulateCommand;
+        __MOCK_EMIT_COMMAND_BLOCK_EVENT__?: typeof emitCommandBlockEvent;
+        __MOCK_EMIT_TERMINAL_OUTPUT__?: typeof emitTerminalOutput;
+      }
+    ).__MOCK_SIMULATE_COMMAND__ = simulateCommand;
+    (
+      window as unknown as {
+        __MOCK_EMIT_COMMAND_BLOCK_EVENT__?: typeof emitCommandBlockEvent;
+      }
+    ).__MOCK_EMIT_COMMAND_BLOCK_EVENT__ = emitCommandBlockEvent;
+    (
+      window as unknown as {
+        __MOCK_EMIT_TERMINAL_OUTPUT__?: typeof emitTerminalOutput;
+      }
+    ).__MOCK_EMIT_TERMINAL_OUTPUT__ = emitTerminalOutput;
   } catch (error) {
     console.error("[Mocks] Error during initial setup:", error);
   }


### PR DESCRIPTION
## Summary
- Fix auto-scroll not triggering when new commands start executing
- Add `hasPendingCommand` to content-change detection so command starts trigger scroll
- Fix container layout overflow handling between PaneLeaf and UnifiedTimeline
- Add green `$ ` prompt prefix to CommandBlock for visual consistency

## Test plan
- [ ] Start a command and verify timeline auto-scrolls to show it
- [ ] Scroll up manually, then start a new command - verify it scrolls back down
- [ ] Run E2E tests: `just test-e2e`