### PR TITLE
refactor(sub-agents): use natural language output for analyzer and explorer

### DIFF
--- a/backend/crates/qbit-sub-agents/src/schemas.rs
+++ b/backend/crates/qbit-sub-agents/src/schemas.rs
@@ -1,8 +1,19 @@
 //! Shared XML schemas for agent handoffs.
 //!
 //! These schemas define the structured formats used for communication between
-//! the main agent and sub-agents. Keeping them in one place ensures consistency
-//! and makes maintenance easier.
+//! the main agent and the coder agent.
+//!
+//! **Important**: The Explorer and Analyzer agents do NOT use these XML schemas.
+//! They return natural language reports that the main agent processes and formats
+//! into XML when preparing handoffs to the Coder agent.
+//!
+//! Only the following agents use XML:
+//! - **Main Agent** → **Coder**: Uses `IMPLEMENTATION_PLAN_SCHEMA`
+//! - **Coder**: Receives `<implementation_plan>` XML input, outputs unified diffs
+//!
+//! The separation ensures that research agents (Explorer, Analyzer) can focus on
+//! clear, flexible natural language reporting while the implementation handoff
+//! remains structured and parseable.
 
 /// Schema description for `<implementation_plan>` - what fields exist and their purpose.
 /// Used by both main agent (output) and coder (input).


### PR DESCRIPTION
## Summary
- Replaces XML schemas with natural language markdown format for analyzer and explorer sub-agents
- Simplifies output format while maintaining actionable, structured information
- Main agent now handles XML formatting for coder handoffs, allowing research agents to focus on clear reporting

## Changes
- **Analyzer prompt**: Now outputs with markdown headers (Analysis Summary, Key Findings, Call Graphs, Impact Assessment, Implementation Guidance)
- **Explorer prompt**: Now outputs with markdown headers (Project Overview, Relevant Files, Codebase Patterns, Entry Points, Dependencies, Recommendations)
- **schemas.rs**: Updated documentation to clarify only Coder uses XML schemas
- **Tests**: Updated to verify natural language format instead of XML

## Test plan
- [ ] Run `just test-rust` to verify tests pass
- [ ] Test analyzer sub-agent invocation returns natural language format
- [ ] Test explorer sub-agent invocation returns natural language format