### PR TITLE
fix(executor): ensure sub-agent spans are parented correctly

### DIFF
--- a/backend/crates/qbit-sub-agents/src/executor.rs
+++ b/backend/crates/qbit-sub-agents/src/executor.rs
@@ -93,8 +93,12 @@ where
     let start_time = std::time::Instant::now();
     let agent_id = &agent_def.id;
 
-    // Create root span for sub-agent execution (Langfuse observability)
+    // Create span for sub-agent execution (Langfuse observability)
+    //
+    // IMPORTANT: Explicitly parent this span to the current span so sub-agent work
+    // is attached to the main trace even when crossing async/task boundaries.
     let sub_agent_span = tracing::info_span!(
+        parent: &tracing::Span::current(),
         "sub_agent",
         "langfuse.observation.type" = "agent",
         "langfuse.session.id" = ctx.session_id.unwrap_or(""),


### PR DESCRIPTION
## Summary
- Add explicit parent to sub-agent execution spans to maintain trace continuity
- Ensures sub-agent work is properly attached to the main trace across async/task boundaries
- Improves Langfuse observability by preserving span hierarchy

## Changes
- Modified `backend/crates/qbit-sub-agents/src/executor.rs` to explicitly parent sub-agent spans to the current span
- Added documentation explaining the importance of span parenting for observability

## Test plan
- [ ] Verify sub-agent execution traces appear correctly in Langfuse
- [ ] Confirm span hierarchy is maintained across async boundaries
- [ ] Check that existing e2e tests pass