### PR TITLE
feat(telemetry): improve Langfuse tracing for sub-agents and LLM spans

### DIFF
--- a/backend/crates/qbit-ai/src/test_utils.rs
+++ b/backend/crates/qbit-ai/src/test_utils.rs
@@ -2969,6 +2969,7 @@ mod tests {
             workspace: &Arc::new(RwLock::new(workspace)),
             provider_name: "mock",
             model_name: "mock-model",
+            session_id: None,
         };
 
         let agent_def = test_sub_agent_definition_for_executor("analyzer");
@@ -3067,6 +3068,7 @@ mod tests {
             workspace: &Arc::new(RwLock::new(workspace)),
             provider_name: "mock",
             model_name: "mock-model",
+            session_id: None,
         };
 
         let agent_def = test_sub_agent_definition_for_executor("executor");
@@ -3126,6 +3128,7 @@ mod tests {
             workspace: &Arc::new(RwLock::new(workspace)),
             provider_name: "mock",
             model_name: "mock-model",
+            session_id: None,
         };
 
         let agent_def = test_sub_agent_definition_for_executor("event_tester");
@@ -3222,6 +3225,7 @@ mod tests {
             workspace: &Arc::new(RwLock::new(workspace)),
             provider_name: "mock",
             model_name: "mock-model",
+            session_id: None,
         };
 
         // Create agent with very low max_iterations to trigger the error path
@@ -3299,6 +3303,7 @@ mod tests {
             workspace: &Arc::new(RwLock::new(workspace)),
             provider_name: "mock",
             model_name: "mock-model",
+            session_id: None,
         };
 
         // Create agent with restricted tools (only read_file allowed)
@@ -3383,6 +3388,7 @@ mod tests {
             workspace: &Arc::new(RwLock::new(workspace)),
             provider_name: "mock",
             model_name: "mock-model",
+            session_id: None,
         };
 
         // Create agent with very low max_iterations to simulate timeout

--- a/backend/crates/qbit/src/settings/commands.rs
+++ b/backend/crates/qbit/src/settings/commands.rs
@@ -122,3 +122,12 @@ pub async fn get_window_state(
     let settings = state.settings_manager.get().await;
     Ok(settings.ui.window)
 }
+
+/// Check if Langfuse tracing is active.
+///
+/// Returns true if Langfuse was enabled in settings and properly configured
+/// (i.e., valid API keys were available) at startup.
+#[tauri::command]
+pub fn is_langfuse_active(state: State<'_, AppState>) -> bool {
+    state.langfuse_active
+}

--- a/backend/crates/qbit/src/state.rs
+++ b/backend/crates/qbit/src/state.rs
@@ -25,13 +25,18 @@ pub struct AppState {
     /// NOTE: Agent bridges have their OWN SidecarState instances (created in configure_bridge)
     /// to enable per-session isolation and avoid blocking between tabs.
     pub sidecar_state: Arc<SidecarState>,
+    /// Whether Langfuse tracing is active (enabled and properly configured).
+    pub langfuse_active: bool,
 }
 
 impl AppState {
     /// Create a new AppState with all subsystems initialized.
     ///
     /// This is async because SettingsManager needs to load from disk.
-    pub async fn new() -> Self {
+    ///
+    /// # Arguments
+    /// * `langfuse_active` - Whether Langfuse tracing is enabled and properly configured.
+    pub async fn new(langfuse_active: bool) -> Self {
         // Initialize settings manager first (needed by TavilyState in the future)
         let settings_manager = Arc::new(
             SettingsManager::new()
@@ -65,6 +70,7 @@ impl AppState {
             settings_manager,
             sidecar_config,
             sidecar_state,
+            langfuse_active,
         }
     }
 }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -28,7 +28,7 @@ import {
 } from "./lib/ai";
 import { notify } from "./lib/notify";
 import { countLeafPanes, findPaneById } from "./lib/pane-utils";
-import { getSettings } from "./lib/settings";
+import { getSettings, isLangfuseActive } from "./lib/settings";
 import {
   getGitBranch,
   gitStatus,
@@ -580,6 +580,16 @@ function App() {
             status: "error",
             errorMessage,
           });
+        }
+
+        // Check if Langfuse tracing is active and notify the user
+        try {
+          const langfuseActive = await isLangfuseActive();
+          if (langfuseActive) {
+            notify.info("Langfuse tracing enabled");
+          }
+        } catch (langfuseError) {
+          logger.warn("Failed to check Langfuse status:", langfuseError);
         }
 
         setIsLoading(false);

--- a/frontend/lib/settings.ts
+++ b/frontend/lib/settings.ts
@@ -371,6 +371,16 @@ export async function getSettingsPath(): Promise<string> {
   return invoke("get_settings_path");
 }
 
+/**
+ * Check if Langfuse tracing is active.
+ *
+ * Returns true if Langfuse was enabled in settings and properly configured
+ * (i.e., valid API keys were available) at startup.
+ */
+export async function isLangfuseActive(): Promise<boolean> {
+  return invoke("is_langfuse_active");
+}
+
 // =============================================================================
 // Default Settings
 // =============================================================================


### PR DESCRIPTION
## Summary

- Add comprehensive OpenTelemetry/Langfuse tracing to sub-agent executor with proper span hierarchy
- Improve main agent LLM span recording to avoid redundant input/output (tool details are in child spans)
- Add startup notification when Langfuse tracing is enabled

## Changes

### Sub-agent Tracing
- Root `sub_agent` span wrapping execution with `agent_type`, `model`, `provider`, `depth` attributes
- `llm_completion` spans per iteration with token usage (`prompt_tokens`, `completion_tokens`)
- `tool_call` spans for each tool execution with input/output
- Session ID propagated from parent agent for Langfuse trace grouping

### Main Agent LLM Span Improvements
- Only record `input` when there's actual user text (not tool results from previous iteration)
- Only record `output` when there's actual text response from the LLM
- Tool call details remain in child `tool_call` spans to avoid duplication
- LLM completion spans still track token usage, latency, and model info

### Langfuse Status Notification
- New `is_langfuse_active` Tauri command to check if Langfuse is enabled and configured
- Info notification shown once on app startup when Langfuse tracing is active

## Test plan

- [ ] Verify sub-agent traces appear in Langfuse with proper hierarchy
- [ ] Verify LLM completion spans show input/output only when there's text content
- [ ] Verify tool call spans show full details
- [ ] Verify token usage is tracked on LLM completion spans
- [ ] Verify Langfuse notification appears on startup when enabled