### PR TITLE
fix(git): Auto-refresh branch/status after checkout commands

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5588,7 +5588,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ast-grep"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-cli-output"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "qbit-core",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "rig-core 0.27.0",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-directory-ops"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5690,7 +5690,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-file-ops"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-hitl"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-indexer"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "reqwest 0.12.24",
  "rig-anthropic-vertex",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-loop-detection"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "serde",
@@ -5756,7 +5756,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-planner"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "proptest",
@@ -5770,7 +5770,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-runtime"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "atty",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tool-policy"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5927,7 +5927,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5949,11 +5949,11 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "qbit-web"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "parking_lot",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6578,7 +6578,7 @@ checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-stream",
  "bytes",

--- a/e2e/git-branch-refresh.spec.ts
+++ b/e2e/git-branch-refresh.spec.ts
@@ -1,0 +1,59 @@
+import { expect, type Page, test } from "@playwright/test";
+
+async function waitForAppReady(page: Page) {
+  await page.goto("/");
+  await page.waitForLoadState("domcontentloaded");
+
+  await page.waitForFunction(
+    () => (window as unknown as { __MOCK_BROWSER_MODE__?: boolean }).__MOCK_BROWSER_MODE__ === true,
+    { timeout: 15000 }
+  );
+}
+
+test.describe("Git branch refresh", () => {
+  test("updates git badge after branch-changing command even if command_end has null command", async ({
+    page,
+  }) => {
+    await waitForAppReady(page);
+
+    const gitBadge = page.locator('button[title="Toggle Git Panel"]');
+
+    // Initial state in mock mode should show main.
+    await expect(gitBadge).toBeVisible({ timeout: 15000 });
+    await expect(gitBadge).toContainText("main", { timeout: 15000 });
+
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __MOCK_SET_GIT_STATE__?: (next: {
+          branch?: string | null;
+          insertions?: number;
+          deletions?: number;
+          ahead?: number;
+          behind?: number;
+        }) => void;
+        __MOCK_EMIT_COMMAND_BLOCK_EVENT__?: (
+          sessionId: string,
+          eventType: "prompt_start" | "prompt_end" | "command_start" | "command_end",
+          command?: string | null,
+          exitCode?: number | null
+        ) => void;
+      };
+
+      // Update mock git state so get_git_branch/git_status reflect the new branch.
+      w.__MOCK_SET_GIT_STATE__?.({ branch: "hiii", insertions: 112, deletions: 111 });
+
+      // Simulate a branch-changing command where command_end omits the command.
+      // This matches the real-world case where the PTY integration sometimes sends null.
+      w.__MOCK_EMIT_COMMAND_BLOCK_EVENT__?.(
+        "mock-session-001",
+        "command_start",
+        "git checkout -b hiii",
+        null
+      );
+      w.__MOCK_EMIT_COMMAND_BLOCK_EVENT__?.("mock-session-001", "command_end", null, 0);
+    });
+
+    // Badge should refresh from main -> hiii.
+    await expect(gitBadge).toContainText("hiii", { timeout: 15000 });
+  });
+});


### PR DESCRIPTION
Automatically refresh git branch and status in the UI after running branch-changing commands (`git checkout`, `git switch`, `gh pr checkout`). Also fixes an issue where some PTY integrations send `command_end` events with a null command, which was preventing refreshes.