### PR TITLE
feat(context-compaction): add events and UI for compaction feedback

### DIFF
--- a/frontend/lib/ai.ts
+++ b/frontend/lib/ai.ts
@@ -292,6 +292,25 @@ export type AiEvent = AiEventBase &
         utilization_before: number;
         utilization_after: number;
       }
+    // Context compaction events
+    | {
+        type: "compaction_started";
+        tokens_before: number;
+        messages_before: number;
+      }
+    | {
+        type: "compaction_completed";
+        tokens_before: number;
+        messages_before: number;
+        messages_after: number;
+        summary_length: number;
+      }
+    | {
+        type: "compaction_failed";
+        tokens_before: number;
+        messages_before: number;
+        error: string;
+      }
     | {
         type: "tool_response_truncated";
         tool_name: string;


### PR DESCRIPTION
## Summary

Implements the frontend portion of Step 6 of the context compaction plan. This builds on the existing `compaction_started`, `compaction_completed`, and `compaction_failed` events that were added to the backend in earlier PRs.

- Add TypeScript types for the compaction events
- Add compaction state to Zustand store (`compactionCount`, `isCompacting`, `isSessionDead`, `compactionError`)
- Handle compaction events in `useAiEvents` hook with toast notifications
- Disable input during compaction in UnifiedInput component
- Show appropriate placeholder text ("Compacting conversation..." or "Session limit exceeded...")

## Test plan

- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] Frontend tests pass (`pnpm test` - 250 tests)
- [ ] Manual testing: trigger compaction and verify notification appears
- [ ] Manual testing: verify input is disabled during compaction with appropriate placeholder