### PR TITLE
fix(session): use current default provider when restoring sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,8 @@ Settings file: `~/.qbit/settings.toml` (auto-generated on first run, see `backen
 
 Sessions stored in: `~/.qbit/sessions/` (override with `VT_SESSION_DIR` env var)
 
+Logs: `~/.qbit/frontend.log` and `~/.qbit/backend.log`
+
 Workspace override: `just dev /path/to/project` or set `QBIT_WORKSPACE` env var
 
 ## Event System

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -20,18 +20,15 @@ import { TerminalPortalProvider } from "./hooks/useTerminalPortal";
 import { ThemeProvider } from "./hooks/useTheme";
 import {
   type AiProvider,
-  getAnthropicApiKey,
-  getOpenAiApiKey,
-  getOpenRouterApiKey,
+  buildProviderConfig,
   getProjectSettings,
   initAiSession,
   isAiSessionInitialized,
-  type ProviderConfig,
   setAgentMode as setAgentModeBackend,
 } from "./lib/ai";
 import { notify } from "./lib/notify";
 import { countLeafPanes, findPaneById } from "./lib/pane-utils";
-import { getSettings, type QbitSettings } from "./lib/settings";
+import { getSettings } from "./lib/settings";
 import {
   getGitBranch,
   gitStatus,
@@ -50,92 +47,6 @@ import {
   useTabLayout,
 } from "./store";
 import { useFileEditorSidebarStore } from "./store/file-editor-sidebar";
-
-/**
- * Build a ProviderConfig for the given provider/model settings.
- * This is used by both session-specific and global initialization.
- */
-async function buildProviderConfig(
-  settings: QbitSettings,
-  workspace: string,
-  overrides?: { provider?: AiProvider | null; model?: string | null }
-): Promise<ProviderConfig> {
-  const default_provider = overrides?.provider ?? settings.ai.default_provider;
-  const default_model = overrides?.model ?? settings.ai.default_model;
-
-  switch (default_provider) {
-    case "vertex_ai": {
-      const { vertex_ai } = settings.ai;
-      if (!vertex_ai.credentials_path || !vertex_ai.project_id) {
-        throw new Error("Vertex AI credentials not configured");
-      }
-      return {
-        provider: "vertex_ai",
-        workspace,
-        credentials_path: vertex_ai.credentials_path,
-        project_id: vertex_ai.project_id,
-        location: vertex_ai.location || "us-east5",
-        model: default_model,
-      };
-    }
-
-    case "anthropic": {
-      const apiKey = settings.ai.anthropic.api_key || (await getAnthropicApiKey());
-      if (!apiKey) throw new Error("Anthropic API key not configured");
-      return { provider: "anthropic", workspace, model: default_model, api_key: apiKey };
-    }
-
-    case "openai": {
-      const apiKey = settings.ai.openai.api_key || (await getOpenAiApiKey());
-      if (!apiKey) throw new Error("OpenAI API key not configured");
-      return { provider: "openai", workspace, model: default_model, api_key: apiKey };
-    }
-
-    case "openrouter": {
-      const apiKey = settings.ai.openrouter.api_key || (await getOpenRouterApiKey());
-      if (!apiKey) throw new Error("OpenRouter API key not configured");
-      return { provider: "openrouter", workspace, model: default_model, api_key: apiKey };
-    }
-
-    case "ollama": {
-      const baseUrl = settings.ai.ollama.base_url;
-      return { provider: "ollama", workspace, model: default_model, base_url: baseUrl };
-    }
-
-    case "gemini": {
-      const apiKey = settings.ai.gemini.api_key;
-      if (!apiKey) throw new Error("Gemini API key not configured");
-      return { provider: "gemini", workspace, model: default_model, api_key: apiKey };
-    }
-
-    case "groq": {
-      const apiKey = settings.ai.groq.api_key;
-      if (!apiKey) throw new Error("Groq API key not configured");
-      return { provider: "groq", workspace, model: default_model, api_key: apiKey };
-    }
-
-    case "xai": {
-      const apiKey = settings.ai.xai.api_key;
-      if (!apiKey) throw new Error("xAI API key not configured");
-      return { provider: "xai", workspace, model: default_model, api_key: apiKey };
-    }
-
-    case "zai": {
-      const apiKey = settings.ai.zai.api_key;
-      if (!apiKey) throw new Error("Z.AI API key not configured");
-      return {
-        provider: "zai",
-        workspace,
-        model: default_model,
-        api_key: apiKey,
-        use_coding_endpoint: settings.ai.zai.use_coding_endpoint,
-      };
-    }
-
-    default:
-      throw new Error(`Unknown provider: ${default_provider}`);
-  }
-}
 
 function App() {
   const {


### PR DESCRIPTION
## Summary
- Fix session restore failing with "API key missing for provider openai_responses" error
- Extract `buildProviderConfig` to `lib/ai.ts` as a shared utility function
- Simplify `restoreSession` to use user's current default provider instead of matching session's original provider

## Details
Session restore was failing when the original provider (e.g., `openai_responses`) wasn't explicitly handled in the restore logic. The conversation history is provider-agnostic, so we now simply use the user's current default provider from settings rather than maintaining a brittle mapping of internal provider names.

This removes ~70 lines of duplicated provider-switching logic.

## Test plan
- [ ] Restore a session that was created with a different provider than currently configured
- [ ] Verify session messages are restored correctly
- [ ] Verify new messages use the current default provider