### PR TITLE
fix: close tab button not working with active agent/running command

### DIFF
--- a/frontend/lib/terminal/index.ts
+++ b/frontend/lib/terminal/index.ts
@@ -1,4 +1,5 @@
 export { liveTerminalManager } from "./LiveTerminalManager";
 export { SyncOutputBuffer } from "./SyncOutputBuffer";
+export { TerminalInstanceManager } from "./TerminalInstanceManager";
 export { VirtualTerminal } from "./VirtualTerminal";
 export { virtualTerminalManager } from "./VirtualTerminalManager";

--- a/frontend/store/index.ts
+++ b/frontend/store/index.ts
@@ -1575,6 +1575,7 @@ export const useStore = create<QbitState>()(
           const layout = state.tabLayouts[tabId];
           if (!layout) {
             // No layout - just remove the session directly (backward compatibility)
+            TerminalInstanceManager.dispose(tabId);
             delete state.sessions[tabId];
             delete state.timelines[tabId];
             delete state.commandBlocks[tabId];
@@ -1605,6 +1606,7 @@ export const useStore = create<QbitState>()(
           // Remove state for each pane session
           for (const pane of panes) {
             const sessionId = pane.sessionId;
+            TerminalInstanceManager.dispose(sessionId);
             delete state.sessions[sessionId];
             delete state.timelines[sessionId];
             delete state.commandBlocks[sessionId];


### PR DESCRIPTION
## Summary

Fixes the issue where the close button doesn't close the tab when there are multiple tabs and one of them has an active agent or a running command.

## Root Causes Fixed

1. **Missing `onMouseDown` stopPropagation on close button** - The parent TabBar div has `onMouseDown={startDrag}` for window dragging, which could interfere with the close button click event.

2. **No outer try-catch in `handleCloseTab`** - If `getTabSessionIds()` or other cleanup code threw an error, `closeTab()` would never be called.

3. **Missing terminal instance cleanup** - Neither `handleCloseTab` nor the store's `closeTab` action were calling `TerminalInstanceManager.dispose()` or `liveTerminalManager.dispose()`, leading to orphaned xterm.js instances.

## Changes

- Add `onMouseDown={(e) => e.stopPropagation()}` to the close button
- Wrap `handleCloseTab` body in try-catch, ensuring `closeTab()` is called even if cleanup fails
- Add `TerminalInstanceManager.dispose()` and `liveTerminalManager.dispose()` cleanup in `handleCloseTab`
- Add `TerminalInstanceManager.dispose()` calls in the store's `closeTab` action
- Export `TerminalInstanceManager` from the terminal index module

## Testing

- `just check` passes
- `just test-fe` passes (216 tests)

## Verification Steps

1. Open multiple tabs
2. Start an agent task in one tab  
3. Try closing the other tab while agent is running
4. Try closing the tab with the running agent
5. Verify both close correctly