### PR TITLE
fix(ai): emit error notifications and fix context pruning event

### DIFF
--- a/backend/crates/qbit-ai/src/agentic_loop.rs
+++ b/backend/crates/qbit-ai/src/agentic_loop.rs
@@ -1217,6 +1217,7 @@ where
             .await;
         let _ = ctx.event_tx.send(AiEvent::ContextPruned {
             messages_removed: pruned_info.messages_removed,
+            tokens_freed: pruned_info.tokens_freed,
             utilization_before: pruned_info.utilization_before,
             utilization_after: pruned_info.utilization_after,
         });

--- a/backend/crates/qbit-cli-output/src/lib.rs
+++ b/backend/crates/qbit-cli-output/src/lib.rs
@@ -303,12 +303,14 @@ pub fn convert_to_cli_json(event: &AiEvent) -> CliJsonEvent {
         // Context management events
         AiEvent::ContextPruned {
             messages_removed,
+            tokens_freed,
             utilization_before,
             utilization_after,
         } => CliJsonEvent::new(
             "context_pruned",
             serde_json::json!({
                 "messages_removed": messages_removed,
+                "tokens_freed": tokens_freed,
                 "utilization_before": utilization_before,
                 "utilization_after": utilization_after
             }),

--- a/backend/crates/qbit-core/src/events.rs
+++ b/backend/crates/qbit-core/src/events.rs
@@ -166,6 +166,7 @@ pub enum AiEvent {
     /// Context was pruned due to token limits
     ContextPruned {
         messages_removed: usize,
+        tokens_freed: usize,
         utilization_before: f64,
         utilization_after: f64,
     },
@@ -600,6 +601,7 @@ mod tests {
         fn context_pruned_event_json_format() {
             let event = AiEvent::ContextPruned {
                 messages_removed: 5,
+                tokens_freed: 15000,
                 utilization_before: 0.95,
                 utilization_after: 0.75,
             };
@@ -607,6 +609,7 @@ mod tests {
 
             assert_eq!(json["type"], "context_pruned");
             assert_eq!(json["messages_removed"], 5);
+            assert_eq!(json["tokens_freed"], 15000);
             assert_eq!(json["utilization_before"], 0.95);
             assert_eq!(json["utilization_after"], 0.75);
         }
@@ -926,6 +929,7 @@ mod tests {
                 },
                 AiEvent::ContextPruned {
                     messages_removed: 5,
+                    tokens_freed: 15000,
                     utilization_before: 0.95,
                     utilization_after: 0.75,
                 },

--- a/backend/crates/qbit/tests/ai_events_characterization.rs
+++ b/backend/crates/qbit/tests/ai_events_characterization.rs
@@ -298,6 +298,7 @@ fn test_sub_agent_error_serialization() {
 fn test_context_pruned_serialization() {
     let event = AiEvent::ContextPruned {
         messages_removed: 5,
+        tokens_freed: 15000,
         utilization_before: 0.95,
         utilization_after: 0.75,
     };
@@ -665,6 +666,7 @@ fn test_all_events_roundtrip() {
         },
         AiEvent::ContextPruned {
             messages_removed: 5,
+            tokens_freed: 15000,
             utilization_before: 0.95,
             utilization_after: 0.75,
         },

--- a/backend/crates/qbit/tests/snapshots/ai_events_characterization__context_pruned_serialization.snap
+++ b/backend/crates/qbit/tests/snapshots/ai_events_characterization__context_pruned_serialization.snap
@@ -5,6 +5,7 @@ expression: json
 {
   "type": "context_pruned",
   "messages_removed": 5,
+  "tokens_freed": 15000,
   "utilization_before": 0.95,
   "utilization_after": 0.75
 }


### PR DESCRIPTION
## Summary
1. Add proper error handling when the LLM stream fails to start
2. Fix the `ContextPruned` event to include `tokens_freed` for the notification

## API Error Notifications
When API errors occur (like "Prompt is too long" / 413), the error was only logged to the backend. Now user-friendly error messages are emitted:

| Error Pattern | Type | User Message |
|--------------|------|--------------|
| "Prompt is too long", "too many tokens", "context_length_exceeded" | `context_overflow` | "The conversation is too long. Please start a new chat or clear some history." |
| "rate_limit", 429 | `rate_limit` | "Rate limit exceeded. Please wait a moment and try again." |
| "authentication", 401, 403 | `authentication` | "Authentication failed. Please check your API credentials." |
| "timeout", "timed out" | `timeout` | "Request timed out. Please try again." |
| Other errors | `api_error` | Raw error message |

## Context Pruning Notification Fix
The frontend was expecting `tokens_freed` in the `ContextPruned` event but the backend wasn't sending it. Now the field is included so the notification properly shows "Removed X messages to free up Y tokens."

## Test plan
- [x] `just check` passes
- [ ] Test with a conversation that exceeds context length
- [ ] Verify error notification appears in the UI
- [ ] Verify pruning notification shows tokens freed