### PR TITLE
fix(session): fix restore initialization order and add agent_mode persistence

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -120,6 +120,18 @@ async function buildProviderConfig(
       return { provider: "xai", workspace, model: default_model, api_key: apiKey };
     }
 
+    case "zai": {
+      const apiKey = settings.ai.zai.api_key;
+      if (!apiKey) throw new Error("Z.AI API key not configured");
+      return {
+        provider: "zai",
+        workspace,
+        model: default_model,
+        api_key: apiKey,
+        use_coding_endpoint: settings.ai.zai.use_coding_endpoint,
+      };
+    }
+
     default:
       throw new Error(`Unknown provider: ${default_provider}`);
   }

--- a/frontend/lib/ai.ts
+++ b/frontend/lib/ai.ts
@@ -971,6 +971,8 @@ export interface SessionSnapshot {
   distinct_tools: string[];
   transcript: string[];
   messages: SessionMessage[];
+  /** Agent mode used in this session ("default", "auto-approve", "planning") */
+  agent_mode?: string;
 }
 
 /**
@@ -1046,8 +1048,11 @@ export async function finalizeAiSession(): Promise<string | null> {
  * @param identifier - The session identifier (file stem)
  * @returns The restored session snapshot
  */
-export async function restoreAiSession(identifier: string): Promise<SessionSnapshot> {
-  return invoke("restore_ai_session", { identifier });
+export async function restoreAiSession(
+  sessionId: string,
+  identifier: string
+): Promise<SessionSnapshot> {
+  return invoke("restore_ai_session", { sessionId, identifier });
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Fix "AI agent not initialized" error when restoring sessions by ensuring `initAiSession` is called before `restoreAiSession` in the frontend
- Update `restore_ai_session` backend command to use per-session bridges (`get_session_bridge`) instead of the legacy single bridge pattern
- Add `agent_mode` persistence to sessions so the agent mode (default/auto-approve/planning) is preserved when restoring

## Changes

### Backend (`qbit-session`)
- Add `agent_mode` field to `QbitSessionSnapshot` and `QbitSessionManager`
- Add companion `.mode` file support for storing agent mode alongside sessions
- Add `set_agent_mode()` method and file read/write helpers

### Backend (`qbit-ai`)
- Add `sync_agent_mode_to_session()` to sync mode before save/finalize
- Call sync in `save_session()` and `finalize_session()`

### Backend (`qbit` commands)
- Update `restore_ai_session` to accept `session_id` parameter
- Use `get_session_bridge()` for per-session bridge lookup
- Restore `agent_mode` from session and apply to bridge

### Frontend
- Reorder `restoreSession()` to call `initAiSession()` before `restoreAiSession()`
- Add missing `zai` provider case in `buildProviderConfig` and `restoreSession`
- Update `restoreAiSession` signature to include `sessionId`
- Add `agent_mode` to `SessionSnapshot` interface

## Test plan
- [ ] Restore a session that was saved with the default agent mode
- [ ] Restore a session saved with auto-approve mode and verify it's restored
- [ ] Restore a session saved with planning mode and verify it's restored
- [ ] Verify sessions can be restored for all providers (anthropic, vertex, openai, zai)