### PR TITLE
fix(sub-agents): include thinking blocks in conversation history

### DIFF
--- a/backend/crates/qbit-llm-providers/src/model_capabilities.rs
+++ b/backend/crates/qbit-llm-providers/src/model_capabilities.rs
@@ -196,7 +196,7 @@ fn detect_thinking_history_support(provider_name: &str, model_name: &str) -> boo
 
     match provider_name {
         // All Anthropic models support extended thinking
-        "anthropic" | "vertex_ai_anthropic" | "vertex_ai" => true,
+        "anthropic" | "anthropic_vertex" | "vertex_ai_anthropic" | "vertex_ai" => true,
 
         // OpenAI Responses API: ALWAYS preserve reasoning history.
         // The Responses API generates internal reasoning IDs (rs_...) that function calls


### PR DESCRIPTION
## Summary

- Fix sub-agent streaming to include thinking blocks in conversation history
- When extended thinking is enabled (Vertex AI with Claude), the Anthropic API requires assistant messages to start with a thinking block before any tool_use blocks
- Sub-agents were not including these blocks, causing the error: `"Expected 'thinking' or 'redacted_thinking', but found 'tool_use'"`

## Changes

- **executor.rs**: Add thinking state tracking (signature, ID) during stream processing
- **executor.rs**: Extract `build_assistant_content()` helper function ensuring correct content ordering (Reasoning → Text → ToolCalls)
- **model_capabilities.rs**: Add `anthropic_vertex` provider alias for thinking history detection
- **executor.rs**: Add 17 unit tests covering thinking block handling and model capability detection

## Test plan

- [x] All 39 unit tests pass in qbit-sub-agents
- [x] All 15 unit tests pass in qbit-llm-providers
- [x] Full workspace build succeeds
- [ ] Manual test with Vertex AI Claude model invoking sub-agents with tool calls