### PR TITLE
fix(agent): resolve tab close and multi-agent initialization issues

### DIFF
--- a/backend/crates/qbit/src/state.rs
+++ b/backend/crates/qbit/src/state.rs
@@ -19,6 +19,11 @@ pub struct AppState {
     pub indexer_state: Arc<IndexerState>,
     pub tavily_state: Arc<TavilyState>,
     pub settings_manager: Arc<SettingsManager>,
+    /// Sidecar configuration - used to create per-session SidecarState instances.
+    pub sidecar_config: SidecarConfig,
+    /// Global sidecar state for UI commands (status, session listing, etc.).
+    /// NOTE: Agent bridges have their OWN SidecarState instances (created in configure_bridge)
+    /// to enable per-session isolation and avoid blocking between tabs.
     pub sidecar_state: Arc<SidecarState>,
 }
 
@@ -47,6 +52,10 @@ impl AppState {
             sidecar_config.enabled
         );
 
+        // Create global sidecar state for UI commands.
+        // Note: Agent bridges create their OWN SidecarState instances for per-session isolation.
+        let sidecar_state = Arc::new(SidecarState::with_config(sidecar_config.clone()));
+
         Self {
             pty_manager: Arc::new(PtyManager::new()),
             ai_state: AiState::new(),
@@ -54,7 +63,8 @@ impl AppState {
             indexer_state: Arc::new(IndexerState::new()),
             tavily_state: Arc::new(TavilyState::new()),
             settings_manager,
-            sidecar_state: Arc::new(SidecarState::with_config(sidecar_config)),
+            sidecar_config,
+            sidecar_state,
         }
     }
 }

--- a/e2e/tabbar-z-index.spec.ts
+++ b/e2e/tabbar-z-index.spec.ts
@@ -1,0 +1,164 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * TabBar Z-Index E2E Tests
+ *
+ * These tests verify that the TabBar maintains correct z-index stacking
+ * to ensure tab close buttons remain clickable even when dialogs are present.
+ *
+ * The fix ensures TabBar has z-[60] which is above dialog overlays (z-50).
+ */
+
+/**
+ * Wait for the app to be fully ready in browser mode.
+ */
+async function waitForAppReady(page: Page) {
+  await page.goto("/");
+  await page.waitForLoadState("domcontentloaded");
+
+  // Wait for the mock browser mode flag to be set
+  await page.waitForFunction(
+    () => (window as unknown as { __MOCK_BROWSER_MODE__?: boolean }).__MOCK_BROWSER_MODE__ === true,
+    { timeout: 15000 }
+  );
+
+  // Wait for the status bar to appear (indicates React has rendered)
+  await expect(page.locator('[data-testid="status-bar"]')).toBeVisible({
+    timeout: 10000,
+  });
+
+  // Wait for the unified input textarea to be visible
+  await expect(page.locator("textarea")).toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * Get tab count from the page.
+ */
+async function getTabCount(page: Page): Promise<number> {
+  return await page.locator('[role="tab"]').count();
+}
+
+/**
+ * Create a new tab via the UI.
+ */
+async function createNewTab(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "New tab" }).click();
+  // Wait for the new tab to appear
+  await page.waitForTimeout(200);
+}
+
+/**
+ * Close the first tab by hovering to reveal the close button.
+ */
+async function closeFirstTab(page: Page): Promise<void> {
+  // The tab structure wraps the trigger and close button in a parent div with class "group"
+  const tabWrapper = page
+    .locator(".group")
+    .filter({ has: page.locator('[role="tab"]') })
+    .first();
+  await tabWrapper.hover();
+  // Wait for the close button to become visible on hover
+  await page.waitForTimeout(100);
+  const closeButton = tabWrapper.locator('button[title="Close tab"]');
+  await closeButton.click();
+  // Wait for the tab to close
+  await page.waitForTimeout(200);
+}
+
+test.describe("TabBar Z-Index", () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page);
+  });
+
+  test("TabBar container has correct z-index class", async ({ page }) => {
+    // Find the TabBar container (the div with the tab list and buttons)
+    // It should have z-[60] class to be above dialog overlays
+    const tabBarContainer = page.locator(".z-\\[60\\]").first();
+
+    // Verify the TabBar container exists and has the correct z-index class
+    await expect(tabBarContainer).toBeVisible();
+
+    // Verify it contains the tabs
+    const tabs = tabBarContainer.locator('[role="tab"]');
+    await expect(tabs).toHaveCount(1); // Initial tab
+  });
+
+  test("tab close button is clickable after creating multiple tabs", async ({ page }) => {
+    // Create a second tab
+    await createNewTab(page);
+    expect(await getTabCount(page)).toBe(2);
+
+    // The close button should be accessible and clickable
+    const tabWrapper = page
+      .locator(".group")
+      .filter({ has: page.locator('[role="tab"]') })
+      .first();
+    await tabWrapper.hover();
+
+    const closeButton = tabWrapper.locator('button[title="Close tab"]');
+    await expect(closeButton).toBeVisible();
+
+    // Click should work and close the tab
+    await closeButton.click();
+    await page.waitForTimeout(200);
+
+    // Verify tab was closed
+    expect(await getTabCount(page)).toBe(1);
+  });
+
+  test("tab close button remains clickable with settings dialog open", async ({ page }) => {
+    // Create a second tab first (so we have a tab to switch to after closing)
+    await createNewTab(page);
+    expect(await getTabCount(page)).toBe(2);
+
+    // Open the settings dialog via the settings button
+    const settingsButton = page.getByRole("button", { name: /settings/i });
+    if (await settingsButton.isVisible()) {
+      await settingsButton.click();
+      await page.waitForTimeout(200);
+
+      // The settings tab should now be active
+      // Note: Settings opens as a tab in this app, not a modal dialog
+      // So we should have 3 tabs now (2 terminal + 1 settings)
+      const tabCount = await getTabCount(page);
+
+      // Close the first terminal tab - this should still work
+      // even with multiple tabs open
+      const tabWrapper = page
+        .locator(".group")
+        .filter({ has: page.locator('[role="tab"]') })
+        .first();
+      await tabWrapper.hover();
+
+      const closeButton = tabWrapper.locator('button[title="Close tab"]');
+      await expect(closeButton).toBeVisible();
+
+      // The click should work (not blocked by any overlay)
+      await closeButton.click();
+      await page.waitForTimeout(300);
+
+      // Verify a tab was closed
+      const newTabCount = await getTabCount(page);
+      expect(newTabCount).toBeLessThan(tabCount);
+    }
+  });
+
+  test("rapid tab creation and closing works correctly", async ({ page }) => {
+    // Test that rapid tab operations don't cause z-index issues
+
+    // Create 3 additional tabs
+    for (let i = 0; i < 3; i++) {
+      await createNewTab(page);
+    }
+    expect(await getTabCount(page)).toBe(4);
+
+    // Close tabs in succession
+    for (let i = 0; i < 3; i++) {
+      await closeFirstTab(page);
+      await page.waitForTimeout(100);
+    }
+
+    // Should have 1 tab remaining
+    expect(await getTabCount(page)).toBe(1);
+  });
+});

--- a/frontend/components/TabBar/TabBar.tsx
+++ b/frontend/components/TabBar/TabBar.tsx
@@ -129,7 +129,7 @@ export function TabBar({
     <TooltipProvider delayDuration={300}>
       {/* biome-ignore lint/a11y/noStaticElementInteractions: div is used for window drag region */}
       <div
-        className="flex items-center h-[38px] bg-card border-b border-[var(--border-subtle)] pl-[78px] pr-1 gap-1"
+        className="relative z-[60] flex items-center h-[38px] bg-card border-b border-[var(--border-subtle)] pl-[78px] pr-1 gap-1"
         onMouseDown={startDrag}
       >
         <Tabs


### PR DESCRIPTION
## Summary

Fixes two related issues with agent sessions and tabs:

- **Tab close button not working during agent execution**: The ToolApprovalDialog overlay was blocking clicks to the close button
- **New agents in separate tabs unable to initialize**: Shared SidecarState was causing blocking between concurrent agent sessions

## Changes

### Fix 1: TabBar Z-Index (Frontend)
- Raised TabBar container z-index from default to `z-[60]`, above dialog overlays (`z-50`)
- File: `frontend/components/TabBar/TabBar.tsx`

### Fix 2: Per-Session SidecarState (Backend)
- Added `sidecar_config` to `AppState` for creating per-session sidecar instances
- Modified `configure_bridge` to create a new `SidecarState` for each session instead of sharing a global one
- Each tab/session now has isolated sidecar state, enabling concurrent agent execution
- Files: `backend/crates/qbit/src/state.rs`, `backend/crates/qbit/src/ai/commands/mod.rs`

### Tests Added
- **Backend unit tests** (`qbit-sidecar`):
  - `test_per_session_sidecar_isolation`: Verifies multiple SidecarState instances are completely isolated
  - `test_per_session_sidecar_concurrent_initialization`: Verifies 5 instances can initialize concurrently
- **E2E tests** (`e2e/tabbar-z-index.spec.ts`):
  - Verifies TabBar has correct z-index class
  - Verifies tab close button is clickable with multiple tabs
  - Verifies tab close works with settings open
  - Stress test for rapid tab creation/closing

## Test plan

- [x] Backend tests pass: `cargo test --package qbit-sidecar`
- [x] Frontend type check passes: `pnpm run typecheck`
- [x] Rust compilation passes: `cargo check --package qbit`
- [ ] Manual test: Open multiple tabs, start agents concurrently, verify no blocking
- [ ] Manual test: With agent running and tool approval dialog open, verify tab close button works
- [ ] E2E tests: `pnpm run test:e2e`