### PR TITLE
feat(sub-agents): add parent_request_id to correlate sub-agent events with tool calls

### DIFF
--- a/backend/crates/qbit-ai/src/agentic_loop.rs
+++ b/backend/crates/qbit-ai/src/agentic_loop.rs
@@ -66,39 +66,130 @@ async fn execute_sub_agent_with_client(
     client: &qbit_llm_providers::LlmClient,
     ctx: SubAgentExecutorContext<'_>,
     tool_provider: &DefaultToolProvider,
+    parent_request_id: &str,
 ) -> anyhow::Result<qbit_sub_agents::SubAgentResult> {
     use qbit_llm_providers::LlmClient;
 
     match client {
         LlmClient::VertexAnthropic(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigOpenRouter(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigOpenAi(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigOpenAiResponses(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigAnthropic(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigOllama(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigGemini(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigGroq(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigXai(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::RigZai(model) => {
-            execute_sub_agent(agent_def, args, context, model, ctx, tool_provider).await
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
         }
         LlmClient::Mock => Err(anyhow::anyhow!("Cannot execute sub-agent with Mock client")),
     }
@@ -314,6 +405,7 @@ pub async fn execute_tool_direct_generic<M>(
     ctx: &AgenticLoopContext<'_>,
     model: &M,
     context: &SubAgentContext,
+    tool_id: &str,
 ) -> Result<ToolExecutionResult>
 where
     M: RigCompletionModel + Sync,
@@ -409,6 +501,7 @@ where
                     &client,
                     sub_ctx,
                     &tool_provider,
+                    tool_id,
                 )
                 .await
             } else {
@@ -434,6 +527,7 @@ where
                     model,
                     sub_ctx,
                     &tool_provider,
+                    tool_id,
                 )
                 .await
             }
@@ -460,6 +554,7 @@ where
                 model,
                 sub_ctx,
                 &tool_provider,
+                tool_id,
             )
             .await
         };
@@ -639,7 +734,15 @@ where
             },
         );
 
-        return execute_tool_direct_generic(tool_name, &effective_args, ctx, model, context).await;
+        return execute_tool_direct_generic(
+            tool_name,
+            &effective_args,
+            ctx,
+            model,
+            context,
+            tool_id,
+        )
+        .await;
     }
 
     // Step 4: Check if tool should be auto-approved based on learned patterns
@@ -655,7 +758,15 @@ where
             },
         );
 
-        return execute_tool_direct_generic(tool_name, &effective_args, ctx, model, context).await;
+        return execute_tool_direct_generic(
+            tool_name,
+            &effective_args,
+            ctx,
+            model,
+            context,
+            tool_id,
+        )
+        .await;
     }
 
     // Step 4.4: Check if agent mode is auto-approve
@@ -671,7 +782,15 @@ where
             },
         );
 
-        return execute_tool_direct_generic(tool_name, &effective_args, ctx, model, context).await;
+        return execute_tool_direct_generic(
+            tool_name,
+            &effective_args,
+            ctx,
+            model,
+            context,
+            tool_id,
+        )
+        .await;
     }
 
     // Step 4.5: Check if runtime has auto-approve enabled (CLI --auto-approve flag)
@@ -688,8 +807,15 @@ where
                 },
             );
 
-            return execute_tool_direct_generic(tool_name, &effective_args, ctx, model, context)
-                .await;
+            return execute_tool_direct_generic(
+                tool_name,
+                &effective_args,
+                ctx,
+                model,
+                context,
+                tool_id,
+            )
+            .await;
         }
     }
 
@@ -732,7 +858,15 @@ where
                     .record_approval(tool_name, true, decision.reason, decision.always_allow)
                     .await;
 
-                execute_tool_direct_generic(tool_name, &effective_args, ctx, model, context).await
+                execute_tool_direct_generic(
+                    tool_name,
+                    &effective_args,
+                    ctx,
+                    model,
+                    context,
+                    tool_id,
+                )
+                .await
             } else {
                 let _ = ctx
                     .approval_recorder

--- a/backend/crates/qbit-ai/src/test_utils.rs
+++ b/backend/crates/qbit-ai/src/test_utils.rs
@@ -2980,6 +2980,7 @@ mod tests {
             &model,
             sub_ctx,
             &tool_provider,
+            "test-parent-request-id",
         )
         .await
         .unwrap();
@@ -3080,6 +3081,7 @@ mod tests {
             &model,
             sub_ctx,
             &tool_provider,
+            "test-parent-request-id",
         )
         .await
         .unwrap();
@@ -3135,6 +3137,7 @@ mod tests {
             &model,
             sub_ctx,
             &tool_provider,
+            "test-parent-request-id",
         )
         .await
         .unwrap();
@@ -3157,6 +3160,7 @@ mod tests {
             agent_name,
             task,
             depth,
+            ..
         }) = started_event
         {
             assert_eq!(agent_id, "event_tester");
@@ -3179,6 +3183,7 @@ mod tests {
             agent_id,
             response,
             duration_ms: _,
+            parent_request_id: _,
         }) = completed_event
         {
             assert_eq!(agent_id, "event_tester");
@@ -3237,6 +3242,7 @@ mod tests {
             &model,
             sub_ctx,
             &tool_provider,
+            "test-parent-request-id",
         )
         .await
         .unwrap();
@@ -3336,6 +3342,7 @@ mod tests {
             &model,
             sub_ctx,
             &tool_provider,
+            "test-parent-request-id",
         )
         .await
         .unwrap();
@@ -3397,6 +3404,7 @@ mod tests {
             &model,
             sub_ctx,
             &tool_provider,
+            "test-parent-request-id",
         )
         .await
         .unwrap();

--- a/backend/crates/qbit/tests/ai_events_characterization.rs
+++ b/backend/crates/qbit/tests/ai_events_characterization.rs
@@ -233,6 +233,7 @@ fn test_sub_agent_started_serialization() {
         agent_name: "analyzer".to_string(),
         task: "Analyze the codebase structure".to_string(),
         depth: 1,
+        parent_request_id: "parent-req-001".to_string(),
     };
     let json = serde_json::to_value(&event).unwrap();
     insta::assert_json_snapshot!(json);
@@ -246,6 +247,7 @@ fn test_sub_agent_tool_request_serialization() {
         tool_name: "read_file".to_string(),
         args: json!({"path": "/config.json"}),
         request_id: "req-sub-1".to_string(),
+        parent_request_id: "parent-req-001".to_string(),
     };
     let json = serde_json::to_value(&event).unwrap();
     insta::assert_json_snapshot!(json);
@@ -260,6 +262,7 @@ fn test_sub_agent_tool_result_serialization() {
         success: true,
         result: json!({"content": "config data"}),
         request_id: "req-sub-1".to_string(),
+        parent_request_id: "parent-req-001".to_string(),
     };
     let json = serde_json::to_value(&event).unwrap();
     insta::assert_json_snapshot!(json);
@@ -272,6 +275,7 @@ fn test_sub_agent_completed_serialization() {
         agent_id: "agent-001".to_string(),
         response: "Analysis complete".to_string(),
         duration_ms: 5000,
+        parent_request_id: "parent-req-001".to_string(),
     };
     let json = serde_json::to_value(&event).unwrap();
     insta::assert_json_snapshot!(json);
@@ -283,6 +287,7 @@ fn test_sub_agent_error_serialization() {
     let event = AiEvent::SubAgentError {
         agent_id: "agent-001".to_string(),
         error: "Failed to parse response".to_string(),
+        parent_request_id: "parent-req-001".to_string(),
     };
     let json = serde_json::to_value(&event).unwrap();
     insta::assert_json_snapshot!(json);
@@ -630,12 +635,14 @@ fn test_all_events_roundtrip() {
             agent_name: "analyzer".to_string(),
             task: "analyze".to_string(),
             depth: 1,
+            parent_request_id: "parent-req-1".to_string(),
         },
         AiEvent::SubAgentToolRequest {
             agent_id: "a1".to_string(),
             tool_name: "read_file".to_string(),
             args: json!({}),
             request_id: "req-1".to_string(),
+            parent_request_id: "parent-req-1".to_string(),
         },
         AiEvent::SubAgentToolResult {
             agent_id: "a1".to_string(),
@@ -643,15 +650,18 @@ fn test_all_events_roundtrip() {
             success: true,
             result: json!({"content": "file contents"}),
             request_id: "req-1".to_string(),
+            parent_request_id: "parent-req-1".to_string(),
         },
         AiEvent::SubAgentCompleted {
             agent_id: "a1".to_string(),
             response: "Done".to_string(),
             duration_ms: 1000,
+            parent_request_id: "parent-req-1".to_string(),
         },
         AiEvent::SubAgentError {
             agent_id: "a1".to_string(),
             error: "Failed".to_string(),
+            parent_request_id: "parent-req-1".to_string(),
         },
         AiEvent::ContextPruned {
             messages_removed: 5,

--- a/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_completed_serialization.snap
+++ b/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_completed_serialization.snap
@@ -1,10 +1,12 @@
 ---
 source: crates/qbit/tests/ai_events_characterization.rs
+assertion_line: 281
 expression: json
 ---
 {
   "type": "sub_agent_completed",
   "agent_id": "agent-001",
   "response": "Analysis complete",
-  "duration_ms": 5000
+  "duration_ms": 5000,
+  "parent_request_id": "parent-req-001"
 }

--- a/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_error_serialization.snap
+++ b/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_error_serialization.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/qbit/tests/ai_events_characterization.rs
+assertion_line: 293
 expression: json
 ---
 {
   "type": "sub_agent_error",
   "agent_id": "agent-001",
-  "error": "Failed to parse response"
+  "error": "Failed to parse response",
+  "parent_request_id": "parent-req-001"
 }

--- a/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_started_serialization.snap
+++ b/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_started_serialization.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/qbit/tests/ai_events_characterization.rs
+assertion_line: 239
 expression: json
 ---
 {
@@ -7,5 +8,6 @@ expression: json
   "agent_id": "agent-001",
   "agent_name": "analyzer",
   "task": "Analyze the codebase structure",
-  "depth": 1
+  "depth": 1,
+  "parent_request_id": "parent-req-001"
 }

--- a/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_tool_request_serialization.snap
+++ b/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_tool_request_serialization.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/qbit/tests/ai_events_characterization.rs
+assertion_line: 253
 expression: json
 ---
 {
@@ -9,5 +10,6 @@ expression: json
   "args": {
     "path": "/config.json"
   },
-  "request_id": "req-sub-1"
+  "request_id": "req-sub-1",
+  "parent_request_id": "parent-req-001"
 }

--- a/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_tool_result_serialization.snap
+++ b/backend/crates/qbit/tests/snapshots/ai_events_characterization__sub_agent_tool_result_serialization.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/qbit/tests/ai_events_characterization.rs
+assertion_line: 268
 expression: json
 ---
 {
@@ -10,5 +11,6 @@ expression: json
   "result": {
     "content": "config data"
   },
-  "request_id": "req-sub-1"
+  "request_id": "req-sub-1",
+  "parent_request_id": "parent-req-001"
 }

--- a/frontend/hooks/useAiEvents.ts
+++ b/frontend/hooks/useAiEvents.ts
@@ -336,13 +336,14 @@ export function useAiEvents() {
           state.startSubAgent(sessionId, {
             agentId: event.agent_id,
             agentName: event.agent_name,
+            parentRequestId: event.parent_request_id,
             task: event.task,
             depth: event.depth,
           });
           break;
 
         case "sub_agent_tool_request":
-          state.addSubAgentToolCall(sessionId, event.agent_id, {
+          state.addSubAgentToolCall(sessionId, event.parent_request_id, {
             id: event.request_id,
             name: event.tool_name,
             args: event.args as Record<string, unknown>,
@@ -352,7 +353,7 @@ export function useAiEvents() {
         case "sub_agent_tool_result":
           state.completeSubAgentToolCall(
             sessionId,
-            event.agent_id,
+            event.parent_request_id,
             event.request_id,
             event.success,
             event.result
@@ -364,14 +365,14 @@ export function useAiEvents() {
           if (event.agent_id === "coder") {
             state.addUdiffResultBlock(sessionId, event.response, event.duration_ms);
           }
-          state.completeSubAgent(sessionId, event.agent_id, {
+          state.completeSubAgent(sessionId, event.parent_request_id, {
             response: event.response,
             durationMs: event.duration_ms,
           });
           break;
 
         case "sub_agent_error":
-          state.failSubAgent(sessionId, event.agent_id, event.error);
+          state.failSubAgent(sessionId, event.parent_request_id, event.error);
           break;
 
         // Context management events

--- a/frontend/lib/ai.ts
+++ b/frontend/lib/ai.ts
@@ -192,6 +192,7 @@ export type AiEvent = AiEventBase &
         agent_name: string;
         task: string;
         depth: number;
+        parent_request_id: string;
       }
     | {
         type: "sub_agent_tool_request";
@@ -199,6 +200,7 @@ export type AiEvent = AiEventBase &
         tool_name: string;
         args: unknown;
         request_id: string;
+        parent_request_id: string;
       }
     | {
         type: "sub_agent_tool_result";
@@ -207,17 +209,20 @@ export type AiEvent = AiEventBase &
         success: boolean;
         result: unknown;
         request_id: string;
+        parent_request_id: string;
       }
     | {
         type: "sub_agent_completed";
         agent_id: string;
         response: string;
         duration_ms: number;
+        parent_request_id: string;
       }
     | {
         type: "sub_agent_error";
         agent_id: string;
         error: string;
+        parent_request_id: string;
       }
     // Workflow events
     | {


### PR DESCRIPTION
## Summary

This PR adds a `parent_request_id` field to all sub-agent events, enabling the frontend to correctly correlate sub-agent tool calls with the parent tool request that spawned them.

## Problem

Previously, sub-agent tool calls in the UI were matched using index-based correlation, which was fragile and could break when:
- Multiple sub-agents were running concurrently
- Events arrived out of order
- Historical messages were being displayed

## Solution

### Backend Changes
- Added `parent_request_id: String` field to all sub-agent event variants in `events.rs`:
  - `SubAgentStarted`
  - `SubAgentToolRequest`
  - `SubAgentToolResult`
  - `SubAgentCompleted`
  - `SubAgentError`
- Updated `executor.rs` to accept and propagate `parent_request_id` through all events
- Updated `agentic_loop.rs` to pass the tool call's `request_id` as the `parent_request_id` when spawning sub-agents
- Updated CLI output formatting to include the new field

### Frontend Changes
- Added `parentRequestId` to `ActiveSubAgent` interface in the store
- Updated `useAiEvents.ts` to extract `parent_request_id` from events
- Updated `UnifiedTimeline.tsx` to match sub-agents by `parentRequestId` instead of index
- Updated `AgentMessage.tsx` to use `parentRequestId` for historical message matching

## Testing
- All backend tests pass (`cargo test`)
- All frontend tests pass (`pnpm test`)
- Updated insta snapshots for serialization characterization tests
- `just check` passes
