### PR TITLE
fix(ai): resolve deadlock in release builds when switching models

### DIFF
--- a/backend/crates/qbit/src/ai/commands/config.rs
+++ b/backend/crates/qbit/src/ai/commands/config.rs
@@ -247,9 +247,10 @@ pub async fn update_ai_workspace(
     let workspace_path: std::path::PathBuf = workspace.into();
 
     // Update session-specific bridge if session_id is provided
+    // IMPORTANT: Use get_session_bridge() to clone the Arc and release the map lock
+    // immediately, avoiding deadlocks when other tasks need write access to the map.
     if let Some(ref sid) = session_id {
-        let bridges = state.ai_state.get_bridges().await;
-        if let Some(bridge) = bridges.get(sid) {
+        if let Some(bridge) = state.ai_state.get_session_bridge(sid).await {
             bridge.set_workspace(workspace_path.clone()).await;
             // Note: set_workspace logs at trace if unchanged, so we don't duplicate here
         } else {


### PR DESCRIPTION
## Summary

- Fixed a deadlock that caused model switching to get stuck at "initializing" in release builds
- Commands were holding read locks on the bridges map while calling async methods, preventing `init_ai_session` from acquiring a write lock to remove old bridges
- Changed affected commands to use `get_session_bridge()` which clones the Arc and releases the lock immediately

## Root Cause

Several commands used `get_bridges().await` to acquire a read lock, then called async methods while still holding the lock:

- `update_ai_workspace` in config.rs
- `clear_ai_conversation_session` in core.rs
- `get_ai_conversation_length_session` in core.rs
- `respond_to_tool_approval` in hitl.rs

When `init_ai_session` tried to call `remove_session_bridge()` (which needs a write lock), it would block forever waiting for the read locks to release.

This race condition was more likely to occur in release builds due to timing differences.

## Test plan

- [x] Verify code compiles (`cargo check --package qbit`)
- [x] Tested manually in release build - model switching no longer hangs