### PR TITLE
feat(context-compaction): implement hard reset mechanism (step 5)

### DIFF
--- a/backend/crates/qbit-ai/src/eval_support.rs
+++ b/backend/crates/qbit-ai/src/eval_support.rs
@@ -228,6 +228,7 @@ where
         session_id: None,
         transcript_writer: None,
         transcript_base_dir: None,
+        continuation_summary: None,
     };
 
     // Detect capabilities from provider/model
@@ -478,6 +479,7 @@ where
             session_id: None,
             transcript_writer: None,
             transcript_base_dir: None,
+            continuation_summary: None,
         };
 
         let loop_config = AgenticLoopConfig {

--- a/backend/crates/qbit-ai/src/lib.rs
+++ b/backend/crates/qbit-ai/src/lib.rs
@@ -39,6 +39,7 @@ mod bridge_policy;
 mod bridge_session;
 pub mod llm_client;
 pub mod memory_file;
+pub mod summarizer;
 pub mod system_prompt;
 pub mod tool_definitions;
 pub mod tool_execution;
@@ -70,6 +71,10 @@ pub use tool_execution::{
     ToolExecutionContext, ToolExecutionError, ToolExecutionResult, ToolSource,
 };
 pub use tool_provider_impl::DefaultToolProvider;
+pub use summarizer::{
+    build_summarizer_user_prompt, generate_summary, generate_summary_with_config, SummaryResponse,
+    SUMMARIZER_SYSTEM_PROMPT,
+};
 pub use transcript::{
     build_summarizer_input, format_for_summarizer, read_transcript, save_summarizer_input,
     save_summary, transcript_path, TranscriptEvent, TranscriptWriter,

--- a/backend/crates/qbit-ai/src/summarizer.rs
+++ b/backend/crates/qbit-ai/src/summarizer.rs
@@ -1,0 +1,311 @@
+//! Conversation summarizer for context compaction.
+//!
+//! This module provides a dedicated AI agent for generating conversation summaries
+//! for context compaction. It is completely isolated from the main agent and sub-agent
+//! system - it cannot be called by any other agent and has no tools. It takes a
+//! conversation transcript and generates a structured summary.
+
+use anyhow::Result;
+use qbit_llm_providers::LlmClient;
+use rig::completion::{CompletionModel as _, CompletionRequest, Message};
+use rig::message::{Text, UserContent};
+use rig::one_or_many::OneOrMany;
+use serde::{Deserialize, Serialize};
+
+/// Response from the conversation summarizer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SummaryResponse {
+    /// The generated summary containing all structured sections
+    pub summary: String,
+}
+
+/// System prompt for the conversation summarizer agent.
+pub const SUMMARIZER_SYSTEM_PROMPT: &str = r#"You are a conversation summarizer for an AI coding assistant. Your sole purpose is to analyze conversation transcripts and generate comprehensive summaries that preserve critical context for continued work.
+
+<purpose>
+Generate summaries that allow the AI assistant to seamlessly continue working on tasks after context compaction. The summary must capture everything needed to maintain continuity.
+</purpose>
+
+<format>
+Your summary MUST include these sections:
+
+## Original Request
+- What the user originally asked for
+- Key requirements and constraints mentioned
+- Any clarifications or refinements to the request
+
+## Current State
+- What has been accomplished so far
+- Files that have been created, modified, or deleted
+- Tests that pass or fail
+- Any running processes or state
+
+## Key Decisions
+- Important technical decisions made and their rationale
+- Trade-offs that were considered
+- Patterns or approaches chosen
+
+## Pending Work
+- What still needs to be done
+- Known issues or blockers
+- Next steps that were planned
+
+## Important Context
+- Error messages or issues encountered
+- Specific file paths and line numbers relevant to ongoing work
+- Dependencies or relationships between components
+- Any warnings or caveats mentioned
+</format>
+
+<output>
+Return ONLY valid JSON in this exact format:
+{"summary": "<the full summary with all sections as markdown>"}
+
+Do NOT include any text before or after the JSON. Do NOT use markdown code blocks around the JSON.
+The summary field should contain markdown-formatted text with the sections above.
+</output>
+
+<rules>
+- Be comprehensive but concise
+- Include specific file paths, function names, and code snippets when relevant
+- Preserve exact error messages if they were discussed
+- Focus on actionable information needed to continue work
+- Do not include meta-commentary about the summarization process
+- If certain sections have no content, include them with "None" or "N/A"
+</rules>"#;
+
+/// Build the user prompt for the summarizer by wrapping the conversation in XML tags.
+pub fn build_summarizer_user_prompt(conversation: &str) -> String {
+    format!(
+        r#"Summarize the following conversation for context compaction:
+
+<conversation>
+{}
+</conversation>
+
+Generate a comprehensive summary following the required format."#,
+        conversation
+    )
+}
+
+/// Generate a conversation summary using the LLM.
+///
+/// This function takes a conversation transcript and produces a structured summary
+/// suitable for context compaction.
+///
+/// # Arguments
+/// * `client` - The LLM client to use for generation
+/// * `conversation` - The conversation transcript to summarize
+///
+/// # Returns
+/// A SummaryResponse containing the structured summary
+pub async fn generate_summary(client: &LlmClient, conversation: &str) -> Result<SummaryResponse> {
+    let user_prompt = build_summarizer_user_prompt(conversation);
+
+    // Build the user message
+    let user_message = Message::User {
+        content: OneOrMany::one(UserContent::Text(Text { text: user_prompt })),
+    };
+
+    // Call the model
+    let response_text = call_summarizer_model(client, user_message).await?;
+
+    // Parse the JSON response
+    parse_summary_response(&response_text)
+}
+
+/// Internal helper that handles different LlmClient variants.
+///
+/// Uses a macro to reduce repetition across the many provider variants.
+async fn call_summarizer_model(client: &LlmClient, user_message: Message) -> Result<String> {
+    // Helper to extract text from completion response
+    fn extract_text(
+        choice: &rig::one_or_many::OneOrMany<rig::completion::AssistantContent>,
+    ) -> String {
+        let mut text = String::new();
+        for content in choice.iter() {
+            if let rig::completion::AssistantContent::Text(t) = content {
+                text.push_str(&t.text);
+            }
+        }
+        text
+    }
+
+    // Build the completion request
+    let chat_history = vec![user_message.clone()];
+    let request = CompletionRequest {
+        preamble: Some(SUMMARIZER_SYSTEM_PROMPT.to_string()),
+        chat_history: OneOrMany::many(chat_history.clone())
+            .unwrap_or_else(|_| OneOrMany::one(chat_history[0].clone())),
+        documents: vec![],
+        tools: vec![],          // No tools - this is a simple completion
+        temperature: Some(0.3), // Low temperature for consistent output
+        max_tokens: Some(4096), // Summaries can be longer than commit messages
+        tool_choice: None,
+        additional_params: None,
+    };
+
+    // Macro to reduce repetition across provider variants
+    macro_rules! complete_with_model {
+        ($model:expr) => {{
+            let response = $model.completion(request).await?;
+            Ok(extract_text(&response.choice))
+        }};
+    }
+
+    match client {
+        LlmClient::VertexAnthropic(model) => complete_with_model!(model),
+        LlmClient::RigOpenRouter(model) => complete_with_model!(model),
+        LlmClient::RigOpenAi(model) => complete_with_model!(model),
+        LlmClient::RigOpenAiResponses(model) => complete_with_model!(model),
+        LlmClient::RigAnthropic(model) => complete_with_model!(model),
+        LlmClient::RigOllama(model) => complete_with_model!(model),
+        LlmClient::RigGemini(model) => complete_with_model!(model),
+        LlmClient::RigGroq(model) => complete_with_model!(model),
+        LlmClient::RigXai(model) => complete_with_model!(model),
+        LlmClient::RigZai(model) => complete_with_model!(model),
+        LlmClient::RigZaiAnthropic(model) => complete_with_model!(model),
+        LlmClient::RigZaiAnthropicLogging(model) => complete_with_model!(model),
+        LlmClient::Mock => {
+            // Return a mock response for testing
+            Ok("{\"summary\": \"## Original Request\\nMock summary for testing.\\n\\n## Current State\\nN/A\\n\\n## Key Decisions\\nN/A\\n\\n## Pending Work\\nN/A\\n\\n## Important Context\\nN/A\"}".to_string())
+        }
+    }
+}
+
+/// Entry point for generating summaries with optional model configuration.
+///
+/// This function handles the case where a specific summarizer model may be configured
+/// in settings, falling back to the session's default client if not.
+///
+/// # Arguments
+/// * `client` - The LLM client to use (either session default or configured summarizer model)
+/// * `conversation` - The conversation transcript to summarize
+///
+/// # Returns
+/// A SummaryResponse containing the structured summary
+pub async fn generate_summary_with_config(
+    client: &LlmClient,
+    conversation: &str,
+) -> Result<SummaryResponse> {
+    // For now, this just delegates to generate_summary.
+    // In the future, this could handle loading a specific summarizer model
+    // from configuration if one is specified.
+    generate_summary(client, conversation).await
+}
+
+/// Parse the LLM response into a SummaryResponse.
+fn parse_summary_response(response: &str) -> Result<SummaryResponse> {
+    let trimmed = response.trim();
+
+    // Handle markdown code blocks if present
+    let json_str = if trimmed.starts_with("```") {
+        let without_start = trimmed
+            .strip_prefix("```json")
+            .or_else(|| trimmed.strip_prefix("```"))
+            .unwrap_or(trimmed);
+        without_start
+            .strip_suffix("```")
+            .unwrap_or(without_start)
+            .trim()
+    } else {
+        trimmed
+    };
+
+    // Try to parse as JSON
+    match serde_json::from_str::<SummaryResponse>(json_str) {
+        Ok(resp) => Ok(resp),
+        Err(json_err) => {
+            // Fallback: treat the entire response as the summary
+            tracing::warn!(
+                "Failed to parse summary as JSON: {}. Using raw response as summary.",
+                json_err
+            );
+
+            // Use the full response as the summary
+            Ok(SummaryResponse {
+                summary: trimmed.to_string(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_summary_response_deserialization() {
+        // JSON with escaped newlines - the \\n becomes \n in the JSON, which becomes actual newline in the parsed string
+        let json = "{\"summary\": \"## Original Request\\nTest summary\"}";
+        let result: SummaryResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(result.summary, "## Original Request\nTest summary");
+    }
+
+    #[test]
+    fn test_summary_response_handles_multiline() {
+        // Test with actual newlines in the JSON string value
+        let json = "{\"summary\": \"## Original Request\\nLine 1\\n\\n## Current State\\nLine 2\\nLine 3\"}";
+        let result: SummaryResponse = serde_json::from_str(json).unwrap();
+        assert!(result.summary.contains("## Original Request"));
+        assert!(result.summary.contains("## Current State"));
+        assert!(result.summary.contains("Line 1"));
+        assert!(result.summary.contains("Line 3"));
+    }
+
+    #[test]
+    fn test_summarizer_system_prompt_not_empty() {
+        assert!(!SUMMARIZER_SYSTEM_PROMPT.is_empty());
+        assert!(SUMMARIZER_SYSTEM_PROMPT.contains("## Original Request"));
+        assert!(SUMMARIZER_SYSTEM_PROMPT.contains("## Current State"));
+        assert!(SUMMARIZER_SYSTEM_PROMPT.contains("## Key Decisions"));
+        assert!(SUMMARIZER_SYSTEM_PROMPT.contains("## Pending Work"));
+        assert!(SUMMARIZER_SYSTEM_PROMPT.contains("## Important Context"));
+    }
+
+    #[test]
+    fn test_build_summarizer_prompt() {
+        let conversation = "User: Hello\nAssistant: Hi there!";
+        let prompt = build_summarizer_user_prompt(conversation);
+
+        assert!(prompt.contains("<conversation>"));
+        assert!(prompt.contains("</conversation>"));
+        assert!(prompt.contains("User: Hello"));
+        assert!(prompt.contains("Assistant: Hi there!"));
+        assert!(prompt.contains("Summarize the following conversation"));
+    }
+
+    #[test]
+    fn test_parse_summary_response_json() {
+        let response = "{\"summary\": \"## Original Request\\nBuild a feature\\n\\n## Current State\\nIn progress\"}";
+        let result = parse_summary_response(response).unwrap();
+        assert!(result.summary.contains("## Original Request"));
+        assert!(result.summary.contains("Build a feature"));
+    }
+
+    #[test]
+    fn test_parse_summary_response_json_in_code_block() {
+        let response = "```json\n{\"summary\": \"## Original Request\\nTest request\"}\n```";
+        let result = parse_summary_response(response).unwrap();
+        assert!(result.summary.contains("## Original Request"));
+        assert!(result.summary.contains("Test request"));
+    }
+
+    #[test]
+    fn test_parse_summary_response_fallback() {
+        let response = "## Original Request\nThis is a raw summary without JSON";
+        let result = parse_summary_response(response).unwrap();
+        assert!(result.summary.contains("## Original Request"));
+        assert!(result.summary.contains("raw summary"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_summary_with_mock_client() {
+        let client = LlmClient::Mock;
+        let conversation = "User: Help me create a new Rust function\nAssistant: I'll help...";
+        let result = generate_summary(&client, conversation).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert!(response.summary.contains("## Original Request"));
+    }
+}

--- a/backend/crates/qbit-ai/src/system_prompt.rs
+++ b/backend/crates/qbit-ai/src/system_prompt.rs
@@ -500,6 +500,97 @@ pub fn read_project_instructions(workspace_path: &Path, memory_file_path: Option
     String::new()
 }
 
+/// The continuation section template for compacted sessions.
+const CONTINUATION_TEMPLATE: &str = r#"
+## Continuation
+
+This is a continuation of a previous session. The conversation so far has been compacted into the summary below. Use this context to continue assisting the user without asking redundant questions.
+
+<summary>
+{summary}
+</summary>
+"#;
+
+/// Append a continuation summary section to a system prompt.
+///
+/// The summary is placed at the end of the system prompt to ensure
+/// it's the most recent context the model sees.
+pub fn append_continuation_summary(base_prompt: &str, summary: &str) -> String {
+    let continuation = CONTINUATION_TEMPLATE.replace("{summary}", summary);
+    format!("{}\n{}", base_prompt.trim_end(), continuation)
+}
+
+/// Check if a system prompt already has a continuation section.
+pub fn has_continuation_section(prompt: &str) -> bool {
+    prompt.contains("## Continuation") && prompt.contains("<summary>")
+}
+
+/// Replace an existing continuation section with a new summary.
+///
+/// If no continuation section exists, appends one.
+pub fn update_continuation_summary(prompt: &str, summary: &str) -> String {
+    if has_continuation_section(prompt) {
+        // Find and replace the existing section
+        if let Some(start) = prompt.find("## Continuation") {
+            let base = prompt[..start].trim_end();
+            return append_continuation_summary(base, summary);
+        }
+    }
+    append_continuation_summary(prompt, summary)
+}
+
+#[cfg(test)]
+mod continuation_tests {
+    use super::*;
+
+    #[test]
+    fn test_append_continuation_summary() {
+        let base = "You are a helpful assistant.";
+        let summary = "User asked to fix a bug in auth.rs.";
+
+        let result = append_continuation_summary(base, summary);
+
+        assert!(result.starts_with(base));
+        assert!(result.contains("## Continuation"));
+        assert!(result.contains("<summary>"));
+        assert!(result.contains(summary));
+        assert!(result.contains("</summary>"));
+    }
+
+    #[test]
+    fn test_has_continuation_section() {
+        let with_section = "Base prompt\n## Continuation\n<summary>test</summary>";
+        let without = "Just a regular prompt.";
+
+        assert!(has_continuation_section(with_section));
+        assert!(!has_continuation_section(without));
+    }
+
+    #[test]
+    fn test_update_continuation_summary_replaces_existing() {
+        let prompt = "Base prompt\n## Continuation\n<summary>old summary</summary>";
+        let new_summary = "new updated summary";
+
+        let result = update_continuation_summary(prompt, new_summary);
+
+        assert!(result.contains(new_summary));
+        assert!(!result.contains("old summary"));
+        // Should only have one continuation section
+        assert_eq!(result.matches("## Continuation").count(), 1);
+    }
+
+    #[test]
+    fn test_update_continuation_summary_appends_if_missing() {
+        let prompt = "Base prompt only";
+        let summary = "new summary";
+
+        let result = update_continuation_summary(prompt, summary);
+
+        assert!(result.contains("## Continuation"));
+        assert!(result.contains(summary));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/crates/qbit-ai/src/test_utils.rs
+++ b/backend/crates/qbit-ai/src/test_utils.rs
@@ -611,6 +611,7 @@ impl TestContext {
             session_id: None,
             transcript_writer: None,
             transcript_base_dir: None,
+            continuation_summary: None,
         }
     }
 

--- a/backend/crates/qbit-ai/src/transcript.rs
+++ b/backend/crates/qbit-ai/src/transcript.rs
@@ -402,6 +402,9 @@ pub fn format_for_summarizer(events: &[TranscriptEvent]) -> String {
             AiEvent::ServerToolStarted { .. } => {}
             AiEvent::WebSearchResult { .. } => {}
             AiEvent::WebFetchResult { .. } => {}
+            AiEvent::CompactionStarted { .. } => {}
+            AiEvent::CompactionCompleted { .. } => {}
+            AiEvent::CompactionFailed { .. } => {}
         }
     }
 

--- a/backend/crates/qbit-core/src/events.rs
+++ b/backend/crates/qbit-core/src/events.rs
@@ -191,6 +191,37 @@ pub enum AiEvent {
     /// Generic warning message (e.g., images stripped for non-vision model)
     Warning { message: String },
 
+    // Context compaction events
+    /// Context compaction started
+    CompactionStarted {
+        /// Number of tokens before compaction
+        tokens_before: u64,
+        /// Number of messages before compaction
+        messages_before: usize,
+    },
+
+    /// Context compaction completed successfully
+    CompactionCompleted {
+        /// Number of tokens before compaction
+        tokens_before: u64,
+        /// Number of messages before compaction
+        messages_before: usize,
+        /// Number of messages after compaction
+        messages_after: usize,
+        /// Length of the generated summary
+        summary_length: usize,
+    },
+
+    /// Context compaction failed
+    CompactionFailed {
+        /// Number of tokens before compaction
+        tokens_before: u64,
+        /// Number of messages before compaction
+        messages_before: usize,
+        /// Error message
+        error: String,
+    },
+
     // Loop protection events
     /// Warning: approaching loop detection threshold
     LoopWarning {
@@ -322,6 +353,9 @@ impl AiEvent {
             AiEvent::ContextWarning { .. } => "context_warning",
             AiEvent::ToolResponseTruncated { .. } => "tool_response_truncated",
             AiEvent::Warning { .. } => "warning",
+            AiEvent::CompactionStarted { .. } => "compaction_started",
+            AiEvent::CompactionCompleted { .. } => "compaction_completed",
+            AiEvent::CompactionFailed { .. } => "compaction_failed",
             AiEvent::LoopWarning { .. } => "loop_warning",
             AiEvent::LoopBlocked { .. } => "loop_blocked",
             AiEvent::MaxIterationsReached { .. } => "max_iterations_reached",
@@ -946,6 +980,21 @@ mod tests {
                     tool_name: "read_file".to_string(),
                     original_tokens: 50000,
                     truncated_tokens: 10000,
+                },
+                AiEvent::CompactionStarted {
+                    tokens_before: 180000,
+                    messages_before: 50,
+                },
+                AiEvent::CompactionCompleted {
+                    tokens_before: 180000,
+                    messages_before: 50,
+                    messages_after: 2,
+                    summary_length: 2000,
+                },
+                AiEvent::CompactionFailed {
+                    tokens_before: 180000,
+                    messages_before: 50,
+                    error: "Summarizer failed".to_string(),
                 },
                 AiEvent::LoopWarning {
                     tool_name: "list".to_string(),

--- a/backend/crates/qbit-sidecar/src/capture.rs
+++ b/backend/crates/qbit-sidecar/src/capture.rs
@@ -274,7 +274,10 @@ impl CaptureContext {
             | AiEvent::ServerToolStarted { .. }
             | AiEvent::WebSearchResult { .. }
             | AiEvent::WebFetchResult { .. }
-            | AiEvent::Warning { .. } => {
+            | AiEvent::Warning { .. }
+            | AiEvent::CompactionStarted { .. }
+            | AiEvent::CompactionCompleted { .. }
+            | AiEvent::CompactionFailed { .. } => {
                 // These events are not captured
             }
         }

--- a/backend/crates/qbit/src/ai/commands/summarizer.rs
+++ b/backend/crates/qbit/src/ai/commands/summarizer.rs
@@ -1,240 +1,15 @@
 //! Isolated conversation summarizer agent.
 //!
-//! This module provides a dedicated AI agent for generating conversation summaries
-//! for context compaction. It is completely isolated from the main agent and sub-agent
-//! system - it cannot be called by any other agent and has no tools. It takes a
-//! conversation transcript and generates a structured summary.
+//! This module provides Tauri command wrappers for the conversation summarizer
+//! in qbit-ai. The actual summarization logic is implemented in qbit-ai::summarizer.
 
-use anyhow::Result;
-use rig::completion::{CompletionModel as _, CompletionRequest, Message};
-use rig::message::{Text, UserContent};
-use rig::one_or_many::OneOrMany;
-use serde::{Deserialize, Serialize};
 use tauri::State;
 
-use crate::ai::llm_client::LlmClient;
+use super::ai_session_not_initialized_error;
 use crate::state::AppState;
 
-use super::ai_session_not_initialized_error;
-
-/// Response from the conversation summarizer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SummaryResponse {
-    /// The generated summary containing all structured sections
-    pub summary: String,
-}
-
-/// System prompt for the conversation summarizer agent.
-pub const SUMMARIZER_SYSTEM_PROMPT: &str = r#"You are a conversation summarizer for an AI coding assistant. Your sole purpose is to analyze conversation transcripts and generate comprehensive summaries that preserve critical context for continued work.
-
-<purpose>
-Generate summaries that allow the AI assistant to seamlessly continue working on tasks after context compaction. The summary must capture everything needed to maintain continuity.
-</purpose>
-
-<format>
-Your summary MUST include these sections:
-
-## Original Request
-- What the user originally asked for
-- Key requirements and constraints mentioned
-- Any clarifications or refinements to the request
-
-## Current State
-- What has been accomplished so far
-- Files that have been created, modified, or deleted
-- Tests that pass or fail
-- Any running processes or state
-
-## Key Decisions
-- Important technical decisions made and their rationale
-- Trade-offs that were considered
-- Patterns or approaches chosen
-
-## Pending Work
-- What still needs to be done
-- Known issues or blockers
-- Next steps that were planned
-
-## Important Context
-- Error messages or issues encountered
-- Specific file paths and line numbers relevant to ongoing work
-- Dependencies or relationships between components
-- Any warnings or caveats mentioned
-</format>
-
-<output>
-Return ONLY valid JSON in this exact format:
-{"summary": "<the full summary with all sections as markdown>"}
-
-Do NOT include any text before or after the JSON. Do NOT use markdown code blocks around the JSON.
-The summary field should contain markdown-formatted text with the sections above.
-</output>
-
-<rules>
-- Be comprehensive but concise
-- Include specific file paths, function names, and code snippets when relevant
-- Preserve exact error messages if they were discussed
-- Focus on actionable information needed to continue work
-- Do not include meta-commentary about the summarization process
-- If certain sections have no content, include them with "None" or "N/A"
-</rules>"#;
-
-/// Build the user prompt for the summarizer by wrapping the conversation in XML tags.
-pub fn build_summarizer_user_prompt(conversation: &str) -> String {
-    format!(
-        r#"Summarize the following conversation for context compaction:
-
-<conversation>
-{}
-</conversation>
-
-Generate a comprehensive summary following the required format."#,
-        conversation
-    )
-}
-
-/// Generate a conversation summary using the LLM.
-///
-/// This function takes a conversation transcript and produces a structured summary
-/// suitable for context compaction.
-///
-/// # Arguments
-/// * `client` - The LLM client to use for generation
-/// * `conversation` - The conversation transcript to summarize
-///
-/// # Returns
-/// A SummaryResponse containing the structured summary
-pub async fn generate_summary(client: &LlmClient, conversation: &str) -> Result<SummaryResponse> {
-    let user_prompt = build_summarizer_user_prompt(conversation);
-
-    // Build the user message
-    let user_message = Message::User {
-        content: OneOrMany::one(UserContent::Text(Text { text: user_prompt })),
-    };
-
-    // Call the model
-    let response_text = call_summarizer_model(client, user_message).await?;
-
-    // Parse the JSON response
-    parse_summary_response(&response_text)
-}
-
-/// Internal helper that handles different LlmClient variants.
-///
-/// Uses a macro to reduce repetition across the many provider variants.
-async fn call_summarizer_model(client: &LlmClient, user_message: Message) -> Result<String> {
-    // Helper to extract text from completion response
-    fn extract_text(
-        choice: &rig::one_or_many::OneOrMany<rig::completion::AssistantContent>,
-    ) -> String {
-        let mut text = String::new();
-        for content in choice.iter() {
-            if let rig::completion::AssistantContent::Text(t) = content {
-                text.push_str(&t.text);
-            }
-        }
-        text
-    }
-
-    // Build the completion request
-    let chat_history = vec![user_message.clone()];
-    let request = CompletionRequest {
-        preamble: Some(SUMMARIZER_SYSTEM_PROMPT.to_string()),
-        chat_history: OneOrMany::many(chat_history.clone())
-            .unwrap_or_else(|_| OneOrMany::one(chat_history[0].clone())),
-        documents: vec![],
-        tools: vec![],          // No tools - this is a simple completion
-        temperature: Some(0.3), // Low temperature for consistent output
-        max_tokens: Some(4096), // Summaries can be longer than commit messages
-        tool_choice: None,
-        additional_params: None,
-    };
-
-    // Macro to reduce repetition across provider variants
-    macro_rules! complete_with_model {
-        ($model:expr) => {{
-            let response = $model.completion(request).await?;
-            Ok(extract_text(&response.choice))
-        }};
-    }
-
-    match client {
-        LlmClient::VertexAnthropic(model) => complete_with_model!(model),
-        LlmClient::RigOpenRouter(model) => complete_with_model!(model),
-        LlmClient::RigOpenAi(model) => complete_with_model!(model),
-        LlmClient::RigOpenAiResponses(model) => complete_with_model!(model),
-        LlmClient::RigAnthropic(model) => complete_with_model!(model),
-        LlmClient::RigOllama(model) => complete_with_model!(model),
-        LlmClient::RigGemini(model) => complete_with_model!(model),
-        LlmClient::RigGroq(model) => complete_with_model!(model),
-        LlmClient::RigXai(model) => complete_with_model!(model),
-        LlmClient::RigZai(model) => complete_with_model!(model),
-        LlmClient::RigZaiAnthropic(model) => complete_with_model!(model),
-        LlmClient::RigZaiAnthropicLogging(model) => complete_with_model!(model),
-        LlmClient::Mock => {
-            // Return a mock response for testing
-            // Note: Using escaped string instead of raw string for proper \n handling in JSON
-            Ok("{\"summary\": \"## Original Request\\nMock summary for testing.\\n\\n## Current State\\nN/A\\n\\n## Key Decisions\\nN/A\\n\\n## Pending Work\\nN/A\\n\\n## Important Context\\nN/A\"}".to_string())
-        }
-    }
-}
-
-/// Entry point for generating summaries with optional model configuration.
-///
-/// This function handles the case where a specific summarizer model may be configured
-/// in settings, falling back to the session's default client if not.
-///
-/// # Arguments
-/// * `client` - The LLM client to use (either session default or configured summarizer model)
-/// * `conversation` - The conversation transcript to summarize
-///
-/// # Returns
-/// A SummaryResponse containing the structured summary
-pub async fn generate_summary_with_config(
-    client: &LlmClient,
-    conversation: &str,
-) -> Result<SummaryResponse> {
-    // For now, this just delegates to generate_summary.
-    // In the future, this could handle loading a specific summarizer model
-    // from configuration if one is specified.
-    generate_summary(client, conversation).await
-}
-
-/// Parse the LLM response into a SummaryResponse.
-fn parse_summary_response(response: &str) -> Result<SummaryResponse> {
-    let trimmed = response.trim();
-
-    // Handle markdown code blocks if present
-    let json_str = if trimmed.starts_with("```") {
-        let without_start = trimmed
-            .strip_prefix("```json")
-            .or_else(|| trimmed.strip_prefix("```"))
-            .unwrap_or(trimmed);
-        without_start
-            .strip_suffix("```")
-            .unwrap_or(without_start)
-            .trim()
-    } else {
-        trimmed
-    };
-
-    // Try to parse as JSON
-    match serde_json::from_str::<SummaryResponse>(json_str) {
-        Ok(resp) => Ok(resp),
-        Err(json_err) => {
-            // Fallback: treat the entire response as the summary
-            tracing::warn!(
-                "Failed to parse summary as JSON: {}. Using raw response as summary.",
-                json_err
-            );
-
-            // Use the full response as the summary
-            Ok(SummaryResponse {
-                summary: trimmed.to_string(),
-            })
-        }
-    }
-}
+// Re-export types from qbit-ai for Tauri command compatibility
+pub use qbit_ai::SummaryResponse;
 
 /// Tauri command to generate a conversation summary.
 ///
@@ -265,8 +40,8 @@ pub async fn generate_conversation_summary(
     let client = bridge.client().clone();
     let client_guard = client.read().await;
 
-    // Generate the summary
-    generate_summary_with_config(&client_guard, &conversation)
+    // Generate the summary using qbit-ai's summarizer
+    qbit_ai::generate_summary_with_config(&client_guard, &conversation)
         .await
         .map_err(|e| format!("Failed to generate summary: {}", e))
 }
@@ -274,25 +49,7 @@ pub async fn generate_conversation_summary(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_summary_response_deserialization() {
-        // JSON with escaped newlines - the \\n becomes \n in the JSON, which becomes actual newline in the parsed string
-        let json = "{\"summary\": \"## Original Request\\nTest summary\"}";
-        let result: SummaryResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(result.summary, "## Original Request\nTest summary");
-    }
-
-    #[test]
-    fn test_summary_response_handles_multiline() {
-        // Test with actual newlines in the JSON string value
-        let json = "{\"summary\": \"## Original Request\\nLine 1\\n\\n## Current State\\nLine 2\\nLine 3\"}";
-        let result: SummaryResponse = serde_json::from_str(json).unwrap();
-        assert!(result.summary.contains("## Original Request"));
-        assert!(result.summary.contains("## Current State"));
-        assert!(result.summary.contains("Line 1"));
-        assert!(result.summary.contains("Line 3"));
-    }
+    use qbit_ai::SUMMARIZER_SYSTEM_PROMPT;
 
     #[test]
     fn test_summarizer_system_prompt_not_empty() {
@@ -302,54 +59,5 @@ mod tests {
         assert!(SUMMARIZER_SYSTEM_PROMPT.contains("## Key Decisions"));
         assert!(SUMMARIZER_SYSTEM_PROMPT.contains("## Pending Work"));
         assert!(SUMMARIZER_SYSTEM_PROMPT.contains("## Important Context"));
-    }
-
-    #[test]
-    fn test_build_summarizer_prompt() {
-        let conversation = "User: Hello\nAssistant: Hi there!";
-        let prompt = build_summarizer_user_prompt(conversation);
-
-        assert!(prompt.contains("<conversation>"));
-        assert!(prompt.contains("</conversation>"));
-        assert!(prompt.contains("User: Hello"));
-        assert!(prompt.contains("Assistant: Hi there!"));
-        assert!(prompt.contains("Summarize the following conversation"));
-    }
-
-    #[test]
-    fn test_parse_summary_response_json() {
-        let response = "{\"summary\": \"## Original Request\\nBuild a feature\\n\\n## Current State\\nIn progress\"}";
-        let result = parse_summary_response(response).unwrap();
-        assert!(result.summary.contains("## Original Request"));
-        assert!(result.summary.contains("Build a feature"));
-    }
-
-    #[test]
-    fn test_parse_summary_response_json_in_code_block() {
-        let response = "```json\n{\"summary\": \"## Original Request\\nTest request\"}\n```";
-        let result = parse_summary_response(response).unwrap();
-        assert!(result.summary.contains("## Original Request"));
-        assert!(result.summary.contains("Test request"));
-    }
-
-    #[test]
-    fn test_parse_summary_response_fallback() {
-        let response = "## Original Request\nThis is a raw summary without JSON";
-        let result = parse_summary_response(response).unwrap();
-        assert!(result.summary.contains("## Original Request"));
-        assert!(result.summary.contains("raw summary"));
-    }
-
-    #[tokio::test]
-    #[ignore = "requires LLM API access"]
-    async fn test_generate_summary_integration() {
-        // This test is ignored by default as it requires a real LLM client.
-        // To run it, use: cargo test --package qbit -- --ignored
-        //
-        // Example conversation for testing:
-        // let conversation = "User: Help me create a new Rust function\nAssistant: I'll help...";
-        // let client = LlmClient::Mock;
-        // let result = generate_summary(&client, conversation).await;
-        // assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- Implements Step 5 of the context compaction feature: the hard reset mechanism
- When context window approaches capacity, the conversation is automatically compacted
- Messages are cleared and replaced with a summary + most recent user message
- System prompt includes continuation summary for context preservation

## Changes

### Core Implementation
- **system_prompt.rs**: Added `append_continuation_summary()`, `has_continuation_section()`, `update_continuation_summary()` helpers
- **agent_bridge.rs**: Added `continuation_summary` field and `build_system_prompt_with_continuation()` method
- **agentic_loop.rs**: Added `CompactionResult`, `maybe_compact()`, `perform_compaction()`, `apply_compaction()` functions
- **summarizer.rs**: **NEW** - Moved summarizer from qbit crate to qbit-ai for proper layer architecture

### Events
- Added `CompactionStarted`, `CompactionCompleted`, `CompactionFailed` events to qbit-core
- Added CLI output handlers for compaction events in qbit-cli-output

### Integration
- Compaction check runs between turns in the main agentic loop
- Artifacts saved to `~/.qbit/artifacts/compaction/` and `~/.qbit/artifacts/summaries/`

### Documentation
- Updated step 5 plan document with completion status
- Added Context Compaction section to CLAUDE.md
- Added compaction events to AI Events table

## Test plan

- [x] All 173 tests pass in qbit-ai (includes 9 compaction tests, 7 summarizer tests, 4 continuation tests)
- [x] All 55 tests pass in qbit-context
- [x] Full workspace builds successfully
- [ ] Manual testing: trigger compaction by having long conversations
- [ ] Verify artifacts are saved correctly
- [ ] Verify continuation summary appears in system prompt after compaction