### PR TITLE
fix(ui): apply agent mode to backend when loading project settings

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -27,6 +27,7 @@ import {
   initAiSession,
   isAiSessionInitialized,
   type ProviderConfig,
+  setAgentMode as setAgentModeBackend,
 } from "./lib/ai";
 import { notify } from "./lib/notify";
 import { countLeafPanes, findPaneById } from "./lib/pane-utils";
@@ -313,10 +314,15 @@ function App() {
 
         // Apply agent mode from project settings if set
         if (projectSettings.agent_mode) {
-          setAgentMode(
-            session.id,
-            projectSettings.agent_mode as "default" | "auto-approve" | "planning"
-          );
+          const mode = projectSettings.agent_mode as "default" | "auto-approve" | "planning";
+          // Update UI state
+          setAgentMode(session.id, mode);
+          // Update backend state
+          try {
+            await setAgentModeBackend(session.id, mode);
+          } catch (err) {
+            logger.warn("Failed to set agent mode on backend:", err);
+          }
         }
 
         // Also update global config for backwards compatibility
@@ -600,10 +606,15 @@ function App() {
 
           // Apply agent mode from project settings if set
           if (projectSettings.agent_mode) {
-            setAgentMode(
-              session.id,
-              projectSettings.agent_mode as "default" | "auto-approve" | "planning"
-            );
+            const mode = projectSettings.agent_mode as "default" | "auto-approve" | "planning";
+            // Update UI state
+            setAgentMode(session.id, mode);
+            // Update backend state
+            try {
+              await setAgentModeBackend(session.id, mode);
+            } catch (err) {
+              logger.warn("Failed to set agent mode on backend:", err);
+            }
           }
 
           // Also update global config for backwards compatibility

--- a/frontend/components/PlanProgress/PlanProgress.tsx
+++ b/frontend/components/PlanProgress/PlanProgress.tsx
@@ -19,9 +19,6 @@ export const PlanProgress = memo(function PlanProgress({ plan, className }: Plan
   const { summary, steps, explanation } = plan;
   const progressPercentage = summary.total > 0 ? (summary.completed / summary.total) * 100 : 0;
 
-  // Find the current in-progress step
-  const currentStep = steps.find((s) => s.status === "in_progress");
-
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <div className={cn("border-l-2 border-l-[#7aa2f7] rounded-r-md bg-card/50", className)}>
@@ -62,19 +59,6 @@ export const PlanProgress = memo(function PlanProgress({ plan, className }: Plan
               <p className="text-xs text-muted-foreground italic border-l-2 border-l-muted pl-2 py-1">
                 {explanation}
               </p>
-            )}
-
-            {/* Current step highlight */}
-            {currentStep && (
-              <div className="bg-[#7aa2f7]/10 border border-[#7aa2f7]/30 rounded-md p-2 mb-2">
-                <div className="flex items-start gap-2">
-                  <Loader2 className="w-4 h-4 text-[#7aa2f7] animate-spin flex-shrink-0 mt-0.5" />
-                  <div>
-                    <p className="text-xs font-medium text-[#7aa2f7]">Current Step</p>
-                    <p className="text-sm text-foreground mt-0.5">{currentStep.step}</p>
-                  </div>
-                </div>
-              </div>
             )}
 
             {/* All steps list */}


### PR DESCRIPTION
## Summary

- Fixes bug where project settings agent mode was only updated in frontend store, not sent to backend
- The UI showed "auto-approve" but backend remained in "default" mode, still prompting for approvals
- Now calls `setAgentModeBackend()` API in addition to store action when loading project settings
- Also removes redundant "Current Step" highlight from Task Plan (already shown in list)

## Test plan

- [ ] Set `agent_mode = "auto-approve"` in `.qbit/project.toml`
- [ ] Open a new tab in that project
- [ ] Verify status bar shows "Auto-approve" mode
- [ ] Send a prompt that triggers tool calls
- [ ] Verify tools are auto-approved without prompting