### PR TITLE
fix(pty): revert parser changes causing terminal visibility issues

### DIFF
--- a/backend/crates/qbit-pty/src/parser.rs
+++ b/backend/crates/qbit-pty/src/parser.rs
@@ -385,10 +385,7 @@ impl OscPerformer {
 
 impl Perform for OscPerformer {
     fn print(&mut self, c: char) {
-        // Pass through Output and Input regions
-        // Input region includes PS2 continuation prompts which should be visible
-        // Only suppress Prompt region (the shell prompt itself)
-        if self.current_region != TerminalRegion::Prompt {
+        if self.current_region == TerminalRegion::Output {
             // Encode char as UTF-8 and add to visible_bytes
             let mut buf = [0u8; 4];
             let encoded = c.encode_utf8(&mut buf);
@@ -397,10 +394,8 @@ impl Perform for OscPerformer {
     }
 
     fn execute(&mut self, byte: u8) {
-        // Pass through Output and Input regions
-        // Input region includes PS2 continuation prompts which should be visible
-        if self.current_region != TerminalRegion::Prompt {
-            // Pass through control characters
+        if self.current_region == TerminalRegion::Output {
+            // Pass through control characters in Output region
             // Common ones: LF (0x0A), CR (0x0D), TAB (0x09), BS (0x08)
             match byte {
                 0x0A | 0x0D | 0x09 | 0x08 => {
@@ -1159,14 +1154,13 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_filtered_passes_through_input_region() {
+    fn test_parse_filtered_suppresses_user_input() {
         let mut parser = TerminalParser::new();
         // After PromptEnd (B), user types - this is the Input region
         // First set up the state: PromptStart -> PromptEnd
         parser.parse_filtered(b"\x1b]133;A\x07\x1b]133;B\x07");
 
         // Now user types "ls -la" and presses enter (CommandStart)
-        // Input region output is now visible (includes PS2 continuation prompts)
         let result = parser.parse_filtered(b"ls -la\x1b]133;C;ls -la\x07");
         assert_eq!(result.events.len(), 1);
         if let OscEvent::CommandStart { command } = &result.events[0] {
@@ -1174,8 +1168,8 @@ mod tests {
         } else {
             panic!("Expected CommandStart");
         }
-        // Input region is now visible (for PS2 prompts and shell output)
-        assert_eq!(result.output, b"ls -la");
+        // User input "ls -la" should be suppressed (between B and C)
+        assert_eq!(result.output, b"");
     }
 
     #[test]
@@ -1199,9 +1193,9 @@ mod tests {
         let r1 = parser.parse_filtered(b"\x1b]133;A\x07user@host:~$ \x1b]133;B\x07");
         assert_eq!(r1.output, b""); // Prompt suppressed
 
-        // 2. User input (visible - includes PS2 continuation prompts)
+        // 2. User input (suppressed)
         let r2 = parser.parse_filtered(b"echo hello\x1b]133;C;echo hello\x07");
-        assert_eq!(r2.output, b"echo hello"); // Input visible for PS2 prompts
+        assert_eq!(r2.output, b""); // Input suppressed
 
         // 3. Command output (visible)
         let r3 = parser.parse_filtered(b"hello\n");

--- a/frontend/components/Terminal/Terminal.tsx
+++ b/frontend/components/Terminal/Terminal.tsx
@@ -196,28 +196,14 @@ export function Terminal({ sessionId }: TerminalProps) {
 
     // Send resize to PTY (needed for both new and reattached terminals)
     // For reattached terminals, the container size may have changed
-    // Guard: Don't resize if dimensions are unreasonably small (e.g., hidden container)
-    // This prevents the shell from getting a tiny COLUMNS value on startup
     const { rows, cols } = terminal;
-    const MIN_COLS = 20;
-    const MIN_ROWS = 2;
-    if (cols >= MIN_COLS && rows >= MIN_ROWS) {
-      logger.debug("[Terminal] Sending resize:", {
-        sessionId,
-        rows,
-        cols,
-        isReattachment: !isNewInstance,
-      });
-      ptyResize(sessionId, rows, cols).catch(console.error);
-    } else {
-      logger.debug("[Terminal] Skipping resize - dimensions too small:", {
-        sessionId,
-        rows,
-        cols,
-        minCols: MIN_COLS,
-        minRows: MIN_ROWS,
-      });
-    }
+    logger.debug("[Terminal] Sending resize:", {
+      sessionId,
+      rows,
+      cols,
+      isReattachment: !isNewInstance,
+    });
+    ptyResize(sessionId, rows, cols).catch(console.error);
 
     // Register input handler (captures sessionId via closure)
     const inputDisposable = terminal.onData((data) => {
@@ -227,12 +213,9 @@ export function Terminal({ sessionId }: TerminalProps) {
     cleanupFnsRef.current.push(() => inputDisposable.dispose());
 
     // Handle xterm.js internal resize events
-    // Apply same guard against tiny dimensions (hidden container in timeline mode)
     const resizeDisposable = terminal.onResize(({ rows, cols }) => {
       if (aborted) return;
-      if (cols >= MIN_COLS && rows >= MIN_ROWS) {
-        ptyResize(sessionId, rows, cols).catch(console.error);
-      }
+      ptyResize(sessionId, rows, cols).catch(console.error);
     });
     cleanupFnsRef.current.push(() => resizeDisposable.dispose());
 


### PR DESCRIPTION
## Summary
- Reverts parser changes from #155 that caused terminal prompt to incorrectly display in timeline mode
- Removes resize guard in Terminal.tsx that was added to handle hidden containers

## Problem
PR #155 introduced changes that caused the shell prompt to leak through and display incorrectly:
1. New tabs showed the terminal prompt at the top when it should be hidden
2. After agent responses, the terminal prompt appeared at the bottom of the timeline

## Root Cause
The parser was changed to pass through Input region content (in addition to Output region) to support PS2 continuation prompts. However, this also caused the shell prompt to be visible when it shouldn't be.

## Changes
- **parser.rs**: Revert to only passing through Output region content (suppress Input region)
- **Terminal.tsx**: Remove resize guard that skipped resize for small dimensions

## Test plan
- [x] Verify new tabs no longer show terminal prompt incorrectly
- [x] Verify agent conversations don't show terminal prompt at the bottom
- [x] All existing tests pass