### PR TITLE
fix(ai): OpenAI temperature regression, UTF-8 panic, and rig-core upgrade

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5576,7 +5576,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rig-anthropic-vertex",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "rustls",
  "serde",
  "serde_json",
@@ -5635,7 +5635,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rig-anthropic-vertex",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "rig-zai",
  "rig-zai-anthropic",
  "serde",
@@ -5711,7 +5711,7 @@ name = "qbit-context"
 version = "0.2.9"
 dependencies = [
  "chrono",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "tokio",
@@ -5771,7 +5771,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rig-anthropic-vertex",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "rig-zai",
  "serde",
  "serde_json",
@@ -5829,7 +5829,7 @@ version = "0.2.9"
 dependencies = [
  "reqwest 0.12.28",
  "rig-anthropic-vertex",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "rig-zai",
  "rig-zai-anthropic",
  "serde",
@@ -5903,7 +5903,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "dirs 5.0.1",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "serial_test",
@@ -5956,7 +5956,7 @@ dependencies = [
  "qbit-settings",
  "qbit-synthesis",
  "reqwest 0.12.28",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5997,7 +5997,7 @@ dependencies = [
  "qbit-udiff",
  "qbit-web",
  "rig-anthropic-vertex",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -6022,7 +6022,7 @@ dependencies = [
  "qbit-core",
  "qbit-evals",
  "reqwest 0.12.28",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -6078,7 +6078,7 @@ dependencies = [
  "qbit-settings",
  "qbit-shell-exec",
  "qbit-web",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "similar",
@@ -6116,7 +6116,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "graph-flow",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "tokio",
@@ -6729,7 +6729,7 @@ dependencies = [
  "futures",
  "gcp_auth",
  "reqwest 0.12.28",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -6769,9 +6769,9 @@ dependencies = [
 
 [[package]]
 name = "rig-core"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799afd8ba38d90d9886be5bf596b0159043f88598b40e1f5aa08aad488f2223"
+checksum = "7207790134ee24d87ac3d022c308e1a7c871219d139acf70d13be76c1f6919c5"
 dependencies = [
  "as-any",
  "async-stream",
@@ -6807,7 +6807,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "reqwest 0.12.28",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -6825,7 +6825,7 @@ dependencies = [
  "http 1.4.0",
  "regex",
  "reqwest 0.12.28",
- "rig-core 0.27.0",
+ "rig-core 0.29.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -137,7 +137,7 @@ readability = "0.2"
 url = "2.5"
 
 # Rig core for LLM orchestration
-rig-core = { version = "^0.27.0", features = [] }
+rig-core = { version = "^0.29.0", features = [] }
 
 # HTTP utilities (for custom HTTP clients)
 http = "1.2"

--- a/backend/crates/qbit-ai/src/event_coordinator.rs
+++ b/backend/crates/qbit-ai/src/event_coordinator.rs
@@ -144,7 +144,9 @@ impl CoordinatorHandle {
     ///
     /// The decision will be sent to the receiver registered with `register_approval`.
     pub fn resolve_approval(&self, decision: ApprovalDecision) {
-        let _ = self.tx.send(CoordinatorCommand::ResolveApproval { decision });
+        let _ = self
+            .tx
+            .send(CoordinatorCommand::ResolveApproval { decision });
     }
 
     /// Query the current coordinator state.
@@ -539,7 +541,9 @@ mod tests {
         // Check state
         let state = handle.query_state().await.unwrap();
         assert_eq!(state.pending_approval_count, 1);
-        assert!(state.pending_approval_ids.contains(&"request-123".to_string()));
+        assert!(state
+            .pending_approval_ids
+            .contains(&"request-123".to_string()));
 
         // Resolve the approval
         handle.resolve_approval(ApprovalDecision {

--- a/backend/crates/qbit-ai/src/lib.rs
+++ b/backend/crates/qbit-ai/src/lib.rs
@@ -62,6 +62,7 @@ pub mod test_utils;
 
 // Public API types from this crate
 pub use agent_mode::AgentMode;
+pub use event_coordinator::{CoordinatorHandle, CoordinatorState, EventCoordinator};
 pub use llm_client::SharedComponentsConfig;
 pub use prompt_registry::PromptContributorRegistry;
 pub use summarizer::{
@@ -81,4 +82,3 @@ pub use transcript::{
     build_summarizer_input, format_for_summarizer, read_transcript, save_summarizer_input,
     save_summary, transcript_path, TranscriptEvent, TranscriptWriter,
 };
-pub use event_coordinator::{CoordinatorHandle, CoordinatorState, EventCoordinator};

--- a/backend/crates/qbit-sub-agents/src/executor.rs
+++ b/backend/crates/qbit-sub-agents/src/executor.rs
@@ -404,13 +404,15 @@ where
                             current_tool_name = Some(tool_call.function.name.clone());
                         }
                     }
-                    StreamedAssistantContent::ToolCallDelta { id, delta } => {
+                    StreamedAssistantContent::ToolCallDelta { id, content } => {
                         // If we don't have a current tool ID but the delta has one, use it
                         if current_tool_id.is_none() && !id.is_empty() {
                             current_tool_id = Some(id);
                         }
-                        // Accumulate tool call argument deltas
-                        current_tool_args.push_str(&delta);
+                        // Accumulate tool call argument deltas (extract string from enum)
+                        if let rig::streaming::ToolCallDeltaContent::Delta(delta) = content {
+                            current_tool_args.push_str(&delta);
+                        }
                     }
                     _ => {
                         // Ignore other stream content types

--- a/backend/crates/rig-anthropic-vertex/src/completion.rs
+++ b/backend/crates/rig-anthropic-vertex/src/completion.rs
@@ -692,7 +692,7 @@ impl completion::CompletionModel for CompletionModel {
                         StreamChunk::ToolInputDelta { partial_json } => {
                             RawStreamingChoice::ToolCallDelta {
                                 id: String::new(),
-                                delta: partial_json,
+                                content: rig::streaming::ToolCallDeltaContent::Delta(partial_json),
                             }
                         }
                         StreamChunk::Done { usage, .. } => {

--- a/frontend/lib/ai.ts
+++ b/frontend/lib/ai.ts
@@ -804,7 +804,7 @@ export const ZAI_ANTHROPIC_MODELS = {
 /**
  * Reasoning effort levels for OpenAI models that support it.
  */
-export type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort = "low" | "medium" | "high";
 
 /**
  * Initialize AI with Anthropic on Google Cloud Vertex AI.

--- a/frontend/lib/models.ts
+++ b/frontend/lib/models.ts
@@ -132,7 +132,7 @@ export const PROVIDER_GROUPS: ProviderGroup[] = [
       {
         id: OPENAI_MODELS.GPT_5_2,
         name: "GPT 5.2 (Extra High)",
-        reasoningEffort: "xhigh",
+        reasoningEffort: "high",
       },
       {
         id: OPENAI_MODELS.GPT_5_1,
@@ -226,7 +226,7 @@ export const PROVIDER_GROUPS: ProviderGroup[] = [
       {
         id: OPENAI_MODELS.GPT_5_2_CODEX,
         name: "GPT 5.2 Codex (Extra High)",
-        reasoningEffort: "xhigh",
+        reasoningEffort: "high",
       },
       {
         id: OPENAI_MODELS.GPT_5_1_CODEX,
@@ -246,7 +246,7 @@ export const PROVIDER_GROUPS: ProviderGroup[] = [
       {
         id: OPENAI_MODELS.GPT_5_1_CODEX,
         name: "GPT 5.1 Codex (Extra High)",
-        reasoningEffort: "xhigh",
+        reasoningEffort: "high",
       },
       {
         id: OPENAI_MODELS.GPT_5_1_CODEX_MAX,
@@ -266,7 +266,7 @@ export const PROVIDER_GROUPS: ProviderGroup[] = [
       {
         id: OPENAI_MODELS.GPT_5_1_CODEX_MAX,
         name: "GPT 5.1 Codex Max (Extra High)",
-        reasoningEffort: "xhigh",
+        reasoningEffort: "high",
       },
       {
         id: OPENAI_MODELS.GPT_5_1_CODEX_MINI,
@@ -429,7 +429,7 @@ export const PROVIDER_GROUPS_NESTED: ProviderGroupNested[] = [
               {
                 id: OPENAI_MODELS.GPT_5_2,
                 name: "Extra High",
-                reasoningEffort: "xhigh",
+                reasoningEffort: "high",
               },
             ],
           },
@@ -580,7 +580,7 @@ export const PROVIDER_GROUPS_NESTED: ProviderGroupNested[] = [
               {
                 id: OPENAI_MODELS.GPT_5_2_CODEX,
                 name: "Extra High",
-                reasoningEffort: "xhigh",
+                reasoningEffort: "high",
               },
             ],
           },
@@ -605,7 +605,7 @@ export const PROVIDER_GROUPS_NESTED: ProviderGroupNested[] = [
               {
                 id: OPENAI_MODELS.GPT_5_1_CODEX,
                 name: "Extra High",
-                reasoningEffort: "xhigh",
+                reasoningEffort: "high",
               },
             ],
           },
@@ -630,7 +630,7 @@ export const PROVIDER_GROUPS_NESTED: ProviderGroupNested[] = [
               {
                 id: OPENAI_MODELS.GPT_5_1_CODEX_MAX,
                 name: "Extra High",
-                reasoningEffort: "xhigh",
+                reasoningEffort: "high",
               },
             ],
           },

--- a/frontend/lib/settings.ts
+++ b/frontend/lib/settings.ts
@@ -55,7 +55,7 @@ export interface ToolsSettings {
 /**
  * Reasoning effort level for models that support it.
  */
-export type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort = "low" | "medium" | "high";
 
 /**
  * Per-sub-agent model override configuration.


### PR DESCRIPTION
## Summary

Fixes three issues affecting OpenAI model usage:

- **GPT-5 temperature error**: GPT-5 series models (gpt-5, gpt-5.1, gpt-5.2, etc.) are reasoning models that don't support the temperature parameter. The API was returning 400 errors.
- **UTF-8 byte boundary panic**: Text truncation at position 2000 panicked when landing in the middle of multi-byte UTF-8 characters (like box drawing `─`)
- **rig-core upgrade**: Updated from 0.27.0 to 0.29.0, fixing breaking API changes in `ToolCallDelta`
- **Removed xhigh reasoning effort**: rig-core only supports `none`, `minimal`, `low`, `medium`, `high` - updated frontend to use `high` instead

## Changes

### Backend
- Updated `model_supports_temperature()` to reject all GPT-5 models
- Updated `detect_thinking_history_support()` to include GPT-5 series as reasoning models
- Fixed UTF-8 safe truncation using `is_char_boundary()` check
- Upgraded rig-core to 0.29.0 and fixed `ToolCallDelta` API change (`delta` → `content: ToolCallDeltaContent`)
- Added comprehensive tests for OpenAI model detection and UTF-8 truncation

### Frontend
- Removed `xhigh` from `ReasoningEffort` type in `ai.ts` and `settings.ts`
- Updated all model entries in `models.ts` to use `high` instead of `xhigh`

## Test plan

- [x] `just check` passes
- [x] `just test-e2e` passes (117 tests)
- [x] New unit tests for GPT-5 model detection
- [x] New unit tests for UTF-8 truncation edge cases