### PR TITLE
feat(ui): add details modal for sub-agent cards in timeline

### DIFF
--- a/frontend/components/SubAgentCard/SubAgentCard.tsx
+++ b/frontend/components/SubAgentCard/SubAgentCard.tsx
@@ -1,10 +1,18 @@
-import { Bot, CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from "lucide-react";
+import {
+  Bot,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Maximize2,
+  XCircle,
+} from "lucide-react";
 import { memo, useState } from "react";
-import { Markdown } from "@/components/Markdown";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import type { ActiveSubAgent, SubAgentToolCall } from "@/store";
+import { SubAgentDetailsModal } from "./SubAgentDetailsModal";
 
 interface SubAgentCardProps {
   subAgent: ActiveSubAgent;
@@ -123,14 +131,12 @@ const ToolCallRow = memo(function ToolCallRow({ tool }: { tool: SubAgentToolCall
 
 /** Number of tool calls to show by default */
 const VISIBLE_TOOL_CALLS = 3;
-/** Max characters to show in truncated response */
-const RESPONSE_PREVIEW_LENGTH = 200;
 
 /** Sub-agent card component */
 export const SubAgentCard = memo(function SubAgentCard({ subAgent }: SubAgentCardProps) {
   const [isExpanded, setIsExpanded] = useState(subAgent.status === "running");
   const [showAllToolCalls, setShowAllToolCalls] = useState(false);
-  const [showFullResponse, setShowFullResponse] = useState(false);
+  const [showDetailsModal, setShowDetailsModal] = useState(false);
 
   // Calculate which tool calls to show
   const totalToolCalls = subAgent.toolCalls.length;
@@ -139,108 +145,94 @@ export const SubAgentCard = memo(function SubAgentCard({ subAgent }: SubAgentCar
     ? subAgent.toolCalls
     : subAgent.toolCalls.slice(-VISIBLE_TOOL_CALLS);
 
-  // Truncate response if needed
-  const responseNeedsTruncation =
-    subAgent.response && subAgent.response.length > RESPONSE_PREVIEW_LENGTH;
-  const displayedResponse =
-    subAgent.response && !showFullResponse && responseNeedsTruncation
-      ? `${subAgent.response.slice(0, RESPONSE_PREVIEW_LENGTH)}...`
-      : subAgent.response;
-
   return (
-    <div className="my-2 rounded-lg border border-border bg-card">
-      <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
-        <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 hover:bg-accent/30">
-          {isExpanded ? (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" />
-          )}
-          <Bot className="h-4 w-4 text-[var(--ansi-magenta)]" />
-          <span className="font-medium text-sm">{subAgent.agentName}</span>
-          <StatusBadge status={subAgent.status} />
-          {subAgent.depth > 1 && (
-            <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-              depth {subAgent.depth}
-            </Badge>
-          )}
-          {subAgent.durationMs !== undefined && (
-            <span className="ml-auto text-xs text-muted-foreground">
-              {formatDuration(subAgent.durationMs)}
-            </span>
-          )}
-        </CollapsibleTrigger>
-
-        <CollapsibleContent className="px-3 pb-2">
-          {/* Task description */}
-          <div className="mb-2 rounded bg-muted/50 px-2 py-1.5 text-xs">
-            <span className="text-muted-foreground">Task: </span>
-            <span>{subAgent.task}</span>
+    <>
+      <div className="my-2 rounded-lg border border-border bg-card">
+        <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+          <div className="flex items-center gap-2 px-3 py-2">
+            <CollapsibleTrigger className="flex flex-1 items-center gap-2 hover:bg-accent/30 rounded -ml-1 pl-1 py-0.5">
+              {isExpanded ? (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              )}
+              <Bot className="h-4 w-4 text-[var(--ansi-magenta)]" />
+              <span className="font-medium text-sm">{subAgent.agentName}</span>
+              <StatusBadge status={subAgent.status} />
+              {subAgent.depth > 1 && (
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                  depth {subAgent.depth}
+                </Badge>
+              )}
+            </CollapsibleTrigger>
+            <div className="flex items-center gap-2">
+              {subAgent.durationMs !== undefined && (
+                <span className="text-xs text-muted-foreground">
+                  {formatDuration(subAgent.durationMs)}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={() => setShowDetailsModal(true)}
+                className="p-1 hover:bg-accent/50 rounded transition-colors"
+                title="View details"
+              >
+                <Maximize2 className="w-3.5 h-3.5 text-muted-foreground hover:text-foreground" />
+              </button>
+            </div>
           </div>
 
-          {/* Tool calls */}
-          {totalToolCalls > 0 && (
-            <div className="mb-2 space-y-0.5">
-              <div className="text-xs text-muted-foreground">Tool calls:</div>
+          <CollapsibleContent className="px-3 pb-2">
+            {/* Tool calls */}
+            {totalToolCalls > 0 && (
+              <div className="space-y-0.5">
+                {/* Show "N previous tool calls" expander if there are hidden calls */}
+                {hiddenCount > 0 && !showAllToolCalls && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllToolCalls(true)}
+                    className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                  >
+                    <ChevronRight className="h-3 w-3" />
+                    <span>
+                      {hiddenCount} previous tool call{hiddenCount > 1 ? "s" : ""}
+                    </span>
+                  </button>
+                )}
 
-              {/* Show "N previous tool calls" expander if there are hidden calls */}
-              {hiddenCount > 0 && !showAllToolCalls && (
-                <button
-                  type="button"
-                  onClick={() => setShowAllToolCalls(true)}
-                  className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                >
-                  <ChevronRight className="h-3 w-3" />
-                  <span>
-                    {hiddenCount} previous tool call{hiddenCount > 1 ? "s" : ""}
-                  </span>
-                </button>
-              )}
+                {/* Show collapse button when expanded */}
+                {showAllToolCalls && hiddenCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllToolCalls(false)}
+                    className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                  >
+                    <ChevronDown className="h-3 w-3" />
+                    <span>Hide {hiddenCount} tool calls</span>
+                  </button>
+                )}
 
-              {/* Show collapse button when expanded */}
-              {showAllToolCalls && hiddenCount > 0 && (
-                <button
-                  type="button"
-                  onClick={() => setShowAllToolCalls(false)}
-                  className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                >
-                  <ChevronDown className="h-3 w-3" />
-                  <span>Hide {hiddenCount} tool calls</span>
-                </button>
-              )}
+                {visibleToolCalls.map((tool) => (
+                  <ToolCallRow key={tool.id} tool={tool} />
+                ))}
+              </div>
+            )}
 
-              {visibleToolCalls.map((tool) => (
-                <ToolCallRow key={tool.id} tool={tool} />
-              ))}
-            </div>
-          )}
+            {/* Error indicator (when failed) */}
+            {subAgent.error && (
+              <div className="mt-2 rounded bg-[var(--ansi-red)]/10 px-2 py-1.5 text-xs text-[var(--ansi-red)]">
+                <span className="font-medium">Error: </span>
+                {subAgent.error}
+              </div>
+            )}
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
 
-          {/* Response (when completed) */}
-          {subAgent.response && (
-            <div className="mt-2 rounded bg-muted/30 px-2 py-1.5 text-xs">
-              <span className="text-muted-foreground">Response:</span>
-              <Markdown content={displayedResponse ?? ""} className="mt-1" />
-              {responseNeedsTruncation && (
-                <button
-                  type="button"
-                  onClick={() => setShowFullResponse(!showFullResponse)}
-                  className="mt-1 text-[var(--ansi-blue)] hover:underline"
-                >
-                  {showFullResponse ? "Show less" : "Show more"}
-                </button>
-              )}
-            </div>
-          )}
-
-          {/* Error (when failed) */}
-          {subAgent.error && (
-            <div className="mt-2 rounded bg-[var(--ansi-red)]/10 px-2 py-1.5 text-xs text-[var(--ansi-red)]">
-              <span className="font-medium">Error: </span>
-              {subAgent.error}
-            </div>
-          )}
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
+      {/* Details Modal */}
+      {showDetailsModal && (
+        <SubAgentDetailsModal subAgent={subAgent} onClose={() => setShowDetailsModal(false)} />
+      )}
+    </>
   );
 });

--- a/frontend/components/SubAgentCard/SubAgentDetailsModal.tsx
+++ b/frontend/components/SubAgentCard/SubAgentDetailsModal.tsx
@@ -1,0 +1,321 @@
+import {
+  Bot,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Copy,
+  Loader2,
+  X,
+  XCircle,
+} from "lucide-react";
+import { useState } from "react";
+import { Markdown } from "@/components/Markdown";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { logger } from "@/lib/logger";
+import { cn } from "@/lib/utils";
+import type { ActiveSubAgent, SubAgentToolCall } from "@/store";
+
+/** Status icon component */
+function StatusIcon({
+  status,
+  size = "md",
+}: {
+  status: "running" | "completed" | "error";
+  size?: "sm" | "md";
+}) {
+  const sizeClass = size === "sm" ? "w-3 h-3" : "w-4 h-4";
+
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 className={cn(sizeClass, "text-[var(--ansi-green)]")} />;
+    case "running":
+      return <Loader2 className={cn(sizeClass, "text-[var(--ansi-blue)] animate-spin")} />;
+    case "error":
+      return <XCircle className={cn(sizeClass, "text-[var(--ansi-red)]")} />;
+  }
+}
+
+/** Format duration in ms to human readable */
+function formatDuration(ms?: number): string {
+  if (!ms) return "";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** Individual tool call row with expandable details */
+function ToolCallRow({ tool }: { tool: SubAgentToolCall }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const status =
+    tool.status === "completed" ? "completed" : tool.status === "error" ? "error" : "running";
+
+  // Get primary argument for display
+  const primaryArg = (() => {
+    const args = tool.args;
+    if (typeof args === "object" && args !== null) {
+      if ("path" in args) return String(args.path);
+      if ("file_path" in args) return String(args.file_path);
+      if ("command" in args) return String(args.command);
+      if ("pattern" in args) return String(args.pattern);
+    }
+    return null;
+  })();
+
+  return (
+    <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+      <CollapsibleTrigger className="group flex w-full items-center gap-1.5 rounded px-2 py-1.5 text-xs hover:bg-accent/50 transition-colors">
+        {isExpanded ? (
+          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3 w-3 text-muted-foreground" />
+        )}
+        <StatusIcon status={status} size="sm" />
+        <span className="font-mono text-[var(--ansi-cyan)]">{tool.name}</span>
+        {primaryArg && (
+          <span className="truncate text-muted-foreground" title={primaryArg}>
+            {primaryArg}
+          </span>
+        )}
+        {tool.completedAt && (
+          <span className="ml-auto text-[10px] text-muted-foreground">
+            {formatDuration(
+              new Date(tool.completedAt).getTime() - new Date(tool.startedAt).getTime()
+            )}
+          </span>
+        )}
+      </CollapsibleTrigger>
+      <CollapsibleContent className="px-6 py-2">
+        <div className="space-y-2 text-xs overflow-hidden">
+          {/* Arguments */}
+          <div className="overflow-hidden">
+            <span className="text-muted-foreground font-medium">Arguments:</span>
+            <pre className="mt-1 rounded-lg bg-muted/50 border border-border px-3 py-2 text-[11px] overflow-auto max-h-32 whitespace-pre-wrap break-all">
+              {JSON.stringify(tool.args, null, 2)}
+            </pre>
+          </div>
+
+          {/* Result (if available) */}
+          {tool.result !== undefined && (
+            <div className="overflow-hidden">
+              <span className="text-muted-foreground font-medium">Result:</span>
+              <pre className="mt-1 max-h-48 overflow-auto rounded-lg bg-muted/50 border border-border px-3 py-2 text-[11px] whitespace-pre-wrap break-all">
+                {typeof tool.result === "string"
+                  ? tool.result
+                  : JSON.stringify(tool.result, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+interface SubAgentDetailsModalProps {
+  subAgent: ActiveSubAgent | null;
+  onClose: () => void;
+}
+
+/** Status badge styling */
+const statusStyles: Record<
+  "running" | "completed" | "error",
+  { badgeClass: string; label: string }
+> = {
+  running: {
+    badgeClass: "bg-[var(--accent-dim)] text-accent",
+    label: "Running",
+  },
+  completed: {
+    badgeClass: "bg-[var(--success-dim)] text-[var(--success)]",
+    label: "Completed",
+  },
+  error: {
+    badgeClass: "bg-destructive/10 text-destructive",
+    label: "Error",
+  },
+};
+
+export function SubAgentDetailsModal({ subAgent, onClose }: SubAgentDetailsModalProps) {
+  const [copiedSection, setCopiedSection] = useState<string | null>(null);
+
+  if (!subAgent) return null;
+
+  const status = statusStyles[subAgent.status];
+
+  const handleCopy = async (content: string, section: string) => {
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopiedSection(section);
+      setTimeout(() => setCopiedSection(null), 2000);
+    } catch (error) {
+      logger.error("Failed to copy:", error);
+    }
+  };
+
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <DialogContent
+        showCloseButton={false}
+        className="!w-[calc(100%-2rem)] !h-[calc(100%-4rem)] !max-w-none !max-h-none !top-[calc(50%+1rem)] flex flex-col p-0 gap-0"
+      >
+        <DialogHeader className="px-6 pt-6 pb-4 border-b border-border">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex items-start gap-3 min-w-0 flex-1">
+              <Bot className="w-5 h-5 text-[var(--ansi-magenta)] shrink-0 mt-0.5" />
+              <div className="min-w-0 flex-1">
+                <DialogTitle className="text-lg font-medium text-foreground">
+                  {subAgent.agentName}
+                </DialogTitle>
+                <DialogDescription className="text-sm text-muted-foreground mt-1">
+                  {subAgent.toolCalls.length} tool call{subAgent.toolCalls.length !== 1 ? "s" : ""}
+                  {subAgent.durationMs !== undefined && ` • ${formatDuration(subAgent.durationMs)}`}
+                </DialogDescription>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Badge
+                variant="outline"
+                className={cn("gap-1 flex items-center text-xs px-2 py-1", status.badgeClass)}
+              >
+                <StatusIcon status={subAgent.status} size="sm" />
+                {status.label}
+              </Badge>
+              {subAgent.depth > 1 && (
+                <Badge variant="outline" className="text-xs px-2 py-1">
+                  depth {subAgent.depth}
+                </Badge>
+              )}
+              <DialogClose asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8 ml-2">
+                  <X className="h-4 w-4" />
+                  <span className="sr-only">Close</span>
+                </Button>
+              </DialogClose>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <ScrollArea className="flex-1 min-h-0 overflow-hidden">
+          <div className="px-6 py-4 space-y-6 w-full max-w-full overflow-hidden">
+            {/* Task Section */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+                  Task
+                </h3>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleCopy(subAgent.task, "task")}
+                  className="h-7 text-xs"
+                >
+                  <Copy className="w-3.5 h-3.5 mr-1" />
+                  {copiedSection === "task" ? "Copied!" : "Copy"}
+                </Button>
+              </div>
+              <div className="bg-muted/50 rounded-lg border border-border p-4 overflow-hidden">
+                <p className="text-sm text-foreground/90 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                  {subAgent.task}
+                </p>
+              </div>
+            </div>
+
+            {/* Metadata Section */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+                Metadata
+              </h3>
+              <div className="bg-muted/50 rounded-lg border border-border p-4 space-y-2 overflow-hidden">
+                <div className="flex items-center gap-2 text-sm min-w-0">
+                  <Bot className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span className="text-muted-foreground shrink-0">Agent ID:</span>
+                  <span className="font-mono text-foreground/90 truncate">{subAgent.agentId}</span>
+                </div>
+                {subAgent.durationMs !== undefined && (
+                  <div className="flex items-center gap-2 text-sm">
+                    <Clock className="w-4 h-4 text-muted-foreground" />
+                    <span className="text-muted-foreground">Duration:</span>
+                    <span className="font-mono text-foreground/90">
+                      {formatDuration(subAgent.durationMs)}
+                    </span>
+                  </div>
+                )}
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="text-muted-foreground ml-6">Depth:</span>
+                  <span className="font-mono text-foreground/90">{subAgent.depth}</span>
+                </div>
+              </div>
+            </div>
+
+            {/* Tool Calls Section */}
+            {subAgent.toolCalls.length > 0 && (
+              <div className="space-y-2 overflow-hidden">
+                <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+                  Tool Calls ({subAgent.toolCalls.length})
+                </h3>
+                <div className="bg-muted/50 rounded-lg border border-border overflow-hidden">
+                  <div className="divide-y divide-border overflow-hidden">
+                    {subAgent.toolCalls.map((tool) => (
+                      <ToolCallRow key={tool.id} tool={tool} />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Response Section */}
+            {subAgent.response && (
+              <div className="space-y-2 overflow-hidden">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+                    Response
+                  </h3>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleCopy(subAgent.response ?? "", "response")}
+                    className="h-7 text-xs"
+                  >
+                    <Copy className="w-3.5 h-3.5 mr-1" />
+                    {copiedSection === "response" ? "Copied!" : "Copy"}
+                  </Button>
+                </div>
+                <div className="bg-muted/50 rounded-lg border border-border p-4 overflow-hidden">
+                  <Markdown
+                    content={subAgent.response}
+                    className="[overflow-wrap:anywhere] [&_*]:![overflow-wrap:anywhere] [&_pre]:whitespace-pre-wrap"
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Error Section */}
+            {subAgent.error && (
+              <div className="space-y-2 overflow-hidden">
+                <h3 className="text-sm font-medium text-destructive uppercase tracking-wide">
+                  Error
+                </h3>
+                <div className="bg-destructive/10 rounded-lg border border-destructive/30 p-4 overflow-hidden">
+                  <p className="text-sm text-destructive whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                    {subAgent.error}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/SubAgentCard/index.ts
+++ b/frontend/components/SubAgentCard/index.ts
@@ -1,1 +1,2 @@
 export { SubAgentCard } from "./SubAgentCard";
+export { SubAgentDetailsModal } from "./SubAgentDetailsModal";


### PR DESCRIPTION
## Summary
- Hide task and response from inline sub-agent card display for a cleaner timeline view
- Add expand icon button to open full details modal (similar to tool call details modal)
- Create `SubAgentDetailsModal` component with Task, Metadata, Tool Calls, and Response sections
- Add proper text wrapping for long content (XML, code, etc.) using `overflow-wrap: anywhere`
- Keep tool calls list and error indicator visible in inline card view

## Test plan
- [ ] Open a session with sub-agent activity
- [ ] Verify sub-agent cards show compact view (agent name, status, tool calls only)
- [ ] Click the expand icon to open the details modal
- [ ] Verify modal shows Task, Metadata, Tool Calls, and Response sections
- [ ] Test with long XML/code content to verify text wrapping works correctly
- [ ] Verify modal can be closed with X button or clicking outside