### PR TITLE
fix: remount race conditions

### DIFF
--- a/frontend/lib/terminal/TerminalInstanceManager.test.ts
+++ b/frontend/lib/terminal/TerminalInstanceManager.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalInstanceManager } from "@/lib/terminal/TerminalInstanceManager";
+
+describe("TerminalInstanceManager", () => {
+  beforeAll(() => {
+    // JSDOM may not provide requestAnimationFrame; manager uses it for safeFit.
+    if (typeof globalThis.requestAnimationFrame !== "function") {
+      vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      });
+    }
+
+    if (typeof globalThis.cancelAnimationFrame !== "function") {
+      vi.stubGlobal("cancelAnimationFrame", (_id: number) => {});
+    }
+  });
+
+  beforeEach(() => {
+    // Ensure singleton doesn't leak instances or DOM across tests.
+    TerminalInstanceManager.disposeAll();
+    document.getElementById("qbit-xterm-parking-lot")?.remove();
+  });
+
+  it("keeps the terminal element in the DOM on detach by parking it offscreen", () => {
+    const sessionId = "session-1";
+
+    const terminalEl = document.createElement("div");
+    terminalEl.className = "xterm";
+
+    const terminal = {
+      element: terminalEl,
+      open: vi.fn(),
+      dispose: vi.fn(),
+    };
+
+    const fitAddon = {
+      fit: vi.fn(),
+    };
+
+    TerminalInstanceManager.register(sessionId, terminal as any, fitAddon as any);
+
+    const containerA = document.createElement("div");
+    const containerB = document.createElement("div");
+    document.body.appendChild(containerA);
+    document.body.appendChild(containerB);
+
+    expect(TerminalInstanceManager.attachToContainer(sessionId, containerA)).toBe(true);
+    expect(containerA.contains(terminalEl)).toBe(true);
+
+    // Detach should move the element to the parking lot so removing containerA
+    // (React unmount) doesn't remove the xterm element.
+    TerminalInstanceManager.detach(sessionId);
+    const parkingLot = document.getElementById("qbit-xterm-parking-lot");
+    expect(parkingLot).toBeTruthy();
+    expect(parkingLot?.contains(terminalEl)).toBe(true);
+
+    containerA.remove();
+    expect(document.body.contains(terminalEl)).toBe(true);
+
+    // Reattach should move element from parking lot into new container.
+    expect(TerminalInstanceManager.attachToContainer(sessionId, containerB)).toBe(true);
+    expect(containerB.contains(terminalEl)).toBe(true);
+  });
+
+  it("does not throw on detach if terminal has no element", () => {
+    const sessionId = "session-2";
+
+    const terminal = {
+      element: null,
+      open: vi.fn(),
+      dispose: vi.fn(),
+    };
+
+    const fitAddon = {
+      fit: vi.fn(),
+    };
+
+    TerminalInstanceManager.register(sessionId, terminal as any, fitAddon as any);
+    expect(() => TerminalInstanceManager.detach(sessionId)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Description
* Fixes a crash in the embedded terminal UI caused by xterm’s internal renderer getting into an invalid state during pane unmount/remount (e.g. “undefined is not an object (evaluating this._renderer.value.dimensions)”).
* Makes terminal remounts safe by keeping the xterm DOM node attached to the document even when the React container unmounts.

## Technical Details
* Root cause: we persist xterm instances across React remounts via TerminalInstanceManager, but on unmount the container subtree is removed from the DOM, which also removes terminal.element. xterm isn’t robust to being fully detached like this; later scroll/resize/render work can read renderer internals that haven’t been reinitialized, producing the dimensions/syncScrollArea crash.
* Fix: added an offscreen “parking lot” DOM node (#qbit-xterm-parking-lot) in TerminalInstanceManager.ts. On detach(sessionId), if terminal.element exists, it is appended into the parking lot so it remains in the DOM across container unmounts. On attachToContainer, the element is moved back into the new container as before.
* This preserves xterm’s internal renderer lifecycle while still allowing the React layout to remount/reattach terminals freely.
Tests
* Added a regression test TerminalInstanceManager.test.ts that simulates:
    * attach terminal → detach → remove container (React unmount) → verify element still in document.body via parking-lot → reattach to a new container.
* Verified the full unit test suite passes with pnpm -w test:run.
