### PR TITLE
fix: add UTF-8 safe string truncation to prevent panics

### DIFF
--- a/backend/crates/qbit-ai/src/agentic_loop.rs
+++ b/backend/crates/qbit-ai/src/agentic_loop.rs
@@ -37,6 +37,7 @@ use qbit_context::{CompactionState, ContextManager};
 use qbit_core::events::AiEvent;
 use qbit_core::hitl::{ApprovalDecision, RiskLevel};
 use qbit_core::runtime::QbitRuntime;
+use qbit_core::utils::truncate_str;
 use qbit_hitl::ApprovalRecorder;
 use qbit_indexer::IndexerState;
 use qbit_llm_providers::ModelCapabilities;
@@ -384,9 +385,9 @@ fn estimate_message_chars(message: &Message) -> usize {
                             })
                             .sum::<usize>()
                 }
-                UserContent::Image(_) => 1000,    // Rough estimate for images
-                UserContent::Audio(_) => 5000,    // Rough estimate for audio
-                UserContent::Video(_) => 10000,   // Rough estimate for video
+                UserContent::Image(_) => 1000, // Rough estimate for images
+                UserContent::Audio(_) => 5000, // Rough estimate for audio
+                UserContent::Video(_) => 10000, // Rough estimate for video
                 UserContent::Document(_) => 5000, // Rough estimate for documents
             })
             .sum(),
@@ -1985,10 +1986,10 @@ where
             let tool_call_id = tool_call.call_id.clone().unwrap_or_else(|| tool_id.clone());
 
             // Create span for tool call (child of llm_span since tools execute during LLM iteration)
-            // Truncate args for span to avoid huge spans
+            // Truncate args for span to avoid huge spans (use truncate_str for UTF-8 safety)
             let args_str = serde_json::to_string(&tool_args).unwrap_or_default();
             let args_for_span = if args_str.len() > 1000 {
-                format!("{}... [truncated]", &args_str[..1000])
+                format!("{}... [truncated]", truncate_str(&args_str, 1000))
             } else {
                 args_str
             };
@@ -2067,10 +2068,10 @@ where
                 success: false,
             });
 
-            // Record tool result in span
+            // Record tool result in span (use truncate_str for UTF-8 safety)
             let result_str = serde_json::to_string(&result.value).unwrap_or_default();
             let result_for_span = if result_str.len() > 1000 {
-                format!("{}... [truncated]", &result_str[..1000])
+                format!("{}... [truncated]", truncate_str(&result_str, 1000))
             } else {
                 result_str
             };

--- a/backend/crates/qbit-ai/src/transcript.rs
+++ b/backend/crates/qbit-ai/src/transcript.rs
@@ -486,11 +486,7 @@ pub fn save_summarizer_input(
 /// # Errors
 ///
 /// Returns an error if the directory cannot be created or the file cannot be written.
-pub fn save_summary(
-    base_dir: &Path,
-    session_id: &str,
-    summary: &str,
-) -> anyhow::Result<PathBuf> {
+pub fn save_summary(base_dir: &Path, session_id: &str, summary: &str) -> anyhow::Result<PathBuf> {
     // Ensure the directory exists
     std::fs::create_dir_all(base_dir)?;
 

--- a/backend/crates/qbit-context/src/context_manager.rs
+++ b/backend/crates/qbit-context/src/context_manager.rs
@@ -1501,7 +1501,10 @@ mod compaction_tests {
 
         let check = manager.should_compact(&state, "claude-3-5-sonnet");
 
-        assert!(!check.should_compact, "50% usage should not trigger compaction");
+        assert!(
+            !check.should_compact,
+            "50% usage should not trigger compaction"
+        );
         assert_eq!(check.current_tokens, 100_000);
         assert_eq!(check.max_tokens, 200_000);
         assert!((check.threshold - 0.80).abs() < f64::EPSILON);
@@ -1537,7 +1540,10 @@ mod compaction_tests {
 
         let check = manager.should_compact(&state, "claude-3-5-sonnet");
 
-        assert!(!check.should_compact, "Should not compact if already attempted");
+        assert!(
+            !check.should_compact,
+            "Should not compact if already attempted"
+        );
         assert_eq!(check.reason, "Already attempted this turn");
     }
 
@@ -1685,7 +1691,10 @@ mod compaction_tests {
         let check = manager.should_compact(&state, "claude-3-5-sonnet");
 
         assert!(check.should_compact);
-        assert!(check.using_heuristic, "Should indicate heuristic is being used");
+        assert!(
+            check.using_heuristic,
+            "Should indicate heuristic is being used"
+        );
     }
 
     #[test]

--- a/backend/crates/qbit-core/src/lib.rs
+++ b/backend/crates/qbit-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod tool;
 pub mod hitl;
 pub mod plan;
 pub mod prompt;
+pub mod utils;
 
 // Re-exports
 pub use events::*; // Re-export all event types

--- a/backend/crates/qbit-core/src/utils.rs
+++ b/backend/crates/qbit-core/src/utils.rs
@@ -1,0 +1,121 @@
+//! Utility functions for common operations.
+
+/// Truncates a string to at most `max_bytes` bytes, respecting UTF-8 character boundaries.
+///
+/// This function ensures the truncation point falls on a valid UTF-8 character boundary,
+/// preventing panics that would occur from slicing in the middle of a multi-byte character.
+///
+/// # Arguments
+/// * `s` - The string to truncate
+/// * `max_bytes` - Maximum number of bytes in the result
+///
+/// # Returns
+/// A string slice that is at most `max_bytes` bytes long, ending at a valid character boundary.
+///
+/// # Example
+/// ```
+/// # use qbit_core::utils::truncate_str;
+/// let s = "Hello, 世界!"; // "世" and "界" are 3 bytes each
+/// assert_eq!(truncate_str(s, 10), "Hello, 世");
+/// assert_eq!(truncate_str(s, 7), "Hello, ");
+/// assert_eq!(truncate_str(s, 100), s); // No truncation needed
+/// ```
+pub fn truncate_str(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+
+    // Find the last character boundary at or before max_bytes
+    // char_indices() yields (byte_position, char) for each character
+    let mut end = 0;
+    for (idx, _) in s.char_indices() {
+        if idx > max_bytes {
+            break;
+        }
+        end = idx;
+    }
+
+    // Handle edge case: if first char is already beyond max_bytes, return empty
+    // Also handle the case where we stopped at a boundary that fits
+    if end == 0 && s.len() > max_bytes {
+        // Check if first character fits
+        if let Some((first_char_end, _)) = s.char_indices().nth(1) {
+            if first_char_end <= max_bytes {
+                end = first_char_end;
+            }
+        } else if s.len() <= max_bytes {
+            // Single character string that fits
+            return s;
+        }
+    }
+
+    // Get the byte position of the next character (or end of string)
+    // to include the character at position `end`
+    let actual_end = s[end..]
+        .char_indices()
+        .nth(1)
+        .map(|(idx, _)| end + idx)
+        .unwrap_or(s.len());
+
+    if actual_end <= max_bytes {
+        &s[..actual_end]
+    } else {
+        &s[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_str_ascii() {
+        let s = "Hello, World!";
+        assert_eq!(truncate_str(s, 5), "Hello");
+        assert_eq!(truncate_str(s, 7), "Hello, ");
+        assert_eq!(truncate_str(s, 100), s);
+        assert_eq!(truncate_str(s, 0), "");
+    }
+
+    #[test]
+    fn test_truncate_str_unicode() {
+        // Each CJK character is 3 bytes
+        let s = "Hello, 世界!";
+        assert_eq!(truncate_str(s, 10), "Hello, 世"); // 7 + 3 = 10
+        assert_eq!(truncate_str(s, 9), "Hello, "); // Can't fit 世 (3 bytes)
+        assert_eq!(truncate_str(s, 8), "Hello, "); // Can't fit 世 (3 bytes)
+        assert_eq!(truncate_str(s, 7), "Hello, ");
+    }
+
+    #[test]
+    fn test_truncate_str_box_drawing() {
+        // Box drawing character ─ is 3 bytes (the one that caused the original panic)
+        let s = "Result: ─────";
+        assert_eq!(truncate_str(s, 8), "Result: ");
+        assert_eq!(truncate_str(s, 11), "Result: ─"); // 8 + 3 = 11
+        assert_eq!(truncate_str(s, 10), "Result: "); // 8 + 2 not enough for ─
+    }
+
+    #[test]
+    fn test_truncate_str_emoji() {
+        // Emoji can be 4 bytes
+        let s = "Hi 👋 there";
+        assert_eq!(truncate_str(s, 3), "Hi ");
+        assert_eq!(truncate_str(s, 7), "Hi 👋"); // 3 + 4 = 7
+        assert_eq!(truncate_str(s, 6), "Hi "); // Can't fit emoji
+    }
+
+    #[test]
+    fn test_truncate_str_empty() {
+        assert_eq!(truncate_str("", 10), "");
+        assert_eq!(truncate_str("", 0), "");
+    }
+
+    #[test]
+    fn test_truncate_str_exact_boundary() {
+        let s = "abc";
+        assert_eq!(truncate_str(s, 3), "abc");
+        assert_eq!(truncate_str(s, 2), "ab");
+        assert_eq!(truncate_str(s, 1), "a");
+    }
+}

--- a/backend/crates/qbit-sub-agents/src/executor.rs
+++ b/backend/crates/qbit-sub-agents/src/executor.rs
@@ -25,6 +25,7 @@ use qbit_udiff::{ApplyResult, UdiffApplier, UdiffParser};
 use crate::definition::{SubAgentContext, SubAgentDefinition, SubAgentResult};
 use crate::transcript::SubAgentTranscriptWriter;
 use qbit_core::events::AiEvent;
+use qbit_core::utils::truncate_str;
 use qbit_llm_providers::ModelCapabilities;
 
 /// Trait for providing tool definitions to the sub-agent executor.
@@ -197,9 +198,9 @@ where
         format!("{}\n\nAdditional context: {}", task, additional_context)
     };
 
-    // Record input on the sub-agent span (truncated for Langfuse)
+    // Record input on the sub-agent span (truncated for Langfuse, use truncate_str for UTF-8 safety)
     let input_truncated = if sub_prompt.len() > 1000 {
-        format!("{}...[truncated]", &sub_prompt[..1000])
+        format!("{}...[truncated]", truncate_str(&sub_prompt, 1000))
     } else {
         sub_prompt.clone()
     };
@@ -793,9 +794,9 @@ where
         );
     }
 
-    // Record output on the sub-agent span (truncated for Langfuse)
+    // Record output on the sub-agent span (truncated for Langfuse, use truncate_str for UTF-8 safety)
     let output_truncated = if final_response.len() > 1000 {
-        format!("{}...[truncated]", &final_response[..1000])
+        format!("{}...[truncated]", truncate_str(&final_response, 1000))
     } else {
         final_response.clone()
     };


### PR DESCRIPTION
## Summary
- Add `truncate_str()` utility function in `qbit-core::utils` that safely truncates strings at UTF-8 character boundaries
- Replace raw string slicing (`&s[..1000]`) with `truncate_str()` in agentic_loop.rs and executor.rs when truncating strings for telemetry spans
- Prevents panics when truncation boundary falls in the middle of multi-byte UTF-8 characters (e.g., box drawing characters ─, CJK, emoji)

## Test plan
- [x] Unit tests for `truncate_str()` covering ASCII, Unicode (CJK), box drawing chars, emoji, empty strings, and exact boundaries
- [x] `just check` passes