### PR TITLE
feat(ai): add rig-openai-responses crate for explicit reasoning model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ React Frontend (frontend/)
   Tauri Commands & Events
         |
         v
-Rust Backend Workspace (backend/crates/) - 31 crates in 4 layers
+Rust Backend Workspace (backend/crates/) - 35 crates in 4 layers
     |
     Layer 4 (Application):
     +-- qbit (main crate - Tauri commands, CLI entry)
@@ -82,6 +82,7 @@ Rust Backend Workspace (backend/crates/) - 31 crates in 4 layers
     +-- rig-anthropic-vertex (Vertex AI provider)
     +-- rig-zai (Z.AI GLM provider)
     +-- rig-zai-anthropic (Z.AI Anthropic SSE transformer)
+    +-- rig-openai-responses (OpenAI Responses adapter with explicit reasoning/text stream separation)
     +-- qbit-ast-grep (AST-based code search)
     |
     Layer 1 (Foundation):
@@ -337,7 +338,7 @@ UI note: `system_hooks_injected` is persisted into the unified timeline as a `Un
 | Purpose | Package |
 |---------|---------|
 | AI/LLM | vtcode-core (external), rig-core |
-| AI routing | rig-anthropic-vertex, rig-zai (local crates) |
+| AI routing | rig-anthropic-vertex, rig-zai, rig-openai-responses (local crates) |
 | Terminal | portable-pty, vte, @xterm/xterm |
 | Workflows | graph-flow |
 | Web search | tavily, reqwest, readability |
@@ -348,7 +349,7 @@ UI note: `system_hooks_injected` is persisted into the unified timeline as a `Un
 | Serialization | serde, serde_json, toml |
 | Testing | Vitest (frontend), Playwright (E2E), proptest (Rust) |
 
-### Internal Workspace Crates (31 total)
+### Internal Workspace Crates
 | Crate | Layer | Purpose |
 |-------|-------|---------|
 | qbit-core | 1 (Foundation) | Core types, traits, zero internal deps |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Each agent sees only the tools relevant to its job. No sprawl. No permission ove
 
 Switch providers mid-session. Use local models for sensitive codebases.
 
+**OpenAI reasoning models** (e.g., `o1*`, `o3*`, `gpt-5*`) are auto-detected and routed through a dedicated Responses API adapter that keeps *reasoning* streaming deltas separate from *text*.
+
 ### AI Tools
 
 - **File Operations**: `read_file`, `edit_file`, `write_file`, `create_file`, `delete_file`
@@ -159,6 +161,12 @@ echo "ANTHROPIC_API_KEY=sk-ant-..." >> .env
 echo "OPENAI_API_KEY=sk-..." >> .env
 ```
 
+Optional (for OpenAI reasoning models like `o1*` / `o3*` / `gpt-5*`):
+```toml
+[ai]
+default_reasoning_effort = "medium" # low | medium | high
+```
+
 **Option D: Ollama (Local)**
 ```bash
 # Just have Ollama running - no API key needed
@@ -246,7 +254,7 @@ qbit/
 │   ├── hooks/              # Tauri event subscriptions
 │   ├── lib/                # Typed invoke() wrappers
 │   └── store/              # Zustand + Immer state
-└── backend/crates/         # Rust workspace (29 crates)
+└── backend/crates/         # Rust workspace (35 crates)
     ├── qbit/               # Main app: Tauri commands, CLI
     ├── qbit-ai/            # Agent orchestration, LLM clients
     ├── qbit-core/          # Foundation types (zero deps)
@@ -256,6 +264,7 @@ qbit/
     ├── qbit-context/       # Token budget, pruning
     ├── qbit-hitl/          # Human-in-the-loop approval
     ├── qbit-workflow/      # Multi-step task pipelines
+    ├── rig-openai-responses/# OpenAI Responses API adapter (reasoning models)
     └── ...                 # 20 more infrastructure crates
 ```
 
@@ -273,10 +282,10 @@ qbit/
 
 ### Crate Layers
 
-The 29 Rust crates follow strict architectural layers:
+The Rust workspace follows strict architectural layers:
 
 1. **Foundation** (`qbit-core`): Types, traits, errors. Zero internal dependencies.
-2. **Infrastructure** (25 crates): Reusable services. Depend only on foundation.
+2. **Infrastructure**: Reusable services. Depend only on foundation.
 3. **Domain** (`qbit-ai`): Agent orchestration. Depends on infrastructure.
 4. **Application** (`qbit`): Entry points. Tauri commands and CLI.
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -316,6 +316,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-openai"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16aa4b9090c12270cd0925f735958ab6f0296af7ac08ce0f53fe320bcaf1e23d"
+dependencies = [
+ "async-openai-macros",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "derive_builder",
+ "eventsource-stream",
+ "futures",
+ "getrandom 0.3.4",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "async-openai-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81872a8e595e8ceceab71c6ba1f9078e313b452a1e31934e6763ef5d308705e4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +526,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -3559,6 +3613,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5722,6 +5785,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rig-anthropic-vertex",
  "rig-core 0.29.0",
+ "rig-openai-responses",
  "rig-vertexai",
  "rig-zai",
  "rig-zai-anthropic",
@@ -5917,6 +5981,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rig-anthropic-vertex",
  "rig-core 0.29.0",
+ "rig-openai-responses",
  "rig-vertexai",
  "rig-zai",
  "rig-zai-anthropic",
@@ -6757,6 +6822,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6775,6 +6841,22 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom 7.1.3",
+ "pin-project-lite",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6884,6 +6966,20 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
+]
+
+[[package]]
+name = "rig-openai-responses"
+version = "0.1.0"
+dependencies = [
+ "async-openai",
+ "futures",
+ "rig-core 0.29.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7248,6 +7344,16 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/rig-anthropic-vertex",
     "crates/rig-zai",
     "crates/rig-zai-anthropic",
+    "crates/rig-openai-responses",
     "crates/qbit-ast-grep",
     "crates/qbit-skills",
     "crates/qbit-benchmarks",

--- a/backend/crates/qbit-ai/Cargo.toml
+++ b/backend/crates/qbit-ai/Cargo.toml
@@ -57,6 +57,8 @@ rig-vertexai = { workspace = true }
 rig-anthropic-vertex = { path = "../rig-anthropic-vertex" }
 rig-zai = { path = "../rig-zai" }
 rig-zai-anthropic = { path = "../rig-zai-anthropic" }
+# Custom OpenAI Responses provider for reasoning models
+rig-openai-responses = { path = "../rig-openai-responses" }
 
 # HTTP client (needed for llm_client.rs)
 reqwest = { workspace = true }

--- a/backend/crates/qbit-ai/src/agentic_loop.rs
+++ b/backend/crates/qbit-ai/src/agentic_loop.rs
@@ -122,6 +122,18 @@ async fn execute_sub_agent_with_client(
             )
             .await
         }
+        LlmClient::OpenAiReasoning(model) => {
+            execute_sub_agent(
+                agent_def,
+                args,
+                context,
+                model,
+                ctx,
+                tool_provider,
+                parent_request_id,
+            )
+            .await
+        }
         LlmClient::RigAnthropic(model) => {
             execute_sub_agent(
                 agent_def,

--- a/backend/crates/qbit-ai/src/summarizer.rs
+++ b/backend/crates/qbit-ai/src/summarizer.rs
@@ -229,6 +229,7 @@ async fn call_summarizer_model(client: &LlmClient, user_message: Message) -> Res
         LlmClient::RigOpenRouter(model) => complete_with_model!(model),
         LlmClient::RigOpenAi(model) => complete_with_model!(model),
         LlmClient::RigOpenAiResponses(model) => complete_with_model!(model),
+        LlmClient::OpenAiReasoning(model) => complete_with_model!(model),
         LlmClient::RigAnthropic(model) => complete_with_model!(model),
         LlmClient::RigOllama(model) => complete_with_model!(model),
         LlmClient::RigGemini(model) => complete_with_model!(model),

--- a/backend/crates/qbit-ai/src/system_hooks/builtins.rs
+++ b/backend/crates/qbit-ai/src/system_hooks/builtins.rs
@@ -35,17 +35,18 @@ fn plan_completion_hook() -> ToolHook {
             }
 
             Some(
-                "Plan complete. Update documentation to reflect what was achieved:
+                "[Plan Complete - Documentation Check]
 
-**Developer docs** (README.md, ./docs/*.md) — for humans:
-- Commands, features, configuration, APIs
-- Setup/install changes, breaking changes
+SKIP documentation updates for: bug fixes, refactors, minor tweaks, test changes, or any work that doesn't change external behavior or developer workflow.
 
-**Agent instructions** (CLAUDE.md, AGENTS.md) — for AI coding agents:
-- Code patterns, conventions, project structure
-- Build/test commands, non-obvious implementation details
+For SIGNIFICANT changes only (new features, new commands, API changes, breaking changes):
+- **Developer docs** (README.md, docs/*.md): commands, setup, APIs
+- **Agent docs** (CLAUDE.md): code patterns, conventions, build commands
 
-Check which files exist and update only those with relevant new information."
+STOP CONDITIONS:
+- Do NOT create new plan tasks after reading this message
+- Do NOT call update_plan again
+- If no docs need updating, respond to the user that the task is complete"
                     .to_string(),
             )
         },
@@ -139,7 +140,7 @@ mod tests {
 
         let message = hook.execute_post(&ctx);
         assert!(message.is_some());
-        assert!(message.unwrap().contains("Plan complete"));
+        assert!(message.unwrap().contains("Plan Complete"));
     }
 
     #[test]

--- a/backend/crates/qbit-ai/src/system_hooks/registry.rs
+++ b/backend/crates/qbit-ai/src/system_hooks/registry.rs
@@ -228,7 +228,7 @@ mod tests {
         let messages = registry.run_post_tool_hooks(&ctx);
         // Should have the plan completion message
         assert!(!messages.is_empty());
-        assert!(messages[0].contains("Plan complete"));
+        assert!(messages[0].contains("Plan Complete"));
     }
 
     #[test]

--- a/backend/crates/qbit-llm-providers/Cargo.toml
+++ b/backend/crates/qbit-llm-providers/Cargo.toml
@@ -12,6 +12,8 @@ rig-vertexai = { workspace = true }
 rig-anthropic-vertex = { path = "../rig-anthropic-vertex" }
 rig-zai = { path = "../rig-zai" }
 rig-zai-anthropic = { path = "../rig-zai-anthropic" }
+# Custom OpenAI Responses provider with explicit reasoning event separation
+rig-openai-responses = { path = "../rig-openai-responses" }
 
 # HTTP client (needed for some rig providers)
 reqwest = { workspace = true }

--- a/backend/crates/qbit-settings/src/template.toml
+++ b/backend/crates/qbit-settings/src/template.toml
@@ -16,6 +16,9 @@ default_provider = "vertex_ai"
 # Default model for the selected provider
 default_model = "claude-opus-4-5@20251101"
 
+# Default reasoning effort for models that support it (e.g., OpenAI reasoning models)
+# default_reasoning_effort = "medium" # low | medium | high
+
 # Per-sub-agent model overrides
 # Use a different model for specific sub-agents (e.g., cheaper model for code generation)
 # Example:

--- a/backend/crates/qbit/src/ai/commands/commit_writer.rs
+++ b/backend/crates/qbit/src/ai/commands/commit_writer.rs
@@ -172,6 +172,10 @@ async fn complete_with_client(
             let response = model.completion(request).await?;
             Ok(extract_text(&response.choice))
         }
+        LlmClient::OpenAiReasoning(model) => {
+            let response = model.completion(request).await?;
+            Ok(extract_text(&response.choice))
+        }
         LlmClient::RigAnthropic(model) => {
             let response = model.completion(request).await?;
             Ok(extract_text(&response.choice))

--- a/backend/crates/qbit/src/ai/commands/workflow.rs
+++ b/backend/crates/qbit/src/ai/commands/workflow.rs
@@ -201,6 +201,16 @@ impl WorkflowLlmExecutor for BridgeLlmExecutor {
                 }
                 text
             }
+            LlmClient::OpenAiReasoning(model) => {
+                let response = model.completion(request).await?;
+                let mut text = String::new();
+                for content in response.choice.iter() {
+                    if let rig::completion::AssistantContent::Text(t) = content {
+                        text.push_str(&t.text);
+                    }
+                }
+                text
+            }
             LlmClient::RigAnthropic(model) => {
                 let response = model.completion(request).await?;
                 let mut text = String::new();
@@ -412,6 +422,10 @@ impl WorkflowLlmExecutor for BridgeLlmExecutor {
                     response.choice
                 }
                 LlmClient::RigOpenAiResponses(model) => {
+                    let response = model.completion(request).await?;
+                    response.choice
+                }
+                LlmClient::OpenAiReasoning(model) => {
                     let response = model.completion(request).await?;
                     response.choice
                 }

--- a/backend/crates/rig-openai-responses/Cargo.toml
+++ b/backend/crates/rig-openai-responses/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rig-openai-responses"
+version = "0.1.0"
+edition = "2021"
+description = "OpenAI Responses API adapter for rig-core with explicit reasoning model support"
+license = "MIT"
+
+[dependencies]
+# Core
+rig-core = "^0.29.0"
+async-openai = { version = "0.32", default-features = false, features = ["responses", "rustls"] }
+
+# Async
+futures = "0.3"
+tokio = { version = "1", features = ["rt"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Utilities
+tracing = "0.1"
+thiserror = "2.0"

--- a/backend/crates/rig-openai-responses/PLAN.md
+++ b/backend/crates/rig-openai-responses/PLAN.md
@@ -1,0 +1,436 @@
+# Plan: rig-openai-responses Crate (Revised)
+
+Thin adapter crate that wraps `async-openai` to provide rig-core `CompletionModel` trait implementation with explicit streaming event handling for reasoning models (o1, o3, gpt-5.x).
+
+## Motivation
+
+The rig-core library has known issues with streaming event handling:
+- **Issue #1054**: Events are inconsistent between providers
+- **Issue #1072**: OpenAI-with-reasoning streaming isn't unified
+
+## Key Decision: Use async-openai
+
+Instead of building SSE parsing from scratch, we leverage **[async-openai](https://github.com/64bit/async-openai)** (v0.32.3):
+
+| What async-openai provides | What we build |
+|---------------------------|---------------|
+| All OpenAI API types | rig-core trait adapter |
+| HTTP client with auth | Event mapping logic |
+| SSE parsing | `CompletionModel` impl |
+| `ResponseStreamEvent` enum (40+ variants) | `RawStreamingChoice` conversion |
+| Battle-tested, maintained | Thin integration layer |
+
+### async-openai Event Types We'll Use
+
+```rust
+// From async-openai::types::responses::stream
+ResponseStreamEvent::ResponseOutputTextDelta(e)           // text delta
+ResponseStreamEvent::ResponseReasoningSummaryTextDelta(e) // reasoning delta
+ResponseStreamEvent::ResponseReasoningTextDelta(e)        // reasoning text delta
+ResponseStreamEvent::ResponseFunctionCallArgumentsDelta(e) // tool args delta
+ResponseStreamEvent::ResponseCompleted(e)                  // completion with usage
+ResponseStreamEvent::ResponseError(e)                      // errors
+```
+
+## Architecture
+
+### Crate Structure (Simplified)
+
+```
+rig-openai-responses/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs           # Module exports, re-exports
+│   ├── completion.rs    # CompletionModel implementation + stream mapping
+│   └── error.rs         # Error type wrapper
+```
+
+**No custom types.rs or streaming.rs needed** - async-openai provides everything.
+
+### Key Types
+
+#### Event Mapping: async-openai → rig-core
+
+```rust
+use async_openai::types::ResponseStreamEvent;
+use rig::streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent};
+
+fn map_event(event: ResponseStreamEvent) -> Option<RawStreamingChoice<StreamingResponseData>> {
+    match event {
+        // Text deltas → Message
+        ResponseStreamEvent::ResponseOutputTextDelta(e) => {
+            Some(RawStreamingChoice::Message(e.delta))
+        }
+
+        // Reasoning deltas → ReasoningDelta (EXPLICIT separation!)
+        ResponseStreamEvent::ResponseReasoningSummaryTextDelta(e) => {
+            Some(RawStreamingChoice::ReasoningDelta {
+                id: Some(e.item_id),
+                reasoning: e.delta,
+            })
+        }
+        ResponseStreamEvent::ResponseReasoningTextDelta(e) => {
+            Some(RawStreamingChoice::ReasoningDelta {
+                id: Some(e.item_id),
+                reasoning: e.delta,
+            })
+        }
+
+        // Function call deltas → ToolCallDelta
+        ResponseStreamEvent::ResponseFunctionCallArgumentsDelta(e) => {
+            Some(RawStreamingChoice::ToolCallDelta {
+                id: e.item_id,
+                content: ToolCallDeltaContent::Delta(e.delta),
+            })
+        }
+
+        // Function call start (from OutputItemAdded)
+        ResponseStreamEvent::ResponseOutputItemAdded(e) => {
+            if let OutputItem::FunctionCall { id, call_id, name, .. } = e.item {
+                Some(RawStreamingChoice::ToolCall(RawStreamingToolCall {
+                    id: id.clone(),
+                    call_id: Some(call_id),
+                    name,
+                    arguments: serde_json::json!({}),
+                    signature: None,
+                    additional_params: None,
+                }))
+            } else {
+                None
+            }
+        }
+
+        // Completion → FinalResponse with usage
+        ResponseStreamEvent::ResponseCompleted(e) => {
+            Some(RawStreamingChoice::FinalResponse(StreamingResponseData {
+                usage: e.response.usage.map(|u| Usage {
+                    prompt_tokens: u.input_tokens,
+                    completion_tokens: u.output_tokens,
+                    total_tokens: u.total_tokens,
+                }),
+            }))
+        }
+
+        // Errors
+        ResponseStreamEvent::ResponseError(e) => {
+            tracing::error!("OpenAI stream error: {:?}", e);
+            Some(RawStreamingChoice::Message(format!("[Error: {:?}]", e)))
+        }
+
+        // Lifecycle events we don't need to emit
+        ResponseStreamEvent::ResponseCreated(_)
+        | ResponseStreamEvent::ResponseInProgress(_)
+        | ResponseStreamEvent::ResponseOutputItemDone(_)
+        | ResponseStreamEvent::ResponseContentPartAdded(_)
+        | ResponseStreamEvent::ResponseContentPartDone(_)
+        | ResponseStreamEvent::ResponseOutputTextDone(_)
+        | ResponseStreamEvent::ResponseReasoningSummaryTextDone(_)
+        | ResponseStreamEvent::ResponseReasoningTextDone(_)
+        | ResponseStreamEvent::ResponseFunctionCallArgumentsDone(_) => None,
+
+        // Other events (web search, file search, etc.) - log and skip for now
+        other => {
+            tracing::debug!("Unhandled OpenAI stream event: {:?}", other);
+            None
+        }
+    }
+}
+```
+
+#### CompletionModel (`completion.rs`)
+
+```rust
+use async_openai::{Client as OpenAIClient, config::OpenAIConfig};
+use async_openai::types::{
+    CreateResponseArgs, ResponseStreamEvent, ReasoningEffort as OAReasoningEffort,
+};
+use rig::completion::{self, CompletionError, CompletionRequest, CompletionResponse};
+use rig::streaming::{RawStreamingChoice, StreamingCompletionResponse};
+
+/// Wrapper around async-openai client
+pub struct Client {
+    inner: OpenAIClient<OpenAIConfig>,
+}
+
+impl Client {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        let config = OpenAIConfig::new().with_api_key(api_key);
+        Self {
+            inner: OpenAIClient::with_config(config),
+        }
+    }
+
+    pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        let config = OpenAIConfig::new()
+            .with_api_key(api_key)
+            .with_api_base(base_url);
+        Self {
+            inner: OpenAIClient::with_config(config),
+        }
+    }
+
+    pub fn completion_model(&self, model: impl Into<String>) -> CompletionModel {
+        CompletionModel::new(self.inner.clone(), model.into())
+    }
+}
+
+pub struct CompletionModel {
+    client: OpenAIClient<OpenAIConfig>,
+    model: String,
+    reasoning_effort: Option<ReasoningEffort>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ReasoningEffort {
+    Low,
+    Medium,
+    High,
+}
+
+impl CompletionModel {
+    pub fn new(client: OpenAIClient<OpenAIConfig>, model: String) -> Self {
+        Self {
+            client,
+            model,
+            reasoning_effort: None,
+        }
+    }
+
+    pub fn with_reasoning_effort(mut self, effort: ReasoningEffort) -> Self {
+        self.reasoning_effort = Some(effort);
+        self
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct StreamingResponseData {
+    pub usage: Option<Usage>,
+}
+
+impl rig::completion::GetTokenUsage for StreamingResponseData {
+    fn token_usage(&self) -> Option<rig::completion::Usage> {
+        self.usage.as_ref().map(|u| rig::completion::Usage {
+            input_tokens: u.input_tokens as u64,
+            output_tokens: u.output_tokens as u64,
+            total_tokens: (u.input_tokens + u.output_tokens) as u64,
+        })
+    }
+}
+
+impl completion::CompletionModel for CompletionModel {
+    type Response = async_openai::types::Response;
+    type StreamingResponse = StreamingResponseData;
+    type Client = Client;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self::new(client.inner.clone(), model.into())
+    }
+
+    async fn completion(&self, request: CompletionRequest)
+        -> Result<CompletionResponse<Self::Response>, CompletionError>
+    {
+        let openai_request = self.build_request(&request)?;
+
+        let response = self.client
+            .responses()
+            .create(openai_request)
+            .await
+            .map_err(|e| CompletionError::ProviderError(e.to_string()))?;
+
+        Ok(self.convert_response(response))
+    }
+
+    async fn stream(&self, request: CompletionRequest)
+        -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError>
+    {
+        let openai_request = self.build_request(&request)?;
+
+        let stream = self.client
+            .responses()
+            .create_stream(openai_request)
+            .await
+            .map_err(|e| CompletionError::ProviderError(e.to_string()))?;
+
+        // Map async-openai events to rig-core RawStreamingChoice
+        use futures::StreamExt;
+        let mapped = stream.filter_map(|result| async move {
+            match result {
+                Ok(event) => map_event(event),
+                Err(e) => {
+                    tracing::error!("Stream error: {}", e);
+                    Some(Ok(RawStreamingChoice::Message(format!("[Error: {}]", e))))
+                }
+            }
+        });
+
+        Ok(StreamingCompletionResponse::stream(Box::pin(mapped)))
+    }
+}
+```
+
+## Key Differences from rig-core
+
+| Aspect | rig-core | rig-openai-responses |
+|--------|----------|---------------------|
+| Event granularity | 6 types | 12+ explicit types |
+| Reasoning handling | Mixed with text | Explicit ReasoningStart/Delta/Done |
+| Tool call tracking | Stateless | Stateful (tracks pending calls) |
+| Error handling | Generic | OpenAI-specific error types |
+| Reasoning IDs | Optional | Always preserved (required for history) |
+
+## Integration Points
+
+### 1. LlmClient Enum (`qbit-llm-providers/src/lib.rs`)
+
+```rust
+pub enum LlmClient {
+    // ... existing variants ...
+
+    /// OpenAI Responses API with explicit reasoning support
+    RigOpenAiResponsesCustom(rig_openai_responses::CompletionModel),
+}
+```
+
+### 2. Client Creation (`qbit-ai/src/llm_client.rs`)
+
+```rust
+pub async fn create_openai_reasoning_components(
+    config: OpenAiClientConfig<'_>,
+    shared_config: SharedComponentsConfig,
+) -> Result<AgentBridgeComponents> {
+    // Use custom provider for reasoning models
+    let client = rig_openai_responses::Client::new(&config.api_key);
+    let mut completion_model = client.completion_model(&config.model);
+
+    // Configure reasoning effort for reasoning models
+    if let Some(effort) = config.reasoning_effort {
+        completion_model = completion_model.with_reasoning_effort(
+            match effort.as_str() {
+                "low" => rig_openai_responses::ReasoningEffort::Low,
+                "medium" => rig_openai_responses::ReasoningEffort::Medium,
+                _ => rig_openai_responses::ReasoningEffort::High,
+            }
+        );
+    }
+
+    Ok(AgentBridgeComponents {
+        model: LlmClient::RigOpenAiResponsesCustom(completion_model),
+        model_name: config.model.to_string(),
+        provider_name: "openai_responses_custom".to_string(),
+        // ... rest of config
+    })
+}
+
+/// Detect if a model should use the custom reasoning provider
+pub fn is_openai_reasoning_model(model: &str) -> bool {
+    let model_lower = model.to_lowercase();
+    model_lower.starts_with("o1")
+        || model_lower.starts_with("o3")
+        || model_lower.starts_with("o4")
+        || model_lower.starts_with("gpt-5")
+}
+```
+
+## Benefits
+
+1. **Explicit reasoning event handling** - No ambiguity between text and reasoning
+2. **Correct reasoning ID preservation** - Required for multi-turn conversations
+3. **Model-specific configuration** - Reasoning effort, web search settings
+4. **Better debugging** - Clear event types in logs
+5. **Future-proof** - Easy to add new event types as OpenAI adds them
+
+## Implementation Order (Simplified)
+
+1. **Phase 1: Crate Setup** (~30 min)
+   - Create `Cargo.toml` with dependencies
+   - Create `lib.rs` with module structure
+   - Create `error.rs` with error wrapper
+
+2. **Phase 2: Core Implementation** (~2 hours)
+   - Create `completion.rs`:
+     - `Client` wrapper around async-openai
+     - `CompletionModel` struct with builder methods
+     - `map_event()` function for stream mapping
+     - Implement `completion::CompletionModel` trait
+   - Message conversion (rig `Message` ↔ async-openai `Input`)
+   - Tool definition conversion
+
+3. **Phase 3: Integration** (~1 hour)
+   - Add `RigOpenAiResponsesCustom` to `LlmClient` enum
+   - Create `create_openai_reasoning_components()` function
+   - Auto-detect reasoning models to use this provider
+
+4. **Phase 4: Testing** (~1 hour)
+   - Unit tests for event mapping
+   - Integration test with mocked responses
+   - Manual E2E test with real API
+
+## Review Feedback (Addressed)
+
+Using `async-openai` eliminates most of the original review concerns:
+
+| Original Concern | Resolution |
+|-----------------|------------|
+| SSE parsing edge cases | Handled by async-openai |
+| PendingToolCall state | Handled by async-openai |
+| Usage data location | Handled by async-openai (`ResponseCompleted` event) |
+| Event name verification | Verified by async-openai against real API |
+| GetTokenUsage impl | Still needed - shown in completion.rs |
+| Refusal mapping | Map to `RawStreamingChoice::Message("[Refusal] ...")` |
+
+### Remaining Items to Implement
+
+1. **Message conversion** - rig `Message` ↔ async-openai `Input`
+2. **Tool definition conversion** - rig `ToolDefinition` ↔ async-openai tool format
+3. **Azure support** - Use `Client::with_base_url()` for custom endpoints
+
+### Verified: rig-core 0.29.0 RawStreamingChoice Variants
+
+Confirmed these variants exist for our mapping:
+- `RawStreamingChoice::Message(String)` - for text deltas
+- `RawStreamingChoice::Reasoning { id, reasoning, signature }` - for complete reasoning
+- `RawStreamingChoice::ReasoningDelta { id, reasoning }` - for reasoning deltas ✓
+- `RawStreamingChoice::ToolCall(RawStreamingToolCall)` - for tool calls
+- `RawStreamingChoice::ToolCallDelta { id, content }` - for tool arg deltas
+- `RawStreamingChoice::FinalResponse(R)` - for completion
+
+### Pre-Implementation Verification: DONE
+
+**async-openai v0.32.3** has already verified all event types against the real OpenAI API.
+The `ResponseStreamEvent` enum matches the official API spec.
+
+## Testing Strategy (Simplified)
+
+1. **Unit tests** for `map_event()` function - verify each event type maps correctly
+2. **Unit tests** for message/tool conversion - rig types ↔ async-openai types
+3. **Integration tests** with mocked async-openai client
+4. **Manual E2E test** with real API (requires OPENAI_API_KEY)
+5. **Regression test** - verify reasoning deltas are NOT mixed with text deltas
+
+## Dependencies (Simplified)
+
+```toml
+[package]
+name = "rig-openai-responses"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# Core
+rig-core = "^0.29.0"
+async-openai = { version = "0.32", features = ["responses"] }
+
+# Async
+futures = "0.3"
+tokio = { version = "1", features = ["rt"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Utilities
+tracing = "0.1"
+thiserror = "2.0"
+```
+
+**Note**: No reqwest or bytes needed - async-openai handles HTTP and SSE parsing.

--- a/backend/crates/rig-openai-responses/src/completion.rs
+++ b/backend/crates/rig-openai-responses/src/completion.rs
@@ -1,0 +1,649 @@
+//! CompletionModel implementation for OpenAI Responses API.
+
+use async_openai::config::OpenAIConfig;
+use async_openai::types::responses::{
+    CreateResponse, EasyInputContent, EasyInputMessage, FunctionTool, InputItem, InputParam,
+    MessageType, OutputItem, OutputMessageContent, Reasoning, ReasoningEffort as OAReasoningEffort,
+    ReasoningSummary, Response, ResponseStreamEvent, Role, SummaryPart, Tool,
+};
+use async_openai::Client as OpenAIClient;
+use futures::StreamExt;
+use rig::completion::{
+    self, AssistantContent, CompletionError, CompletionRequest, CompletionResponse, Message,
+    ToolDefinition,
+};
+use rig::message::{Text, ToolCall, ToolFunction, UserContent};
+use rig::one_or_many::OneOrMany;
+use rig::streaming::{
+    RawStreamingChoice, RawStreamingToolCall, StreamingCompletionResponse, ToolCallDeltaContent,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::OpenAiResponsesError;
+
+// ============================================================================
+// Client
+// ============================================================================
+
+/// Wrapper around async-openai client for creating completion models.
+#[derive(Clone)]
+pub struct Client {
+    inner: OpenAIClient<OpenAIConfig>,
+}
+
+impl Client {
+    /// Create a new client with the given API key.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        let config = OpenAIConfig::new().with_api_key(api_key);
+        Self {
+            inner: OpenAIClient::with_config(config),
+        }
+    }
+
+    /// Create a new client with a custom base URL (e.g., for Azure OpenAI).
+    pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        let config = OpenAIConfig::new()
+            .with_api_key(api_key)
+            .with_api_base(base_url);
+        Self {
+            inner: OpenAIClient::with_config(config),
+        }
+    }
+
+    /// Create a completion model for the given model name.
+    pub fn completion_model(&self, model: impl Into<String>) -> CompletionModel {
+        CompletionModel::new(self.clone(), model.into())
+    }
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client").finish_non_exhaustive()
+    }
+}
+
+// ============================================================================
+// ReasoningEffort
+// ============================================================================
+
+/// Reasoning effort level for OpenAI reasoning models.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ReasoningEffort {
+    /// Low reasoning effort - faster but less thorough.
+    Low,
+    /// Medium reasoning effort - balanced.
+    #[default]
+    Medium,
+    /// High reasoning effort - slower but more thorough.
+    High,
+}
+
+impl From<ReasoningEffort> for OAReasoningEffort {
+    fn from(effort: ReasoningEffort) -> Self {
+        match effort {
+            ReasoningEffort::Low => OAReasoningEffort::Low,
+            ReasoningEffort::Medium => OAReasoningEffort::Medium,
+            ReasoningEffort::High => OAReasoningEffort::High,
+        }
+    }
+}
+
+// ============================================================================
+// CompletionModel
+// ============================================================================
+
+/// Completion model for OpenAI Responses API with explicit reasoning support.
+#[derive(Clone)]
+pub struct CompletionModel {
+    client: Client,
+    model: String,
+    reasoning_effort: Option<ReasoningEffort>,
+}
+
+impl CompletionModel {
+    /// Create a new completion model.
+    pub fn new(client: Client, model: String) -> Self {
+        Self {
+            client,
+            model,
+            reasoning_effort: None,
+        }
+    }
+
+    /// Set the reasoning effort level for reasoning models.
+    pub fn with_reasoning_effort(mut self, effort: ReasoningEffort) -> Self {
+        self.reasoning_effort = Some(effort);
+        self
+    }
+
+    /// Get the model name.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Build an OpenAI Responses API request from a rig CompletionRequest.
+    fn build_request(
+        &self,
+        request: &CompletionRequest,
+    ) -> Result<CreateResponse, OpenAiResponsesError> {
+        // Convert chat history to input items using EasyInputMessage
+        let mut input_items: Vec<InputItem> = Vec::new();
+
+        for msg in request.chat_history.iter() {
+            match msg {
+                Message::User { content } => {
+                    let text = extract_user_text(content);
+                    if !text.is_empty() {
+                        input_items.push(InputItem::EasyMessage(EasyInputMessage {
+                            r#type: MessageType::Message,
+                            role: Role::User,
+                            content: EasyInputContent::Text(text),
+                        }));
+                    }
+                }
+                Message::Assistant { content, .. } => {
+                    let text = extract_assistant_text(content);
+                    if !text.is_empty() {
+                        input_items.push(InputItem::EasyMessage(EasyInputMessage {
+                            r#type: MessageType::Message,
+                            role: Role::Assistant,
+                            content: EasyInputContent::Text(text),
+                        }));
+                    }
+                }
+            }
+        }
+
+        // Add the current prompt/preamble as a system/developer message
+        if let Some(preamble) = &request.preamble {
+            input_items.insert(
+                0,
+                InputItem::EasyMessage(EasyInputMessage {
+                    r#type: MessageType::Message,
+                    role: Role::Developer,
+                    content: EasyInputContent::Text(preamble.clone()),
+                }),
+            );
+        }
+
+        // Build the input
+        let input = if input_items.is_empty() {
+            InputParam::Text(String::new())
+        } else if input_items.len() == 1 {
+            // For single user text message, we can use simple text input
+            if let InputItem::EasyMessage(msg) = &input_items[0] {
+                if matches!(msg.role, Role::User) {
+                    if let EasyInputContent::Text(text) = &msg.content {
+                        InputParam::Text(text.clone())
+                    } else {
+                        InputParam::Items(input_items)
+                    }
+                } else {
+                    InputParam::Items(input_items)
+                }
+            } else {
+                InputParam::Items(input_items)
+            }
+        } else {
+            InputParam::Items(input_items)
+        };
+
+        // Convert tools
+        let tools: Option<Vec<Tool>> = if request.tools.is_empty() {
+            None
+        } else {
+            Some(request.tools.iter().map(convert_tool_definition).collect())
+        };
+
+        // Build reasoning config if enabled
+        let reasoning = self.reasoning_effort.map(|effort| Reasoning {
+            effort: Some(effort.into()),
+            summary: Some(ReasoningSummary::Auto),
+        });
+
+        // Build the request
+        // Note: Reasoning models (o1, o3, o4, gpt-5.x) don't support temperature
+        let temperature = if crate::is_reasoning_model(&self.model) {
+            if request.temperature.is_some() {
+                tracing::debug!(
+                    "Ignoring temperature parameter for reasoning model {}",
+                    self.model
+                );
+            }
+            None
+        } else {
+            request.temperature.map(|t| t as f32)
+        };
+
+        Ok(CreateResponse {
+            model: Some(self.model.clone()),
+            input,
+            tools,
+            reasoning,
+            temperature,
+            max_output_tokens: request.max_tokens.map(|t| t as u32),
+            ..Default::default()
+        })
+    }
+
+    /// Convert an OpenAI Response to a rig CompletionResponse.
+    fn convert_response(response: Response) -> CompletionResponse<Response> {
+        let mut content: Vec<AssistantContent> = Vec::new();
+
+        // Extract content from output items
+        for output in &response.output {
+            match output {
+                OutputItem::Message(msg) => {
+                    for c in &msg.content {
+                        match c {
+                            OutputMessageContent::OutputText(text_output) => {
+                                content.push(AssistantContent::Text(Text {
+                                    text: text_output.text.clone(),
+                                }));
+                            }
+                            OutputMessageContent::Refusal(refusal) => {
+                                content.push(AssistantContent::Text(Text {
+                                    text: format!("[Refusal]: {}", refusal.refusal),
+                                }));
+                            }
+                        }
+                    }
+                }
+                OutputItem::Reasoning(reasoning) => {
+                    // Extract reasoning text from summary
+                    // SummaryPart only has one variant (SummaryText), so we use map
+                    let reasoning_text: String = reasoning
+                        .summary
+                        .iter()
+                        .map(|SummaryPart::SummaryText(st)| st.text.clone())
+                        .collect::<Vec<_>>()
+                        .join("\n");
+
+                    if !reasoning_text.is_empty() {
+                        // Create Reasoning using rig's builder pattern
+                        content.push(AssistantContent::Reasoning(
+                            rig::message::Reasoning::new(&reasoning_text)
+                                .with_id(reasoning.id.clone()),
+                        ));
+                    }
+                }
+                OutputItem::FunctionCall(fc) => {
+                    let arguments: serde_json::Value =
+                        serde_json::from_str(&fc.arguments).unwrap_or(serde_json::json!({}));
+                    // fc.id is Option<String>, use empty string as fallback
+                    let id = fc.id.clone().unwrap_or_default();
+                    content.push(AssistantContent::ToolCall(ToolCall {
+                        id,
+                        call_id: Some(fc.call_id.clone()),
+                        function: ToolFunction {
+                            name: fc.name.clone(),
+                            arguments,
+                        },
+                        signature: None,
+                        additional_params: None,
+                    }));
+                }
+                _ => {}
+            }
+        }
+
+        // Extract usage
+        let usage = response.usage.as_ref().map(|u| rig::completion::Usage {
+            input_tokens: u.input_tokens as u64,
+            output_tokens: u.output_tokens as u64,
+            total_tokens: u.total_tokens as u64,
+        });
+
+        CompletionResponse {
+            choice: OneOrMany::many(content).unwrap_or_else(|_| {
+                OneOrMany::one(AssistantContent::Text(Text {
+                    text: String::new(),
+                }))
+            }),
+            usage: usage.unwrap_or(rig::completion::Usage {
+                input_tokens: 0,
+                output_tokens: 0,
+                total_tokens: 0,
+            }),
+            raw_response: response,
+        }
+    }
+}
+
+impl std::fmt::Debug for CompletionModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompletionModel")
+            .field("model", &self.model)
+            .field("reasoning_effort", &self.reasoning_effort)
+            .finish_non_exhaustive()
+    }
+}
+
+// ============================================================================
+// StreamingResponseData
+// ============================================================================
+
+/// Data accumulated during streaming, returned as the final response.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct StreamingResponseData {
+    /// Token usage statistics (populated at end of stream).
+    pub usage: Option<Usage>,
+}
+
+/// Token usage for streaming responses.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Usage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub total_tokens: u32,
+}
+
+impl rig::completion::GetTokenUsage for StreamingResponseData {
+    fn token_usage(&self) -> Option<rig::completion::Usage> {
+        self.usage.as_ref().map(|u| rig::completion::Usage {
+            input_tokens: u.input_tokens as u64,
+            output_tokens: u.output_tokens as u64,
+            total_tokens: u.total_tokens as u64,
+        })
+    }
+}
+
+// ============================================================================
+// CompletionModel Trait Implementation
+// ============================================================================
+
+impl completion::CompletionModel for CompletionModel {
+    type Response = Response;
+    type StreamingResponse = StreamingResponseData;
+    type Client = Client;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self::new(client.clone(), model.into())
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        let openai_request = self.build_request(&request)?;
+
+        let response = self
+            .client
+            .inner
+            .responses()
+            .create(openai_request)
+            .await
+            .map_err(|e| CompletionError::ProviderError(e.to_string()))?;
+
+        Ok(Self::convert_response(response))
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        let openai_request = self.build_request(&request)?;
+
+        tracing::debug!("Starting OpenAI Responses stream for model: {}", self.model);
+
+        let stream = self
+            .client
+            .inner
+            .responses()
+            .create_stream(openai_request)
+            .await
+            .map_err(|e| CompletionError::ProviderError(e.to_string()))?;
+
+        // Map async-openai events to rig-core RawStreamingChoice
+        let mapped = stream.filter_map(|result| async move {
+            match result {
+                Ok(event) => map_stream_event(event).map(Ok),
+                Err(e) => {
+                    tracing::error!("OpenAI stream error: {}", e);
+                    Some(Ok(RawStreamingChoice::Message(format!("[Error: {}]", e))))
+                }
+            }
+        });
+
+        Ok(StreamingCompletionResponse::stream(Box::pin(mapped)))
+    }
+}
+
+// ============================================================================
+// Event Mapping
+// ============================================================================
+
+/// Map an async-openai ResponseStreamEvent to a rig-core RawStreamingChoice.
+///
+/// This is the core function that ensures reasoning events are explicitly
+/// separated from text events.
+fn map_stream_event(
+    event: ResponseStreamEvent,
+) -> Option<RawStreamingChoice<StreamingResponseData>> {
+    match event {
+        // Text deltas → Message
+        ResponseStreamEvent::ResponseOutputTextDelta(e) => {
+            tracing::trace!("Text delta: {} chars", e.delta.len());
+            Some(RawStreamingChoice::Message(e.delta))
+        }
+
+        // Reasoning summary deltas → ReasoningDelta (EXPLICIT separation!)
+        ResponseStreamEvent::ResponseReasoningSummaryTextDelta(e) => {
+            tracing::trace!("Reasoning summary delta: {} chars", e.delta.len());
+            Some(RawStreamingChoice::ReasoningDelta {
+                id: Some(e.item_id),
+                reasoning: e.delta,
+            })
+        }
+
+        // Reasoning text deltas → ReasoningDelta
+        ResponseStreamEvent::ResponseReasoningTextDelta(e) => {
+            tracing::trace!("Reasoning text delta: {} chars", e.delta.len());
+            Some(RawStreamingChoice::ReasoningDelta {
+                id: Some(e.item_id),
+                reasoning: e.delta,
+            })
+        }
+
+        // Function call argument deltas → ToolCallDelta
+        ResponseStreamEvent::ResponseFunctionCallArgumentsDelta(e) => {
+            tracing::trace!("Function call args delta: {} chars", e.delta.len());
+            Some(RawStreamingChoice::ToolCallDelta {
+                id: e.item_id,
+                content: ToolCallDeltaContent::Delta(e.delta),
+            })
+        }
+
+        // Output item added - check for function calls
+        ResponseStreamEvent::ResponseOutputItemAdded(e) => {
+            if let OutputItem::FunctionCall(fc) = e.item {
+                tracing::info!("Function call started: {}", fc.name);
+                // fc.id is Option<String>, use empty string as fallback
+                let id = fc.id.clone().unwrap_or_default();
+                Some(RawStreamingChoice::ToolCall(RawStreamingToolCall {
+                    id,
+                    call_id: Some(fc.call_id),
+                    name: fc.name,
+                    arguments: serde_json::json!({}),
+                    signature: None,
+                    additional_params: None,
+                }))
+            } else {
+                None
+            }
+        }
+
+        // Response completed → FinalResponse with usage
+        ResponseStreamEvent::ResponseCompleted(e) => {
+            tracing::info!("Response completed");
+            let usage = e.response.usage.map(|u| Usage {
+                input_tokens: u.input_tokens,
+                output_tokens: u.output_tokens,
+                total_tokens: u.total_tokens,
+            });
+            Some(RawStreamingChoice::FinalResponse(StreamingResponseData {
+                usage,
+            }))
+        }
+
+        // Errors - ResponseErrorEvent has code, message, param fields
+        ResponseStreamEvent::ResponseError(e) => {
+            tracing::error!(
+                "OpenAI response error: code={:?}, message={:?}",
+                e.code,
+                e.message
+            );
+            Some(RawStreamingChoice::Message(format!(
+                "[Error: {:?} - {:?}]",
+                e.code, e.message
+            )))
+        }
+
+        // Response failed
+        ResponseStreamEvent::ResponseFailed(e) => {
+            tracing::error!("OpenAI response failed: {:?}", e.response.status);
+            Some(RawStreamingChoice::Message(format!(
+                "[Response failed: {:?}]",
+                e.response.status
+            )))
+        }
+
+        // Refusal deltas
+        ResponseStreamEvent::ResponseRefusalDelta(e) => {
+            tracing::warn!("Refusal delta received");
+            Some(RawStreamingChoice::Message(format!(
+                "[Refusal] {}",
+                e.delta
+            )))
+        }
+
+        // Lifecycle events we don't need to emit as content
+        ResponseStreamEvent::ResponseCreated(_)
+        | ResponseStreamEvent::ResponseInProgress(_)
+        | ResponseStreamEvent::ResponseIncomplete(_)
+        | ResponseStreamEvent::ResponseQueued(_)
+        | ResponseStreamEvent::ResponseOutputItemDone(_)
+        | ResponseStreamEvent::ResponseContentPartAdded(_)
+        | ResponseStreamEvent::ResponseContentPartDone(_)
+        | ResponseStreamEvent::ResponseOutputTextDone(_)
+        | ResponseStreamEvent::ResponseRefusalDone(_)
+        | ResponseStreamEvent::ResponseReasoningSummaryPartAdded(_)
+        | ResponseStreamEvent::ResponseReasoningSummaryPartDone(_)
+        | ResponseStreamEvent::ResponseReasoningSummaryTextDone(_)
+        | ResponseStreamEvent::ResponseReasoningTextDone(_)
+        | ResponseStreamEvent::ResponseFunctionCallArgumentsDone(_) => None,
+
+        // Other events (web search, file search, MCP, etc.) - log and skip
+        other => {
+            tracing::debug!("Unhandled OpenAI stream event: {:?}", other);
+            None
+        }
+    }
+}
+
+// ============================================================================
+// Conversion Helpers
+// ============================================================================
+
+/// Extract text content from user message content.
+fn extract_user_text(content: &OneOrMany<UserContent>) -> String {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            UserContent::Text(text) => Some(text.text.clone()),
+            UserContent::ToolResult(result) => {
+                // Extract text from tool result content
+                let result_text = result
+                    .content
+                    .iter()
+                    .filter_map(|item| {
+                        if let rig::message::ToolResultContent::Text(t) = item {
+                            Some(t.text.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if result_text.is_empty() {
+                    None
+                } else {
+                    Some(format!("[Tool result for {}]: {}", result.id, result_text))
+                }
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Extract text content from assistant message content.
+fn extract_assistant_text(content: &OneOrMany<AssistantContent>) -> String {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            AssistantContent::Text(text) => Some(text.text.clone()),
+            AssistantContent::ToolCall(tc) => Some(format!(
+                "[Called tool {}]: {}",
+                tc.function.name,
+                serde_json::to_string(&tc.function.arguments).unwrap_or_default()
+            )),
+            AssistantContent::Reasoning(r) => {
+                Some(format!("[Reasoning]: {}", r.reasoning.join("")))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Convert a rig ToolDefinition to an async-openai Tool.
+fn convert_tool_definition(tool: &ToolDefinition) -> Tool {
+    Tool::Function(FunctionTool {
+        name: tool.name.clone(),
+        description: Some(tool.description.clone()),
+        parameters: Some(tool.parameters.clone()),
+        strict: Some(true),
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reasoning_effort_conversion() {
+        assert!(matches!(
+            OAReasoningEffort::from(ReasoningEffort::Low),
+            OAReasoningEffort::Low
+        ));
+        assert!(matches!(
+            OAReasoningEffort::from(ReasoningEffort::Medium),
+            OAReasoningEffort::Medium
+        ));
+        assert!(matches!(
+            OAReasoningEffort::from(ReasoningEffort::High),
+            OAReasoningEffort::High
+        ));
+    }
+
+    #[test]
+    fn test_extract_user_text() {
+        let content = OneOrMany::one(UserContent::Text(Text {
+            text: "Hello, world!".to_string(),
+        }));
+        assert_eq!(extract_user_text(&content), "Hello, world!");
+    }
+
+    #[test]
+    fn test_extract_assistant_text() {
+        let content = OneOrMany::one(AssistantContent::Text(Text {
+            text: "Hello from assistant!".to_string(),
+        }));
+        assert_eq!(extract_assistant_text(&content), "Hello from assistant!");
+    }
+}

--- a/backend/crates/rig-openai-responses/src/error.rs
+++ b/backend/crates/rig-openai-responses/src/error.rs
@@ -1,0 +1,25 @@
+//! Error types for rig-openai-responses.
+
+use thiserror::Error;
+
+/// Errors that can occur when using the OpenAI Responses API provider.
+#[derive(Debug, Error)]
+pub enum OpenAiResponsesError {
+    /// Error from the async-openai client
+    #[error("OpenAI API error: {0}")]
+    ApiError(#[from] async_openai::error::OpenAIError),
+
+    /// Error converting between rig and OpenAI types
+    #[error("Conversion error: {0}")]
+    ConversionError(String),
+
+    /// JSON serialization/deserialization error
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+}
+
+impl From<OpenAiResponsesError> for rig::completion::CompletionError {
+    fn from(err: OpenAiResponsesError) -> Self {
+        rig::completion::CompletionError::ProviderError(err.to_string())
+    }
+}

--- a/backend/crates/rig-openai-responses/src/lib.rs
+++ b/backend/crates/rig-openai-responses/src/lib.rs
@@ -1,0 +1,77 @@
+//! OpenAI Responses API adapter for rig-core.
+//!
+//! This crate provides a thin adapter layer that wraps `async-openai` to implement
+//! rig-core's `CompletionModel` trait with explicit streaming event handling for
+//! reasoning models (o1, o3, gpt-5.x).
+//!
+//! # Key Features
+//!
+//! - **Explicit reasoning event separation**: Reasoning deltas are mapped to
+//!   `RawStreamingChoice::ReasoningDelta`, never mixed with text deltas.
+//! - **Full Responses API support**: Uses OpenAI's newer Responses API instead
+//!   of the Chat Completions API.
+//! - **Reasoning effort configuration**: Configure `low`, `medium`, or `high`
+//!   reasoning effort for supported models.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use rig_openai_responses::{Client, ReasoningEffort};
+//!
+//! let client = Client::new("your-api-key");
+//! let model = client
+//!     .completion_model("gpt-5")
+//!     .with_reasoning_effort(ReasoningEffort::High);
+//! ```
+
+mod completion;
+mod error;
+
+pub use completion::{Client, CompletionModel, ReasoningEffort, StreamingResponseData};
+pub use error::OpenAiResponsesError;
+
+/// Check if a model is an OpenAI reasoning model that benefits from this provider.
+///
+/// Reasoning models include:
+/// - o1, o1-preview, o1-mini
+/// - o3, o3-mini
+/// - o4-mini (future)
+/// - gpt-5, gpt-5.1, gpt-5.2, gpt-5-mini, gpt-5-nano
+pub fn is_reasoning_model(model: &str) -> bool {
+    let model_lower = model.to_lowercase();
+    model_lower.starts_with("o1")
+        || model_lower.starts_with("o3")
+        || model_lower.starts_with("o4")
+        || model_lower.starts_with("gpt-5")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_reasoning_model() {
+        // Reasoning models
+        assert!(is_reasoning_model("o1"));
+        assert!(is_reasoning_model("o1-preview"));
+        assert!(is_reasoning_model("o1-mini"));
+        assert!(is_reasoning_model("o3"));
+        assert!(is_reasoning_model("o3-mini"));
+        assert!(is_reasoning_model("o4-mini"));
+        assert!(is_reasoning_model("gpt-5"));
+        assert!(is_reasoning_model("gpt-5.1"));
+        assert!(is_reasoning_model("gpt-5.2"));
+        assert!(is_reasoning_model("gpt-5-mini"));
+        assert!(is_reasoning_model("gpt-5-nano"));
+
+        // Case insensitive
+        assert!(is_reasoning_model("GPT-5"));
+        assert!(is_reasoning_model("O3-MINI"));
+
+        // Non-reasoning models
+        assert!(!is_reasoning_model("gpt-4o"));
+        assert!(!is_reasoning_model("gpt-4.1"));
+        assert!(!is_reasoning_model("gpt-4o-mini"));
+        assert!(!is_reasoning_model("chatgpt-4o-latest"));
+    }
+}

--- a/docs/system-prompt-design-input.md
+++ b/docs/system-prompt-design-input.md
@@ -308,6 +308,7 @@ The system includes provider-specific prompt sections:
 
 ### OpenAI
 - Web search via Responses API
+- Reasoning models (`o1*`, `o3*`, `gpt-5*`) should keep reasoning deltas separate from text deltas during streaming
 - Clear, specific queries
 - Source citation
 


### PR DESCRIPTION
## Summary
- Adds new `rig-openai-responses` crate that wraps `async-openai` to provide explicit separation of reasoning events from text events for OpenAI reasoning models (o1, o3, o4, gpt-5.x)
- Integrates the new provider into the app - automatically used when a reasoning model is detected
- Fixes temperature parameter issue (reasoning models don't support it)
- Improves plan completion hook to prevent infinite doc update loops

## Changes

### New crate: `rig-openai-responses`
- Custom `CompletionModel` implementation using OpenAI Responses API
- Explicit mapping of `ResponseStreamEvent` variants to rig-core `RawStreamingChoice`:
  - `ResponseOutputTextDelta` → `Message`
  - `ResponseReasoningSummaryTextDelta` / `ResponseReasoningTextDelta` → `ReasoningDelta`
  - `ResponseFunctionCallArgumentsDelta` → `ToolCallDelta`
- `ReasoningEffort` configuration (low/medium/high)
- `is_reasoning_model()` helper for detecting o1, o3, o4, gpt-5.x models
- Temperature parameter automatically omitted for reasoning models

### Provider integration
- Added `LlmClient::OpenAiReasoning` variant
- Auto-detection in `create_openai_components()` routes reasoning models to new provider
- Detailed box-formatted logging for provider selection (target: `qbit::provider`)
- Updated all `LlmClient` match statements across the codebase

### Plan completion hook fix
- Updated prompt to skip doc updates for minor changes (bug fixes, refactors, tests)
- Added explicit stop conditions to prevent infinite loops
- Only triggers doc updates for significant changes (new features, API changes, breaking changes)

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace --lib` passes
- [x] Verified logging output shows correct provider selection
- [x] Verified reasoning text displays in timeline