### PR TITLE
feat: add LLM API request/response logging

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5419,6 +5419,7 @@ dependencies = [
  "portable-pty 0.8.1",
  "proptest",
  "qbit-ai",
+ "qbit-api-logger",
  "qbit-artifacts",
  "qbit-cli-output",
  "qbit-context",
@@ -5511,6 +5512,19 @@ dependencies = [
  "tracing",
  "uuid",
  "vtcode-core",
+]
+
+[[package]]
+name = "qbit-api-logger"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -6610,6 +6624,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 1.4.0",
+ "qbit-api-logger",
  "reqwest 0.12.28",
  "rig-core 0.27.0",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/rig-anthropic-vertex",
     "crates/rig-zai",
     "crates/qbit-ast-grep",
+    "crates/qbit-api-logger",
 ]
 resolver = "2"
 

--- a/backend/crates/qbit-api-logger/Cargo.toml
+++ b/backend/crates/qbit-api-logger/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "qbit-api-logger"
+version = "0.1.0"
+edition = "2021"
+description = "Raw LLM API request/response file logger for Qbit"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+once_cell = "1.19"
+parking_lot = "0.12"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/backend/crates/qbit-api-logger/src/lib.rs
+++ b/backend/crates/qbit-api-logger/src/lib.rs
@@ -1,0 +1,354 @@
+//! Raw LLM API request/response file logger.
+//!
+//! This module provides a global singleton logger for capturing raw LLM API
+//! request/response JSON data. When enabled, it writes JSONL-formatted logs
+//! to session-specific files in the configured directory.
+//!
+//! # Usage
+//!
+//! Configure the logger at session initialization:
+//! ```ignore
+//! use qbit_api_logger::API_LOGGER;
+//!
+//! API_LOGGER.configure(true, PathBuf::from("./logs/api"), "session-123".to_string());
+//! ```
+//!
+//! Log from provider code:
+//! ```ignore
+//! API_LOGGER.log_request("zai", "glm-4.7", &request_json);
+//! API_LOGGER.log_sse_chunk("zai", &raw_sse_data);
+//! API_LOGGER.log_response("zai", "glm-4.7", &response_json);
+//! ```
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use chrono::Utc;
+use parking_lot::RwLock;
+use serde::Serialize;
+
+/// Global API logging state (thread-safe singleton pattern)
+pub static API_LOGGER: once_cell::sync::Lazy<ApiLoggerState> =
+    once_cell::sync::Lazy::new(ApiLoggerState::default);
+
+/// Thread-safe API logger state.
+pub struct ApiLoggerState {
+    enabled: AtomicBool,
+    extract_raw_sse: AtomicBool,
+    log_dir: RwLock<Option<PathBuf>>,
+    session_id: RwLock<Option<String>>,
+}
+
+impl Default for ApiLoggerState {
+    fn default() -> Self {
+        Self {
+            enabled: AtomicBool::new(false),
+            extract_raw_sse: AtomicBool::new(false),
+            log_dir: RwLock::new(None),
+            session_id: RwLock::new(None),
+        }
+    }
+}
+
+/// A single log entry in JSONL format.
+#[derive(Debug, Serialize)]
+struct LogEntry<'a> {
+    timestamp: String,
+    #[serde(rename = "type")]
+    entry_type: &'a str,
+    provider: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<&'a serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    raw: Option<&'a str>,
+}
+
+impl ApiLoggerState {
+    /// Configure the API logger.
+    ///
+    /// # Arguments
+    /// * `enabled` - Whether logging is enabled
+    /// * `extract_raw_sse` - Whether to parse SSE chunks as JSON instead of escaped strings
+    /// * `log_dir` - Directory to write log files (e.g., `./logs/api`)
+    /// * `session_id` - Current session ID for log file naming
+    pub fn configure(
+        &self,
+        enabled: bool,
+        extract_raw_sse: bool,
+        log_dir: PathBuf,
+        session_id: String,
+    ) {
+        self.enabled.store(enabled, Ordering::SeqCst);
+        self.extract_raw_sse
+            .store(extract_raw_sse, Ordering::SeqCst);
+        *self.log_dir.write() = Some(log_dir);
+        *self.session_id.write() = Some(session_id);
+
+        if enabled {
+            tracing::info!(
+                "API logging enabled (extract_raw_sse={}), logs will be written to ./logs/api/",
+                extract_raw_sse
+            );
+        }
+    }
+
+    /// Check if API logging is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::SeqCst)
+    }
+
+    /// Check if raw SSE extraction is enabled.
+    pub fn should_extract_raw_sse(&self) -> bool {
+        self.extract_raw_sse.load(Ordering::SeqCst)
+    }
+
+    /// Log a raw request JSON to file.
+    ///
+    /// Call this before sending the HTTP request to the LLM API.
+    pub fn log_request(&self, provider: &str, model: &str, request_json: &serde_json::Value) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let entry = LogEntry {
+            timestamp: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            entry_type: "request",
+            provider,
+            model: Some(model),
+            data: Some(request_json),
+            raw: None,
+        };
+
+        self.write_entry(&entry);
+    }
+
+    /// Log a raw SSE chunk to file.
+    ///
+    /// Call this for each SSE chunk received from the LLM API during streaming.
+    /// If `extract_raw_sse` is enabled, the chunk will be parsed as JSON and
+    /// logged as a structured object instead of an escaped string.
+    pub fn log_sse_chunk(&self, provider: &str, chunk: &str) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        if self.should_extract_raw_sse() {
+            // Try to parse the chunk as JSON and log it as structured data
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(chunk) {
+                let entry = LogEntry {
+                    timestamp: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                    entry_type: "sse_chunk",
+                    provider,
+                    model: None,
+                    data: Some(&parsed),
+                    raw: None,
+                };
+                self.write_entry(&entry);
+                return;
+            }
+            // Fall through to raw logging if parsing fails
+        }
+
+        let entry = LogEntry {
+            timestamp: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            entry_type: "sse_chunk",
+            provider,
+            model: None,
+            data: None,
+            raw: Some(chunk),
+        };
+
+        self.write_entry(&entry);
+    }
+
+    /// Log accumulated response data to file.
+    ///
+    /// Call this after the streaming response is complete with summary data.
+    pub fn log_response(&self, provider: &str, model: &str, response_json: &serde_json::Value) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let entry = LogEntry {
+            timestamp: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            entry_type: "response",
+            provider,
+            model: Some(model),
+            data: Some(response_json),
+            raw: None,
+        };
+
+        self.write_entry(&entry);
+    }
+
+    /// Log an error that occurred during API interaction.
+    pub fn log_error(&self, provider: &str, error: &str) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let error_json = serde_json::json!({ "error": error });
+        let entry = LogEntry {
+            timestamp: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            entry_type: "error",
+            provider,
+            model: None,
+            data: Some(&error_json),
+            raw: None,
+        };
+
+        self.write_entry(&entry);
+    }
+
+    /// Log a stream completion event (for tracking when streams end normally vs abnormally).
+    pub fn log_stream_end(&self, provider: &str, reason: &str) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let reason_json = serde_json::json!({ "reason": reason });
+        let entry = LogEntry {
+            timestamp: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            entry_type: "stream_end",
+            provider,
+            model: None,
+            data: Some(&reason_json),
+            raw: None,
+        };
+
+        self.write_entry(&entry);
+    }
+
+    fn write_entry(&self, entry: &LogEntry) {
+        let log_dir = self.log_dir.read();
+        let session_id = self.session_id.read();
+
+        let Some(dir) = log_dir.as_ref() else {
+            return;
+        };
+        let session = session_id.as_deref().unwrap_or("default");
+
+        // Create directory if needed
+        if let Err(e) = fs::create_dir_all(dir) {
+            tracing::warn!("Failed to create API log directory: {}", e);
+            return;
+        }
+
+        let file_path = dir.join(format!("{}.jsonl", session));
+
+        let json_line = match serde_json::to_string(entry) {
+            Ok(json) => json,
+            Err(e) => {
+                tracing::warn!("Failed to serialize API log entry: {}", e);
+                return;
+            }
+        };
+
+        match OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&file_path)
+        {
+            Ok(mut file) => {
+                if let Err(e) = writeln!(file, "{}", json_line) {
+                    tracing::warn!("Failed to write API log entry: {}", e);
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to open API log file {:?}: {}", file_path, e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_logging_when_disabled() {
+        // When disabled, logging should be a no-op
+        let logger = ApiLoggerState::default();
+        assert!(!logger.is_enabled());
+
+        // These should not panic even without configuration
+        logger.log_request("test", "model", &serde_json::json!({}));
+        logger.log_sse_chunk("test", "data: test");
+        logger.log_response("test", "model", &serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_logging_when_enabled() {
+        let temp_dir = tempdir().unwrap();
+        let log_dir = temp_dir.path().join("logs/api");
+
+        let logger = ApiLoggerState::default();
+        logger.configure(true, false, log_dir.clone(), "test-session".to_string());
+
+        assert!(logger.is_enabled());
+        assert!(!logger.should_extract_raw_sse());
+
+        // Log some entries
+        logger.log_request("zai", "glm-4.7", &serde_json::json!({"messages": []}));
+        logger.log_sse_chunk("zai", "{\"choices\":[]}");
+        logger.log_response("zai", "glm-4.7", &serde_json::json!({"done": true}));
+
+        // Check file was created
+        let log_file = log_dir.join("test-session.jsonl");
+        assert!(log_file.exists());
+
+        // Check content
+        let content = fs::read_to_string(&log_file).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3);
+
+        // Verify JSON structure
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["type"], "request");
+        assert_eq!(first["provider"], "zai");
+
+        // Verify SSE chunk is logged as raw string
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["type"], "sse_chunk");
+        assert!(second.get("raw").is_some());
+        assert!(second.get("data").is_none());
+    }
+
+    #[test]
+    fn test_logging_with_extract_raw_sse() {
+        let temp_dir = tempdir().unwrap();
+        let log_dir = temp_dir.path().join("logs/api");
+
+        let logger = ApiLoggerState::default();
+        logger.configure(
+            true,
+            true,
+            log_dir.clone(),
+            "test-session-extract".to_string(),
+        );
+
+        assert!(logger.is_enabled());
+        assert!(logger.should_extract_raw_sse());
+
+        // Log SSE chunk with valid JSON
+        logger.log_sse_chunk("zai", "{\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}");
+
+        // Check file was created
+        let log_file = log_dir.join("test-session-extract.jsonl");
+        assert!(log_file.exists());
+
+        // Check content - should have parsed data, not raw string
+        let content = fs::read_to_string(&log_file).unwrap();
+        let entry: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(entry["type"], "sse_chunk");
+        assert!(entry.get("data").is_some());
+        assert!(entry.get("raw").is_none());
+        assert_eq!(entry["data"]["choices"][0]["delta"]["content"], "hello");
+    }
+}

--- a/backend/crates/qbit-settings/src/schema.rs
+++ b/backend/crates/qbit-settings/src/schema.rs
@@ -596,6 +596,14 @@ pub struct AdvancedSettings {
 
     /// Log level
     pub log_level: LogLevel,
+
+    /// Enable LLM API request/response logging to ./logs/api/
+    /// When enabled, raw JSON request/response data is logged per session
+    pub enable_llm_api_logs: bool,
+
+    /// Extract and parse the raw SSE JSON instead of logging escaped strings
+    /// When enabled, SSE chunks are logged as parsed JSON objects
+    pub extract_raw_sse: bool,
 }
 
 /// Code indexer settings.

--- a/backend/crates/qbit-settings/src/template.toml
+++ b/backend/crates/qbit-settings/src/template.toml
@@ -217,6 +217,14 @@ enable_experimental = false
 # Debug logging level: "error" | "warn" | "info" | "debug" | "trace"
 log_level = "info"
 
+# Log raw LLM API request/response JSON to ./logs/api/
+# Useful for debugging provider issues (e.g., random stops, malformed responses)
+# enable_llm_api_logs = false
+
+# Extract and parse the raw SSE JSON instead of logging escaped strings
+# When enabled, SSE chunks are logged as parsed JSON objects instead of escaped strings
+# extract_raw_sse = false
+
 # =============================================================================
 # Context Window Management
 # =============================================================================

--- a/backend/crates/qbit/Cargo.toml
+++ b/backend/crates/qbit/Cargo.toml
@@ -45,6 +45,7 @@ qbit-planner = { path = "../qbit-planner" }
 qbit-artifacts = { path = "../qbit-artifacts" }
 qbit-llm-providers = { path = "../qbit-llm-providers" }
 qbit-synthesis = { path = "../qbit-synthesis" }
+qbit-api-logger = { path = "../qbit-api-logger" }
 
 # Domain crate
 qbit-ai = { path = "../qbit-ai" }

--- a/backend/crates/qbit/src/ai/commands/core.rs
+++ b/backend/crates/qbit/src/ai/commands/core.rs
@@ -542,6 +542,19 @@ pub async fn init_ai_session(
 
     configure_bridge(&mut bridge, &state).await;
 
+    // Configure API logger if enabled in settings
+    let settings = state.settings_manager.get().await;
+    if settings.advanced.enable_llm_api_logs {
+        let workspace = bridge.workspace().read().await.clone();
+        let log_dir = workspace.join("logs").join("api");
+        qbit_api_logger::API_LOGGER.configure(
+            true,
+            settings.advanced.extract_raw_sse,
+            log_dir,
+            session_id.clone(),
+        );
+    }
+
     // Set the session_id for event routing (for per-tab AI event isolation)
     bridge.set_event_session_id(session_id.clone());
 

--- a/backend/crates/rig-zai/Cargo.toml
+++ b/backend/crates/rig-zai/Cargo.toml
@@ -30,5 +30,8 @@ thiserror.workspace = true
 tracing.workspace = true
 bytes.workspace = true
 
+# API logging
+qbit-api-logger = { path = "../qbit-api-logger" }
+
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/frontend/components/Settings/AdvancedSettings.tsx
+++ b/frontend/components/Settings/AdvancedSettings.tsx
@@ -88,6 +88,40 @@ export function AdvancedSettings({
         />
       </div>
 
+      {/* LLM API Logs */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <label htmlFor="advanced-llm-api-logs" className="text-sm font-medium text-foreground">
+            LLM API Logs
+          </label>
+          <p className="text-xs text-muted-foreground">
+            Log raw API request/response to ./logs/api/
+          </p>
+        </div>
+        <Switch
+          id="advanced-llm-api-logs"
+          checked={settings.enable_llm_api_logs}
+          onCheckedChange={(checked) => onChange({ ...settings, enable_llm_api_logs: checked })}
+        />
+      </div>
+
+      {/* Extract Raw SSE */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <label htmlFor="advanced-extract-raw-sse" className="text-sm font-medium text-foreground">
+            Extract Raw SSE Property
+          </label>
+          <p className="text-xs text-muted-foreground">
+            Parse SSE chunks as JSON objects instead of escaped strings
+          </p>
+        </div>
+        <Switch
+          id="advanced-extract-raw-sse"
+          checked={settings.extract_raw_sse}
+          onCheckedChange={(checked) => onChange({ ...settings, extract_raw_sse: checked })}
+        />
+      </div>
+
       {/* Privacy Section */}
       <div className="space-y-4 p-4 rounded-lg bg-muted border border-[var(--border-medium)]">
         <h4 className="text-sm font-medium text-accent">Privacy</h4>

--- a/frontend/lib/settings.ts
+++ b/frontend/lib/settings.ts
@@ -272,6 +272,10 @@ export interface PrivacySettings {
 export interface AdvancedSettings {
   enable_experimental: boolean;
   log_level: "error" | "warn" | "info" | "debug" | "trace";
+  /** Log raw LLM API request/response JSON to ./logs/api/ */
+  enable_llm_api_logs: boolean;
+  /** Extract and parse raw SSE JSON instead of logging escaped strings */
+  extract_raw_sse: boolean;
 }
 
 /**
@@ -493,6 +497,8 @@ export const DEFAULT_SETTINGS: QbitSettings = {
   advanced: {
     enable_experimental: false,
     log_level: "info",
+    enable_llm_api_logs: false,
+    extract_raw_sse: false,
   },
   sidecar: {
     enabled: false,


### PR DESCRIPTION
## Summary
- Add `qbit-api-logger` crate for logging raw LLM API requests, SSE chunks, and responses to JSONL files
- Integrate logging with the `rig-zai` provider to capture Z.AI GLM API traffic
- Add settings (`enable_llm_api_logs`, `extract_raw_sse`) with frontend UI toggles in Advanced Settings

This is useful for debugging provider issues like random stops, malformed responses, or unexpected behavior from LLM APIs.

## Test plan
- [ ] Enable "LLM API Logs" in Advanced Settings
- [ ] Start a new AI session and send a message using Z.AI provider
- [ ] Verify log file created at `./logs/api/{session_id}.jsonl`
- [ ] Check that requests, SSE chunks, and response summaries are logged
- [ ] Test "Extract Raw SSE" option parses chunks as JSON objects instead of escaped strings