### PR TITLE
fix(git): show diff for untracked files in GitPanel

### DIFF
--- a/frontend/lib/tauri.ts
+++ b/frontend/lib/tauri.ts
@@ -199,3 +199,13 @@ export async function gitPush(
 export async function readFileAsBase64(path: string): Promise<string> {
   return invoke("read_file_as_base64", { path });
 }
+
+/**
+ * Read a text file's contents.
+ * Used for displaying untracked file diffs.
+ */
+export async function readTextFile(workingDirectory: string, relativePath: string): Promise<string> {
+  // Use the read_prompt command which reads file contents
+  const fullPath = `${workingDirectory}/${relativePath}`;
+  return invoke("read_prompt", { path: fullPath });
+}


### PR DESCRIPTION
## Summary
- Fix untracked files showing "(no diff)" in the Git Panel diff viewer
- Detect untracked files and read their contents directly to generate a synthetic diff
- All lines in untracked files are displayed as additions (green)

## Problem
When clicking on an untracked file in the Git Panel, the diff viewer showed "(no diff)" because `git diff -- <file>` returns empty output for untracked files.

## Solution
- Added `readTextFile` helper to read file contents via Tauri
- Updated `handleDiff` to accept the full `GitChange` object instead of just the path
- For files with `kind === "untracked"`, generate a synthetic diff showing all lines as additions
- The synthetic diff format matches what `git diff --no-index /dev/null <file>` produces

## Test plan
- [ ] Open Git Panel with untracked files present
- [ ] Click on an untracked file
- [ ] Verify the diff viewer shows all file contents as additions (green lines)
- [ ] Verify tracked modified files still show normal diffs
- [ ] Verify staged files still show diffs correctly