### PR TITLE
fix: update e2e test regex and add auto-approve safeguards

### DIFF
--- a/e2e/provider-visibility-toggle.spec.ts
+++ b/e2e/provider-visibility-toggle.spec.ts
@@ -153,7 +153,10 @@ test.describe("Provider Visibility Toggle - Settings UI", () => {
     await expect(page.locator("text=Default Model")).toBeVisible();
 
     // Verify at least one provider is listed (e.g., Anthropic)
-    await expect(page.locator("text=Anthropic")).toBeVisible();
+    // Use negative lookbehind to avoid matching "Z.AI (Anthropic)"
+    await expect(
+      page.getByRole("button", { name: /(?<!\()Anthropic.*Not configured/ })
+    ).toBeVisible();
 
     // Close settings
     await closeSettings(page);

--- a/frontend/mocks.ts
+++ b/frontend/mocks.ts
@@ -373,6 +373,8 @@ let mockSettings = {
   ai: {
     default_provider: "vertex_ai",
     default_model: "claude-opus-4-5@20251101",
+    default_reasoning_effort: undefined,
+    sub_agent_models: {},
     vertex_ai: {
       credentials_path: "/mock/path/to/credentials.json",
       project_id: "mock-project-id",
@@ -411,6 +413,10 @@ let mockSettings = {
     zai: {
       api_key: null,
       use_coding_endpoint: true,
+      show_in_selector: true,
+    },
+    zai_anthropic: {
+      api_key: null,
       show_in_selector: true,
     },
   },


### PR DESCRIPTION
## Summary
- Fix `provider-visibility-toggle` e2e test failing due to new Z.AI (Anthropic) provider matching the Anthropic regex
- Add frontend safeguard for auto-approve mode in `useAiEvents` hook
- Reduce telemetry log verbosity by disabling span events and filtering verbose sub-agent executor logs
- Update browser mocks with Z.AI provider settings for e2e testing

## Test plan
- [x] All 154 e2e tests pass (`just test-e2e`)
- [ ] Verify auto-approve mode works correctly in the app
- [ ] Confirm reduced log verbosity in `~/.qbit/backend.log`