### PR TITLE
test(tool-call-display): ensure tool preview shows last 3 in order

### DIFF
--- a/frontend/components/ToolCallDisplay/MainToolGroup.test.tsx
+++ b/frontend/components/ToolCallDisplay/MainToolGroup.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MainToolGroup } from "./MainToolGroup";
+
+describe("MainToolGroup", () => {
+  it("shows the 3 most recent tool calls in chronological order (oldest → newest)", () => {
+    const tools = Array.from({ length: 10 }, (_, i) => {
+      const n = i + 1;
+      return {
+        id: `tool-${n}`,
+        name: "read_file",
+        status: "completed",
+        startedAt: new Date(2020, 0, n).toISOString(),
+        args: { path: `tool-${n}` },
+      };
+    });
+
+    render(
+      <MainToolGroup
+        tools={tools as any}
+        onViewToolDetails={vi.fn()}
+        onViewGroupDetails={vi.fn()}
+      />
+    );
+
+    // The preview should include only the last 3 tools: 8, 9, 10
+    // and display them in that order.
+    const rows = screen.getAllByText("read_file");
+    expect(rows).toHaveLength(3);
+
+    // Use the tool IDs as the primaryArg so we can assert ordering from rendered text.
+    const text = screen.getByText("tool-8").closest("div")?.parentElement?.parentElement?.textContent ?? "";
+
+    const idx8 = text.indexOf("tool-8");
+    const idx9 = text.indexOf("tool-9");
+    const idx10 = text.indexOf("tool-10");
+
+    expect(idx8).toBeGreaterThanOrEqual(0);
+    expect(idx9).toBeGreaterThan(idx8);
+    expect(idx10).toBeGreaterThan(idx9);
+  });
+});

--- a/frontend/components/ToolCallDisplay/MainToolGroup.tsx
+++ b/frontend/components/ToolCallDisplay/MainToolGroup.tsx
@@ -104,9 +104,10 @@ export function MainToolGroup({
   const StatusIcon = status.icon;
   const { label: durationLabel } = computeToolGroupDuration(tools);
 
-  // Get 3 most recent tools (by startedAt desc)
+  // Get 3 most recent tools, but display them oldest → newest within the preview
+  // (e.g. for 8,9,10 we want to show 8 then 9 then 10)
   const sortedDesc = sortToolsByStartedAtDesc(tools);
-  const previewTools = sortedDesc.slice(0, 3);
+  const previewTools = sortedDesc.slice(0, 3).reverse();
   const hiddenCount = tools.length - 3;
 
   return (


### PR DESCRIPTION
Add a MainToolGroup test asserting the preview renders only the 3 most recent tool calls and in chronological order (oldest → newest). Update previewTools selection to reverse the latest-3 slice so the UI displays 8, 9, 10 in that order.
