### PR TITLE
fix(agent): auto-approve mode now bypasses tool policy checks

### DIFF
--- a/backend/crates/qbit-ai/src/test_utils.rs
+++ b/backend/crates/qbit-ai/src/test_utils.rs
@@ -2597,11 +2597,11 @@ mod tests {
         // 2. Planning mode restrictions work correctly
         // 3. Constraint violations are handled properly
 
-        // Test 1: Policy denial
+        // Test 1: Policy denial (in Default mode, denied tools should be rejected)
         {
             let test_ctx = TestContextBuilder::new()
                 .deny_tool("forbidden_tool")
-                .agent_mode(AgentMode::AutoApprove)
+                .agent_mode(AgentMode::Default)
                 .build()
                 .await;
 


### PR DESCRIPTION
## Summary

Fixes a bug where Auto-Approve mode only updated system prompts but didn't actually bypass tool policy restrictions programmatically.

## Problem

Previously, the tool approval flow checked policies **before** checking the agent mode:

```
Step 1: Policy Deny check → BLOCKS if tool is denied
Step 2: Constraints check
Step 3: Policy Allow check
Step 4: Learned patterns check
Step 4.4: AutoApprove mode check ← TOO LATE!
Step 4.5: --auto-approve flag check ← TOO LATE!
Step 5: HITL approval request
```

This meant tools with `Deny` policy would be blocked even when Auto-Approve mode was enabled.

## Solution

Moved the AutoApprove checks to happen **before** any policy checks:

```
Step 0.1: AutoApprove mode → bypass all policy, execute immediately ✅
Step 0.2: --auto-approve flag → bypass all policy, execute immediately ✅
Step 0.3: Planning mode → restrict to read-only tools
Step 1: Policy Deny check (only reached if not auto-approved)
Step 2+: Normal policy flow
```

## Changes

- `backend/crates/qbit-ai/src/agentic_loop.rs`:
  - Moved `agent_mode.is_auto_approve()` check to Step 0.1
  - Moved `runtime.auto_approve()` check to Step 0.2
  - Removed duplicate checks at Step 4.4 and Step 4.5
  - Added clarifying comments about check order

## Test plan

- [x] Code compiles: `cargo check --package qbit-ai`
- [ ] Manual test: Enable Auto-Approve mode, verify denied tools now execute
- [ ] Manual test: Use `--auto-approve` CLI flag, verify same behavior