### PR TITLE
feat(ci): add Linux x86_64 build to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,6 +40,10 @@ jobs:
             args: --target x86_64-apple-darwin
             rust_target: x86_64-apple-darwin
             name: macOS-x86_64
+          - platform: ubuntu-22.04
+            args: --target x86_64-unknown-linux-gnu
+            rust_target: x86_64-unknown-linux-gnu
+            name: Linux-x86_64
 
     runs-on: ${{ matrix.platform }}
     name: Build (${{ matrix.name }})
@@ -61,6 +65,16 @@ jobs:
 
       - name: Install frontend dependencies
         run: pnpm install
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
Adds Linux x86_64 build target to the release workflow, enabling automatic creation of Linux packages when a release is published.

## Commits
- `1a1b715` feat(ci): add Linux x86_64 build to release workflow

## Changes
- Added `ubuntu-22.04` platform with `x86_64-unknown-linux-gnu` target to build matrix
- Added conditional step to install Linux system dependencies:
  - `libwebkit2gtk-4.1-dev` - WebKit rendering engine for Tauri 2
  - `libappindicator3-dev` - System tray support
  - `librsvg2-dev` - SVG icon rendering
  - `patchelf` - ELF binary patching for AppImage
- Build produces `.deb` and `.AppImage` artifacts

## Breaking Changes
None

## Test Plan
- [ ] Merge to main and create a release to trigger the workflow
- [ ] Verify Linux build job runs successfully in GitHub Actions
- [ ] Verify `.deb` and `.AppImage` artifacts are uploaded to the release

## Release Notes
Linux x86_64 builds are now automatically created when a new release is published. Users can download `.deb` packages for Debian/Ubuntu or portable `.AppImage` files.

## Checklist
- [x] Conventional commit format followed
- [x] CI workflow syntax is valid