### PR TITLE
feat(ui): add clickable file path links in markdown and terminal

### DIFF
--- a/frontend/components/CommandBlock/CommandBlock.tsx
+++ b/frontend/components/CommandBlock/CommandBlock.tsx
@@ -8,6 +8,7 @@ import { StaticTerminalOutput } from "./StaticTerminalOutput";
 
 interface CommandBlockProps {
   block: CommandBlockType;
+  sessionId?: string;
   onToggleCollapse: (blockId: string) => void;
 }
 
@@ -20,7 +21,7 @@ function formatDuration(ms: number | null): string {
   return `${minutes}m ${seconds}s`;
 }
 
-export function CommandBlock({ block, onToggleCollapse }: CommandBlockProps) {
+export function CommandBlock({ block, sessionId, onToggleCollapse }: CommandBlockProps) {
   const isSuccess = block.exitCode === 0;
 
   // Strip OSC sequences but keep ANSI color codes for rendering
@@ -81,7 +82,11 @@ export function CommandBlock({ block, onToggleCollapse }: CommandBlockProps) {
       {/* Output - now using xterm for consistency with LiveTerminalBlock */}
       <CollapsibleContent>
         <div className="px-5 pb-4">
-          <StaticTerminalOutput output={cleanOutput} />
+          <StaticTerminalOutput
+            output={cleanOutput}
+            sessionId={sessionId}
+            workingDirectory={block.workingDirectory}
+          />
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/frontend/components/CommandBlock/StaticTerminalOutput.tsx
+++ b/frontend/components/CommandBlock/StaticTerminalOutput.tsx
@@ -1,27 +1,51 @@
+import type { ILink, Terminal as TerminalType } from "@xterm/xterm";
 import { Terminal } from "@xterm/xterm";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FilePathPopup } from "@/components/FilePathPopup";
+import { useFileEditorSidebar } from "@/hooks/useFileEditorSidebar";
+import { type DetectedPath, detectFilePaths } from "@/lib/pathDetection";
+import { type ResolvedPath, resolvePath } from "@/lib/pathResolution";
 import { ThemeManager } from "@/lib/theme";
 import "@xterm/xterm/css/xterm.css";
 
 interface StaticTerminalOutputProps {
   /** ANSI-formatted output to display */
   output: string;
+  /** Session ID for file editor */
+  sessionId?: string;
+  /** Working directory for path resolution */
+  workingDirectory?: string;
 }
 
 /**
  * Renders terminal output using xterm.js in read-only mode.
  * This ensures visual consistency with LiveTerminalBlock.
  */
-export function StaticTerminalOutput({ output }: StaticTerminalOutputProps) {
+export function StaticTerminalOutput({
+  output,
+  sessionId,
+  workingDirectory,
+}: StaticTerminalOutputProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const terminalRef = useRef<Terminal | null>(null);
+  const terminalRef = useRef<TerminalType | null>(null);
+
+  const [popupOpen, setPopupOpen] = useState(false);
+  const [popupPosition, setPopupPosition] = useState<{ x: number; y: number } | null>(null);
+  const [popupPaths, setPopupPaths] = useState<ResolvedPath[]>([]);
+  const [popupLoading, setPopupLoading] = useState(false);
+  // Store the detected path for resolution
+  const pendingDetectedRef = useRef<DetectedPath | null>(null);
+
+  const { openFile } = useFileEditorSidebar(sessionId ?? null, workingDirectory);
 
   // Calculate rows needed for content (pre-render estimate)
   const lineCount = output.split("\n").length;
   const rows = Math.max(lineCount, 1);
 
+  // Effect to create terminal (runs once on mount)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: rows is only needed for initial creation; resizing is handled in separate effect
   useEffect(() => {
-    if (!containerRef.current || !output) return;
+    if (!containerRef.current) return;
 
     // Create terminal if it doesn't exist
     if (!terminalRef.current) {
@@ -58,16 +82,6 @@ export function StaticTerminalOutput({ output }: StaticTerminalOutputProps) {
       terminalRef.current = terminal;
     }
 
-    // Update rows if content changed
-    const terminal = terminalRef.current;
-    if (terminal.rows !== rows) {
-      terminal.resize(terminal.cols, rows);
-    }
-
-    // Write output
-    terminal.clear();
-    terminal.write(output);
-
     return () => {
       // Cleanup on unmount
       if (terminalRef.current) {
@@ -75,12 +89,107 @@ export function StaticTerminalOutput({ output }: StaticTerminalOutputProps) {
         terminalRef.current = null;
       }
     };
+  }, []);
+
+  // Effect to register link provider when sessionId/workingDirectory available
+  useEffect(() => {
+    if (!sessionId || !workingDirectory || !terminalRef.current) return;
+
+    const terminal = terminalRef.current;
+    const wdRef = workingDirectory; // Capture for closure
+
+    const disposable = terminal.registerLinkProvider({
+      provideLinks: (bufferLineNumber, callback) => {
+        const buffer = terminal.buffer.active;
+        const line = buffer.getLine(bufferLineNumber - 1);
+        if (!line) {
+          callback(undefined);
+          return;
+        }
+
+        const lineText = line.translateToString(true);
+        const detected = detectFilePaths(lineText);
+
+        if (detected.length === 0) {
+          callback(undefined);
+          return;
+        }
+
+        const links: ILink[] = detected.map((pathInfo) => ({
+          range: {
+            start: { x: pathInfo.start + 1, y: bufferLineNumber },
+            end: { x: pathInfo.end, y: bufferLineNumber },
+          },
+          text: pathInfo.raw,
+          activate: async (event: MouseEvent) => {
+            // Store the detected path for resolution
+            pendingDetectedRef.current = pathInfo;
+
+            setPopupLoading(true);
+            setPopupPosition({ x: event.clientX, y: event.clientY });
+            setPopupOpen(true);
+
+            try {
+              const resolved = await resolvePath(pathInfo, wdRef);
+              setPopupPaths(resolved);
+            } catch (error) {
+              console.error("Failed to resolve path:", error);
+              setPopupPaths([]);
+            } finally {
+              setPopupLoading(false);
+            }
+          },
+        }));
+
+        callback(links);
+      },
+    });
+
+    return () => {
+      disposable.dispose();
+    };
+  }, [sessionId, workingDirectory]);
+
+  // Effect to write content
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (!terminal || !output) return;
+
+    // Update rows if content changed
+    if (terminal.rows !== rows) {
+      terminal.resize(terminal.cols, rows);
+    }
+
+    // Write output
+    terminal.clear();
+    terminal.write(output);
   }, [output, rows]);
 
+  const handleOpenFile = useCallback(
+    (absolutePath: string, _line?: number, _column?: number) => {
+      // TODO: Support line navigation when CodeMirror supports it
+      openFile(absolutePath);
+      setPopupOpen(false);
+    },
+    [openFile]
+  );
+
   return (
-    <div
-      ref={containerRef}
-      className="overflow-hidden [&_.xterm-viewport]:!overflow-hidden [&_.xterm-screen]:!h-auto"
-    />
+    <>
+      <div
+        ref={containerRef}
+        className="overflow-hidden [&_.xterm-viewport]:!overflow-hidden [&_.xterm-screen]:!h-auto"
+      />
+      {popupPosition && (
+        <FilePathPopup
+          open={popupOpen}
+          onOpenChange={setPopupOpen}
+          paths={popupPaths}
+          loading={popupLoading}
+          onOpenFile={handleOpenFile}
+          position={popupPosition}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/components/FilePathLink/FilePathLink.tsx
+++ b/frontend/components/FilePathLink/FilePathLink.tsx
@@ -1,0 +1,84 @@
+/**
+ * FilePathLink - Clickable file path link for Markdown content
+ * Renders detected file paths as styled, clickable text that opens a popup with actions
+ */
+
+import { type ReactNode, useCallback, useState } from "react";
+import { FilePathPopup } from "@/components/FilePathPopup";
+import { PopoverAnchor } from "@/components/ui/popover";
+import { useFileEditorSidebar } from "@/hooks/useFileEditorSidebar";
+import type { DetectedPath } from "@/lib/pathDetection";
+import type { ResolvedPath } from "@/lib/pathResolution";
+import { resolvePath } from "@/lib/pathResolution";
+
+interface FilePathLinkProps {
+  /** The detected path info */
+  detected: DetectedPath;
+  /** Working directory for path resolution */
+  workingDirectory: string;
+  /** Session ID for file editor */
+  sessionId: string;
+  /** The text to display (may differ from detected.raw if we only wrap part of it) */
+  children: ReactNode;
+}
+
+export function FilePathLink({
+  detected,
+  workingDirectory,
+  sessionId,
+  children,
+}: FilePathLinkProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [resolvedPaths, setResolvedPaths] = useState<ResolvedPath[]>([]);
+
+  const { openFile } = useFileEditorSidebar(sessionId, workingDirectory);
+
+  const handleClick = useCallback(async () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+
+    setOpen(true);
+    setLoading(true);
+
+    try {
+      const paths = await resolvePath(detected, workingDirectory);
+      setResolvedPaths(paths);
+    } catch (error) {
+      console.error("Failed to resolve path:", error);
+      setResolvedPaths([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [detected, workingDirectory, open]);
+
+  const handleOpenFile = useCallback(
+    (absolutePath: string, _line?: number, _column?: number) => {
+      // TODO: Support line navigation when CodeMirror supports it
+      openFile(absolutePath);
+    },
+    [openFile]
+  );
+
+  return (
+    <FilePathPopup
+      open={open}
+      onOpenChange={setOpen}
+      paths={resolvedPaths}
+      loading={loading}
+      onOpenFile={handleOpenFile}
+    >
+      <PopoverAnchor asChild>
+        <button
+          type="button"
+          onClick={handleClick}
+          className="file-path-link inline bg-transparent p-0 text-left text-current"
+        >
+          {children}
+        </button>
+      </PopoverAnchor>
+    </FilePathPopup>
+  );
+}

--- a/frontend/components/FilePathLink/index.ts
+++ b/frontend/components/FilePathLink/index.ts
@@ -1,0 +1,1 @@
+export { FilePathLink } from "./FilePathLink";

--- a/frontend/components/FilePathPopup/FilePathPopup.tsx
+++ b/frontend/components/FilePathPopup/FilePathPopup.tsx
@@ -1,0 +1,210 @@
+/**
+ * FilePathPopup - Popup for file path actions
+ * Shows "Open in Editor" and "Copy Path" actions for detected file paths
+ */
+
+import { Copy, ExternalLink, File } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent } from "@/components/ui/popover";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import type { ResolvedPath } from "@/lib/pathResolution";
+
+interface FilePathPopupProps {
+  /** Whether the popup is open */
+  open: boolean;
+  /** Callback when open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** Resolved path(s) - may be multiple for ambiguous filename */
+  paths: ResolvedPath[];
+  /** Callback to open file in editor */
+  onOpenFile: (absolutePath: string, line?: number, column?: number) => void;
+  /** Position for fixed positioning (for terminal links) */
+  position?: { x: number; y: number };
+  /** Whether we're still loading/resolving paths */
+  loading?: boolean;
+  children?: React.ReactNode;
+}
+
+export function FilePathPopup({
+  open,
+  onOpenChange,
+  paths,
+  onOpenFile,
+  position,
+  loading,
+  children,
+}: FilePathPopupProps) {
+  const { copied, copy } = useCopyToClipboard();
+
+  const handleOpenFile = (path: ResolvedPath) => {
+    onOpenFile(path.absolutePath, path.line, path.column);
+    onOpenChange(false);
+  };
+
+  const handleCopyPath = async (path: ResolvedPath) => {
+    await copy(path.absolutePath);
+  };
+
+  // For fixed positioning (terminal links), we don't use children/anchor
+  const isFixedPosition = !!position;
+
+  const content = (
+    <div className="bg-popover border border-border rounded-md overflow-hidden min-w-[280px]">
+      {loading ? (
+        <div className="py-3 px-4 text-sm text-muted-foreground">Resolving path...</div>
+      ) : paths.length === 0 ? (
+        <div className="py-3 px-4 text-sm text-muted-foreground">File not found</div>
+      ) : paths.length === 1 ? (
+        // Single path - show actions directly
+        <SinglePathView
+          path={paths[0]}
+          copied={copied}
+          onOpen={() => handleOpenFile(paths[0])}
+          onCopy={() => handleCopyPath(paths[0])}
+        />
+      ) : (
+        // Multiple paths - show list
+        <MultiplePathsView paths={paths} onOpen={handleOpenFile} onCopy={handleCopyPath} />
+      )}
+    </div>
+  );
+
+  if (isFixedPosition) {
+    // Fixed positioning for terminal links
+    if (!open) return null;
+    return (
+      <>
+        {/* Backdrop to close on click outside */}
+        <button
+          type="button"
+          aria-label="Close file path popup"
+          className="fixed inset-0 z-40 cursor-default bg-transparent p-0 m-0 border-0 focus:outline-none"
+          onClick={() => onOpenChange(false)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              onOpenChange(false);
+            }
+          }}
+        />
+        <div
+          className="fixed z-50"
+          style={{
+            left: position.x,
+            top: position.y,
+            transform: "translateY(-100%)", // Position above click
+          }}
+        >
+          {content}
+        </div>
+      </>
+    );
+  }
+
+  // Popover mode for Markdown links
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      {children}
+      <PopoverContent
+        className="w-auto p-0"
+        side="top"
+        align="start"
+        sideOffset={8}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {content}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// View for single resolved path
+function SinglePathView({
+  path,
+  copied,
+  onOpen,
+  onCopy,
+}: {
+  path: ResolvedPath;
+  copied: boolean;
+  onOpen: () => void;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="p-2">
+      {/* Path display */}
+      <div className="px-2 py-1.5 mb-2">
+        <div className="flex items-center gap-2 text-sm text-foreground font-mono truncate">
+          <File className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+          <span className="truncate">{path.relativePath}</span>
+          {path.line && (
+            <span className="text-muted-foreground">
+              :{path.line}
+              {path.column ? `:${path.column}` : ""}
+            </span>
+          )}
+        </div>
+      </div>
+      {/* Actions */}
+      <div className="flex gap-1">
+        <Button variant="ghost" size="sm" className="flex-1 justify-start gap-2" onClick={onOpen}>
+          <ExternalLink className="w-4 h-4" />
+          Open in Editor
+        </Button>
+        <Button variant="ghost" size="sm" className="justify-start gap-2" onClick={onCopy}>
+          <Copy className="w-4 h-4" />
+          {copied ? "Copied!" : "Copy"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// View for multiple resolved paths (ambiguous filename)
+function MultiplePathsView({
+  paths,
+  onOpen,
+  onCopy,
+}: {
+  paths: ResolvedPath[];
+  onOpen: (path: ResolvedPath) => void;
+  onCopy: (path: ResolvedPath) => void;
+}) {
+  return (
+    <div className="py-1">
+      <div className="px-3 py-1.5 text-xs text-muted-foreground font-medium uppercase tracking-wide border-b border-border">
+        Multiple matches found
+      </div>
+      <div className="max-h-[200px] overflow-y-auto">
+        {paths.map((path) => (
+          <div key={path.absolutePath} className="px-2 py-1 hover:bg-card transition-colors">
+            <div className="flex items-center gap-2 text-sm text-foreground font-mono">
+              <File className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+              <span className="truncate flex-1">{path.relativePath}</span>
+              <div className="flex gap-1 flex-shrink-0">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => onOpen(path)}
+                  title="Open in Editor"
+                >
+                  <ExternalLink className="w-3.5 h-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => onCopy(path)}
+                  title="Copy Path"
+                >
+                  <Copy className="w-3.5 h-3.5" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/FilePathPopup/index.ts
+++ b/frontend/components/FilePathPopup/index.ts
@@ -1,0 +1,1 @@
+export { FilePathPopup } from "./FilePathPopup";

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -294,3 +294,24 @@
 .titlebar-no-drag {
   -webkit-app-region: no-drag;
 }
+
+/* Clickable file path links in Markdown */
+.file-path-link {
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  transition: opacity 0.15s ease, text-decoration-color 0.15s ease;
+  border-radius: 2px;
+}
+
+.file-path-link:hover {
+  opacity: 0.85;
+  text-decoration-color: var(--success);
+}
+
+.file-path-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/frontend/lib/pathDetection.ts
+++ b/frontend/lib/pathDetection.ts
@@ -1,0 +1,150 @@
+/**
+ * File path detection utilities
+ * Detects file paths in text content using regex patterns
+ */
+
+export interface DetectedPath {
+  /** Original matched text */
+  raw: string;
+  /** Extracted path (without line numbers) */
+  path: string;
+  /** Line number if present (e.g., file.ts:42) */
+  line?: number;
+  /** Column if present (e.g., file.ts:42:10) */
+  column?: number;
+  /** Start index in source text */
+  start: number;
+  /** End index in source text */
+  end: number;
+  /** Type of path detected */
+  type: "absolute" | "relative" | "filename";
+}
+
+// Common file extensions to match
+const FILE_EXTENSIONS =
+  "(?:ts|tsx|js|jsx|mjs|cjs|json|md|mdx|py|rs|go|java|c|cpp|h|hpp|css|scss|html|xml|yaml|yml|toml|sh|bash|zsh|sql|rb|php|swift|kt|scala|vim|lua|zig|hs|ex|exs|erl|clj|vue|svelte|astro)";
+
+/**
+ * Main regex pattern for detecting file paths.
+ * Captures:
+ * - Absolute paths: /Users/foo/bar.ts
+ * - Relative paths: ./src/file.ts, ../lib/util.ts, src/file.ts
+ * - Filenames: main.rs
+ * - With optional line:column suffix: file.ts:42, file.ts:42:10
+ */
+const FILE_PATH_REGEX = new RegExp(
+  // Start boundary: beginning of string or common delimiters
+  `(?:^|[\\s"'\`({\\[])` +
+    // Capture group for the full match (path + optional line:col)
+    `(` +
+    // Path part: either absolute (/...), relative (./... or ../... or name/...), or just filename
+    `(?:` +
+    // Absolute path starting with /
+    `/[\\w./-]+` +
+    `|` +
+    // Relative path: starts with ./ or ../ or has / in it
+    `\\.{1,2}/[\\w./-]+` +
+    `|` +
+    // Path with directory (no leading dot): dir/file.ext
+    `[a-zA-Z_][\\w-]*(?:/[\\w.-]+)+` +
+    `|` +
+    // Just a filename: name.ext (must start with letter)
+    `[a-zA-Z_][\\w.-]*` +
+    `)` +
+    // Must end with known file extension
+    `\\.${FILE_EXTENSIONS}` +
+    // Optional line number suffix :42 or :42:10
+    `(?::(\\d+)(?::(\\d+))?)?` +
+    `)` +
+    // End boundary: end of string or common delimiters
+    `(?=$|[\\s"'\`)}\\]:,;])`,
+  "gi"
+);
+
+// Patterns to exclude (URLs, emails, etc.)
+const EXCLUDE_PATTERNS = [
+  /^https?:\/\//i, // URLs
+  /^ftp:\/\//i, // FTP
+  /^file:\/\//i, // File URLs
+  /@[a-z]+\.[a-z]/i, // Email-like patterns
+  /^\d+\.\d+\.\d+/, // Version numbers like 1.2.3
+];
+
+/**
+ * Detect file paths in text content
+ * @param text - Text to scan for file paths
+ * @returns Array of detected paths with their positions
+ */
+export function detectFilePaths(text: string): DetectedPath[] {
+  const results: DetectedPath[] = [];
+
+  // Reset regex state
+  FILE_PATH_REGEX.lastIndex = 0;
+
+  let match: RegExpExecArray | null = FILE_PATH_REGEX.exec(text);
+  while (match !== null) {
+    const fullMatch = match[1]; // The captured path (without boundary chars)
+    const lineNum = match[2];
+    const colNum = match[3];
+
+    // Calculate actual start position (match.index includes boundary char)
+    const boundaryOffset = match[0].indexOf(fullMatch);
+    const start = match.index + boundaryOffset;
+    const end = start + fullMatch.length;
+
+    // Extract path without line:col suffix
+    let path = fullMatch;
+    if (lineNum) {
+      path = fullMatch.replace(/:(\d+)(?::(\d+))?$/, "");
+    }
+
+    // Skip excluded patterns
+    if (EXCLUDE_PATTERNS.some((pattern) => pattern.test(path))) {
+      match = FILE_PATH_REGEX.exec(text);
+      continue;
+    }
+
+    // Determine path type
+    let type: DetectedPath["type"];
+    if (path.startsWith("/")) {
+      type = "absolute";
+    } else if (path.includes("/")) {
+      type = "relative";
+    } else {
+      type = "filename";
+    }
+
+    results.push({
+      raw: fullMatch,
+      path,
+      line: lineNum ? Number.parseInt(lineNum, 10) : undefined,
+      column: colNum ? Number.parseInt(colNum, 10) : undefined,
+      start,
+      end,
+      type,
+    });
+
+    match = FILE_PATH_REGEX.exec(text);
+  }
+
+  return results;
+}
+
+/**
+ * Check if a string looks like a file path
+ * @param text - Text to check
+ * @returns true if the text appears to be a file path
+ */
+export function isLikelyFilePath(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+
+  // Quick check: must have a file extension
+  const extensionMatch = new RegExp(`\\.${FILE_EXTENSIONS}(?::\\d+(?::\\d+)?)?$`, "i");
+  if (!extensionMatch.test(trimmed)) return false;
+
+  // Exclude URLs and emails
+  if (EXCLUDE_PATTERNS.some((pattern) => pattern.test(trimmed))) return false;
+
+  return true;
+}

--- a/frontend/lib/pathResolution.ts
+++ b/frontend/lib/pathResolution.ts
@@ -1,0 +1,155 @@
+/**
+ * File path resolution utilities
+ * Resolves detected paths to absolute paths using workspace context
+ */
+
+import { searchFiles } from "./indexer";
+import type { DetectedPath } from "./pathDetection";
+
+export interface ResolvedPath {
+  /** Absolute path to the file */
+  absolutePath: string;
+  /** Path relative to workspace (for display) */
+  relativePath: string;
+  /** Line number to navigate to */
+  line?: number;
+  /** Column number to navigate to */
+  column?: number;
+}
+
+/**
+ * Normalize path separators and resolve . and .. segments
+ */
+function normalizePath(path: string): string {
+  // Replace backslashes with forward slashes
+  let normalized = path.replace(/\\/g, "/");
+
+  // Remove duplicate slashes
+  normalized = normalized.replace(/\/+/g, "/");
+
+  // Resolve . and .. segments
+  const segments = normalized.split("/");
+  const result: string[] = [];
+
+  for (const segment of segments) {
+    if (segment === "..") {
+      result.pop();
+    } else if (segment !== "." && segment !== "") {
+      result.push(segment);
+    }
+  }
+
+  // Preserve leading slash for absolute paths
+  const prefix = normalized.startsWith("/") ? "/" : "";
+  return prefix + result.join("/");
+}
+
+/**
+ * Join path segments, handling absolute vs relative paths
+ */
+function joinPaths(base: string, relative: string): string {
+  if (relative.startsWith("/")) {
+    return normalizePath(relative);
+  }
+
+  // Remove trailing slash from base
+  const cleanBase = base.endsWith("/") ? base.slice(0, -1) : base;
+
+  // Remove leading ./ from relative
+  const cleanRelative = relative.startsWith("./") ? relative.slice(2) : relative;
+
+  return normalizePath(`${cleanBase}/${cleanRelative}`);
+}
+
+/**
+ * Get relative path from workspace root
+ */
+function getRelativePath(absolutePath: string, workingDirectory: string): string {
+  const normalizedAbs = normalizePath(absolutePath);
+  const normalizedWd = normalizePath(workingDirectory);
+
+  if (normalizedAbs.startsWith(`${normalizedWd}/`)) {
+    return normalizedAbs.slice(normalizedWd.length + 1);
+  }
+
+  return normalizedAbs;
+}
+
+/**
+ * Resolve a detected path to absolute path(s)
+ *
+ * @param detected - The detected path info
+ * @param workingDirectory - Current working directory for resolution
+ * @returns Array of resolved paths (may be multiple for bare filenames)
+ */
+export async function resolvePath(
+  detected: DetectedPath,
+  workingDirectory: string
+): Promise<ResolvedPath[]> {
+  const { path, line, column, type } = detected;
+
+  if (type === "absolute") {
+    // Absolute path - use directly
+    return [
+      {
+        absolutePath: normalizePath(path),
+        relativePath: getRelativePath(path, workingDirectory),
+        line,
+        column,
+      },
+    ];
+  }
+
+  if (type === "relative") {
+    // Relative path - resolve against working directory
+    const absolutePath = joinPaths(workingDirectory, path);
+    return [
+      {
+        absolutePath,
+        relativePath: getRelativePath(absolutePath, workingDirectory),
+        line,
+        column,
+      },
+    ];
+  }
+
+  // Filename only - search for matches
+  const matches = await findFilesByName(path);
+
+  if (matches.length === 0) {
+    // No matches found - return as relative path anyway
+    const absolutePath = joinPaths(workingDirectory, path);
+    return [
+      {
+        absolutePath,
+        relativePath: path,
+        line,
+        column,
+      },
+    ];
+  }
+
+  return matches.map((absPath) => ({
+    absolutePath: absPath,
+    relativePath: getRelativePath(absPath, workingDirectory),
+    line,
+    column,
+  }));
+}
+
+/**
+ * Search for files by name in the workspace
+ * @param filename - Filename to search for (e.g., "main.rs")
+ * @returns Array of absolute paths matching the filename
+ */
+export async function findFilesByName(filename: string): Promise<string[]> {
+  try {
+    // Use glob pattern to search for the filename anywhere in workspace
+    const pattern = `**/${filename}`;
+    const results = await searchFiles(pattern);
+    return results;
+  } catch (error) {
+    console.error("Failed to search for files:", error);
+    return [];
+  }
+}


### PR DESCRIPTION
Detect file paths in Markdown and static terminal output, resolve them against the working directory, and show a popup to open in editor or copy the resolved path. Adds path detection/resolution utilities and passes session/working directory context through relevant components.
