### PR TITLE
fix(settings): remove obsolete zai and zai_anthropic frontend references

### DIFF
--- a/frontend/components/Settings/ModelSelector.tsx
+++ b/frontend/components/Settings/ModelSelector.tsx
@@ -45,10 +45,8 @@ function isProviderAvailable(settings: AiSettings, providerId: AiProvider): bool
       return settings.groq.show_in_selector !== false && !!settings.groq.api_key;
     case "xai":
       return settings.xai.show_in_selector !== false && !!settings.xai.api_key;
-    case "zai":
-      return settings.zai.show_in_selector !== false && !!settings.zai.api_key;
-    case "zai_anthropic":
-      return settings.zai_anthropic.show_in_selector !== false && !!settings.zai_anthropic.api_key;
+    case "zai_sdk":
+      return settings.zai_sdk?.show_in_selector !== false && !!settings.zai_sdk?.api_key;
     default:
       return false;
   }

--- a/frontend/components/Settings/ProviderSettings.tsx
+++ b/frontend/components/Settings/ProviderSettings.tsx
@@ -30,8 +30,6 @@ interface ProviderConfig {
     | "gemini"
     | "groq"
     | "xai"
-    | "zai"
-    | "zai_anthropic"
     | "zai_sdk"
   >;
   name: string;
@@ -96,20 +94,6 @@ const PROVIDERS: ProviderConfig[] = [
     icon: "𝕏",
     description: "Grok models from xAI",
     getConfigured: (s) => !!s.xai.api_key,
-  },
-  {
-    id: "zai",
-    name: "Z.AI",
-    icon: "🌐",
-    description: "GLM models from Zhipu AI",
-    getConfigured: (s) => !!s.zai.api_key,
-  },
-  {
-    id: "zai_anthropic",
-    name: "Z.AI (Anthropic)",
-    icon: "🔶",
-    description: "GLM via Anthropic-compatible API",
-    getConfigured: (s) => !!s.zai_anthropic.api_key,
   },
   {
     id: "zai_sdk",
@@ -401,55 +385,6 @@ export function ProviderSettings({ settings, onChange }: ProviderSettingsProps) 
               placeholder="xai-..."
             />
             <p className="text-xs text-muted-foreground">Get your API key from x.ai</p>
-          </div>
-        );
-
-      case "zai":
-        return (
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <label htmlFor="zai-key" className="text-sm text-foreground">
-                API Key
-              </label>
-              <PasswordInput
-                id="zai-key"
-                value={settings.zai.api_key || ""}
-                onChange={(value) => updateProvider("zai", "api_key", value)}
-                placeholder="your-zai-api-key"
-              />
-              <p className="text-xs text-muted-foreground">Get your API key from z.ai</p>
-            </div>
-
-            <div className="flex items-center justify-between py-2">
-              <div>
-                <div className="text-sm font-medium text-foreground">Coding Endpoint</div>
-                <div className="text-xs text-muted-foreground">
-                  Use coding-optimized API for better code assistance
-                </div>
-              </div>
-              <Switch
-                checked={settings.zai.use_coding_endpoint}
-                onCheckedChange={(checked) => updateProvider("zai", "use_coding_endpoint", checked)}
-              />
-            </div>
-          </div>
-        );
-
-      case "zai_anthropic":
-        return (
-          <div className="space-y-2">
-            <label htmlFor="zai-anthropic-key" className="text-sm text-foreground">
-              API Key
-            </label>
-            <PasswordInput
-              id="zai-anthropic-key"
-              value={settings.zai_anthropic.api_key || ""}
-              onChange={(value) => updateProvider("zai_anthropic", "api_key", value)}
-              placeholder="your-zai-api-key"
-            />
-            <p className="text-xs text-muted-foreground">
-              Get your API key from z.ai. Uses Anthropic-compatible endpoint.
-            </p>
           </div>
         );
 

--- a/frontend/components/Settings/SubAgentSettings.tsx
+++ b/frontend/components/Settings/SubAgentSettings.tsx
@@ -24,8 +24,6 @@ const PROVIDER_OPTIONS: { value: AiProvider; label: string }[] = [
   { value: "groq", label: "Groq" },
   { value: "ollama", label: "Ollama" },
   { value: "xai", label: "xAI (Grok)" },
-  { value: "zai", label: "Z.AI (GLM)" },
-  { value: "zai_anthropic", label: "Z.AI (Anthropic)" },
   { value: "zai_sdk", label: "Z.AI SDK" },
 ];
 
@@ -52,8 +50,6 @@ const MODEL_SUGGESTIONS: Record<AiProvider, string[]> = {
   groq: ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"],
   ollama: ["llama3.2", "codellama", "mistral"],
   xai: ["grok-4-1-fast-reasoning", "grok-4-1-fast-non-reasoning"],
-  zai: ["GLM-4.7", "GLM-4.5-air"],
-  zai_anthropic: ["GLM-4.7", "GLM-4.6", "GLM-4.5-Air"],
   zai_sdk: ["glm-4.7", "glm-4.6v", "glm-4.5-air", "glm-4-flash"],
 };
 

--- a/frontend/components/UnifiedInput/InputStatusRow.tsx
+++ b/frontend/components/UnifiedInput/InputStatusRow.tsx
@@ -132,15 +132,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
   const [xaiEnabled, setXaiEnabled] = useState(false);
   const [xaiApiKey, setXaiApiKey] = useState<string | null>(null);
 
-  // Track Z.AI availability
-  const [zaiEnabled, setZaiEnabled] = useState(false);
-  const [zaiApiKey, setZaiApiKey] = useState<string | null>(null);
-  const [zaiUseCodingEndpoint, setZaiUseCodingEndpoint] = useState(true);
-
-  // Track Z.AI (Anthropic) availability
-  const [zaiAnthropicEnabled, setZaiAnthropicEnabled] = useState(false);
-  const [zaiAnthropicApiKey, setZaiAnthropicApiKey] = useState<string | null>(null);
-
   // Track Z.AI SDK availability
   const [zaiSdkEnabled, setZaiSdkEnabled] = useState(false);
   const [zaiSdkApiKey, setZaiSdkApiKey] = useState<string | null>(null);
@@ -163,8 +154,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
     gemini: true,
     groq: true,
     xai: true,
-    zai: true,
-    zai_anthropic: true,
     zai_sdk: true,
   });
 
@@ -185,11 +174,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
       setGroqEnabled(!!settings.ai.groq.api_key);
       setXaiApiKey(settings.ai.xai.api_key);
       setXaiEnabled(!!settings.ai.xai.api_key);
-      setZaiApiKey(settings.ai.zai.api_key);
-      setZaiEnabled(!!settings.ai.zai.api_key);
-      setZaiUseCodingEndpoint(settings.ai.zai.use_coding_endpoint);
-      setZaiAnthropicApiKey(settings.ai.zai_anthropic.api_key);
-      setZaiAnthropicEnabled(!!settings.ai.zai_anthropic.api_key);
       setZaiSdkApiKey(settings.ai.zai_sdk?.api_key ?? null);
       setZaiSdkEnabled(!!settings.ai.zai_sdk?.api_key);
       // Vertex AI - check for credentials_path OR project_id
@@ -211,8 +195,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
         gemini: settings.ai.gemini.show_in_selector,
         groq: settings.ai.groq.show_in_selector,
         xai: settings.ai.xai.show_in_selector,
-        zai: settings.ai.zai.show_in_selector,
-        zai_anthropic: settings.ai.zai_anthropic.show_in_selector,
         zai_sdk: settings.ai.zai_sdk?.show_in_selector ?? true,
       });
     } catch (e) {
@@ -253,11 +235,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
         setGroqEnabled(!!settings.ai.groq.api_key);
         setXaiApiKey(settings.ai.xai.api_key);
         setXaiEnabled(!!settings.ai.xai.api_key);
-        setZaiApiKey(settings.ai.zai.api_key);
-        setZaiEnabled(!!settings.ai.zai.api_key);
-        setZaiUseCodingEndpoint(settings.ai.zai.use_coding_endpoint);
-        setZaiAnthropicApiKey(settings.ai.zai_anthropic.api_key);
-        setZaiAnthropicEnabled(!!settings.ai.zai_anthropic.api_key);
         setZaiSdkApiKey(settings.ai.zai_sdk?.api_key ?? null);
         setZaiSdkEnabled(!!settings.ai.zai_sdk?.api_key);
         // Vertex AI - check for credentials_path OR project_id
@@ -279,8 +256,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
           gemini: settings.ai.gemini.show_in_selector,
           groq: settings.ai.groq.show_in_selector,
           xai: settings.ai.xai.show_in_selector,
-          zai: settings.ai.zai.show_in_selector,
-          zai_anthropic: settings.ai.zai_anthropic.show_in_selector,
           zai_sdk: settings.ai.zai_sdk?.show_in_selector ?? true,
         });
       } catch (e) {
@@ -305,8 +280,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
       | "gemini"
       | "groq"
       | "xai"
-      | "zai"
-      | "zai_anthropic"
       | "zai_sdk",
     reasoningEffort?: ReasoningEffort
   ) => {
@@ -320,8 +293,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
       gemini: "gemini",
       groq: "groq",
       xai: "xai",
-      zai: "zai",
-      zai_anthropic: "zai_anthropic",
       zai_sdk: "zai_sdk",
     };
     if (model === modelId && provider === providerMap[modelProvider]) {
@@ -471,35 +442,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
         };
         await initAiSession(sessionId, config);
         setSessionAiConfig(sessionId, { status: "ready", provider: "xai" });
-      } else if (modelProvider === "zai") {
-        // Z.AI model switch
-        const apiKey = zaiApiKey;
-        if (!apiKey) {
-          throw new Error("Z.AI API key not configured");
-        }
-        config = {
-          provider: "zai",
-          workspace,
-          model: modelId,
-          api_key: apiKey,
-          use_coding_endpoint: zaiUseCodingEndpoint,
-        };
-        await initAiSession(sessionId, config);
-        setSessionAiConfig(sessionId, { status: "ready", provider: "zai" });
-      } else if (modelProvider === "zai_anthropic") {
-        // Z.AI (Anthropic) model switch
-        const apiKey = zaiAnthropicApiKey;
-        if (!apiKey) {
-          throw new Error("Z.AI (Anthropic) API key not configured");
-        }
-        config = {
-          provider: "zai_anthropic",
-          workspace,
-          model: modelId,
-          api_key: apiKey,
-        };
-        await initAiSession(sessionId, config);
-        setSessionAiConfig(sessionId, { status: "ready", provider: "zai_anthropic" });
       } else if (modelProvider === "zai_sdk") {
         // Z.AI SDK model switch
         const apiKey = zaiSdkApiKey;
@@ -546,8 +488,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
   const showGemini = providerVisibility.gemini && geminiEnabled;
   const showGroq = providerVisibility.groq && groqEnabled;
   const showXai = providerVisibility.xai && xaiEnabled;
-  const showZai = providerVisibility.zai && zaiEnabled;
-  const showZaiAnthropic = providerVisibility.zai_anthropic && zaiAnthropicEnabled;
   const showZaiSdk = providerVisibility.zai_sdk && zaiSdkEnabled;
   const hasVisibleProviders =
     showVertexAi ||
@@ -558,8 +498,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
     showGemini ||
     showGroq ||
     showXai ||
-    showZai ||
-    showZaiAnthropic ||
     showZaiSdk;
 
   return (
@@ -914,69 +852,6 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
                 </>
               )}
 
-              {/* Z.AI Models */}
-              {showZai && (
-                <>
-                  {(showVertexAi ||
-                    showOpenRouter ||
-                    showOpenAi ||
-                    showAnthropic ||
-                    showOllama ||
-                    showGemini ||
-                    showGroq ||
-                    showXai) && <DropdownMenuSeparator />}
-                  <div className="px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wide">
-                    Z.AI (GLM)
-                  </div>
-                  {(getProviderGroup("zai")?.models ?? []).map((m) => (
-                    <DropdownMenuItem
-                      key={m.id}
-                      onClick={() => handleModelSelect(m.id, "zai")}
-                      className={cn(
-                        "text-xs cursor-pointer",
-                        model === m.id && provider === "zai"
-                          ? "text-accent bg-[var(--accent-dim)]"
-                          : "text-foreground hover:text-accent"
-                      )}
-                    >
-                      {m.name}
-                    </DropdownMenuItem>
-                  ))}
-                </>
-              )}
-
-              {/* Z.AI (Anthropic) Models */}
-              {showZaiAnthropic && (
-                <>
-                  {(showVertexAi ||
-                    showOpenRouter ||
-                    showOpenAi ||
-                    showAnthropic ||
-                    showOllama ||
-                    showGemini ||
-                    showGroq ||
-                    showXai ||
-                    showZai) && <DropdownMenuSeparator />}
-                  <div className="px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wide">
-                    Z.AI (Anthropic)
-                  </div>
-                  {(getProviderGroup("zai_anthropic")?.models ?? []).map((m) => (
-                    <DropdownMenuItem
-                      key={m.id}
-                      onClick={() => handleModelSelect(m.id, "zai_anthropic")}
-                      className={cn(
-                        "text-xs cursor-pointer",
-                        model === m.id && provider === "zai_anthropic"
-                          ? "text-accent bg-[var(--accent-dim)]"
-                          : "text-foreground hover:text-accent"
-                      )}
-                    >
-                      {m.name}
-                    </DropdownMenuItem>
-                  ))}
-                </>
-              )}
-
               {/* Z.AI SDK Models */}
               {showZaiSdk && (
                 <>
@@ -987,9 +862,7 @@ export function InputStatusRow({ sessionId }: InputStatusRowProps) {
                     showOllama ||
                     showGemini ||
                     showGroq ||
-                    showXai ||
-                    showZai ||
-                    showZaiAnthropic) && <DropdownMenuSeparator />}
+                    showXai) && <DropdownMenuSeparator />}
                   <div className="px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wide">
                     Z.AI SDK
                   </div>

--- a/frontend/lib/ai.project-settings.test.ts
+++ b/frontend/lib/ai.project-settings.test.ts
@@ -94,7 +94,7 @@ describe("Project Settings API", () => {
         "gemini",
         "groq",
         "xai",
-        "zai",
+        "zai_sdk",
       ];
 
       for (const provider of providers) {

--- a/frontend/lib/ai.ts
+++ b/frontend/lib/ai.ts
@@ -30,8 +30,6 @@ export type AiProvider =
   | "gemini"
   | "groq"
   | "xai"
-  | "zai"
-  | "zai_anthropic"
   | "zai_sdk";
 
 /** Per-project settings from .qbit/project.toml */
@@ -98,19 +96,6 @@ export type ProviderConfig =
     }
   | {
       provider: "xai";
-      workspace: string;
-      model: string;
-      api_key: string;
-    }
-  | {
-      provider: "zai";
-      workspace: string;
-      model: string;
-      api_key: string;
-      use_coding_endpoint?: boolean;
-    }
-  | {
-      provider: "zai_anthropic";
       workspace: string;
       model: string;
       api_key: string;
@@ -789,25 +774,6 @@ export const XAI_MODELS = {
   GROK_CODE_FAST_1: "grok-code-fast-1",
   GROK_4_FAST_REASONING: "grok-4-fast-reasoning",
   GROK_4_FAST_NON_REASONING: "grok-4-fast-non-reasoning",
-} as const;
-
-/**
- * Available Z.AI (GLM) models.
- * @see https://docs.z.ai/devpack/tool/others
- */
-export const ZAI_MODELS = {
-  GLM_4_7: "GLM-4.7",
-  GLM_4_5_AIR: "GLM-4.5-air",
-} as const;
-
-/**
- * Available Z.AI models via Anthropic-compatible API.
- * Uses Z.AI's Anthropic endpoint at https://api.z.ai/api/anthropic.
- */
-export const ZAI_ANTHROPIC_MODELS = {
-  GLM_4_7: "GLM-4.7",
-  GLM_4_6: "GLM-4.6",
-  GLM_4_5_AIR: "GLM-4.5-Air",
 } as const;
 
 /**
@@ -1553,29 +1519,6 @@ export async function buildProviderConfig(
       if (!apiKey) throw new Error("xAI API key not configured");
       return {
         provider: "xai",
-        workspace,
-        model: default_model,
-        api_key: apiKey,
-      };
-    }
-
-    case "zai": {
-      const apiKey = settings.ai.zai.api_key;
-      if (!apiKey) throw new Error("Z.AI API key not configured");
-      return {
-        provider: "zai",
-        workspace,
-        model: default_model,
-        api_key: apiKey,
-        use_coding_endpoint: settings.ai.zai.use_coding_endpoint,
-      };
-    }
-
-    case "zai_anthropic": {
-      const apiKey = settings.ai.zai_anthropic.api_key;
-      if (!apiKey) throw new Error("Z.AI (Anthropic) API key not configured");
-      return {
-        provider: "zai_anthropic",
         workspace,
         model: default_model,
         api_key: apiKey,

--- a/frontend/lib/models.ts
+++ b/frontend/lib/models.ts
@@ -11,8 +11,6 @@ import {
   OPENAI_MODELS,
   VERTEX_AI_MODELS,
   XAI_MODELS,
-  ZAI_ANTHROPIC_MODELS,
-  ZAI_MODELS,
   ZAI_SDK_MODELS,
 } from "./ai";
 import type { AiProvider } from "./settings";
@@ -323,25 +321,6 @@ export const PROVIDER_GROUPS: ProviderGroup[] = [
       { id: XAI_MODELS.GROK_4_FAST_REASONING, name: "Grok 4 (Reasoning)" },
       { id: XAI_MODELS.GROK_4_FAST_NON_REASONING, name: "Grok 4" },
       { id: XAI_MODELS.GROK_CODE_FAST_1, name: "Grok Code" },
-    ],
-  },
-  {
-    provider: "zai",
-    providerName: "Z.AI",
-    icon: "🌐",
-    models: [
-      { id: ZAI_MODELS.GLM_4_7, name: "GLM 4.7" },
-      { id: ZAI_MODELS.GLM_4_5_AIR, name: "GLM 4.5 Air" },
-    ],
-  },
-  {
-    provider: "zai_anthropic",
-    providerName: "Z.AI (Anthropic)",
-    icon: "🔶",
-    models: [
-      { id: ZAI_ANTHROPIC_MODELS.GLM_4_7, name: "GLM 4.7" },
-      { id: ZAI_ANTHROPIC_MODELS.GLM_4_6, name: "GLM 4.6" },
-      { id: ZAI_ANTHROPIC_MODELS.GLM_4_5_AIR, name: "GLM 4.5 Air" },
     ],
   },
   {
@@ -707,25 +686,6 @@ export const PROVIDER_GROUPS_NESTED: ProviderGroupNested[] = [
       { id: XAI_MODELS.GROK_4_FAST_REASONING, name: "Grok 4 (Reasoning)" },
       { id: XAI_MODELS.GROK_4_FAST_NON_REASONING, name: "Grok 4" },
       { id: XAI_MODELS.GROK_CODE_FAST_1, name: "Grok Code" },
-    ],
-  },
-  {
-    provider: "zai",
-    providerName: "Z.AI",
-    icon: "🌐",
-    models: [
-      { id: ZAI_MODELS.GLM_4_7, name: "GLM 4.7" },
-      { id: ZAI_MODELS.GLM_4_5_AIR, name: "GLM 4.5 Air" },
-    ],
-  },
-  {
-    provider: "zai_anthropic",
-    providerName: "Z.AI (Anthropic)",
-    icon: "🔶",
-    models: [
-      { id: ZAI_ANTHROPIC_MODELS.GLM_4_7, name: "GLM 4.7" },
-      { id: ZAI_ANTHROPIC_MODELS.GLM_4_6, name: "GLM 4.6" },
-      { id: ZAI_ANTHROPIC_MODELS.GLM_4_5_AIR, name: "GLM 4.5 Air" },
     ],
   },
   {

--- a/frontend/lib/settings.ts
+++ b/frontend/lib/settings.ts
@@ -82,8 +82,6 @@ export interface AiSettings {
   gemini: GeminiSettings;
   groq: GroqSettings;
   xai: XaiSettings;
-  zai: ZaiSettings;
-  zai_anthropic: ZaiAnthropicSettings;
   zai_sdk: ZaiSdkSettings;
 }
 
@@ -96,8 +94,6 @@ export type AiProvider =
   | "gemini"
   | "groq"
   | "xai"
-  | "zai"
-  | "zai_anthropic"
   | "zai_sdk";
 
 /**
@@ -172,25 +168,6 @@ export interface GroqSettings {
  * xAI (Grok) API settings.
  */
 export interface XaiSettings {
-  api_key: string | null;
-  show_in_selector: boolean;
-}
-
-/**
- * Z.AI (GLM) API settings.
- */
-export interface ZaiSettings {
-  api_key: string | null;
-  /** Use coding-optimized API endpoint instead of general endpoint */
-  use_coding_endpoint: boolean;
-  show_in_selector: boolean;
-}
-
-/**
- * Z.AI (Anthropic-compatible) API settings.
- * Uses Z.AI's Anthropic-compatible endpoint at https://api.z.ai/api/anthropic.
- */
-export interface ZaiAnthropicSettings {
   api_key: string | null;
   show_in_selector: boolean;
 }
@@ -466,15 +443,6 @@ export const DEFAULT_SETTINGS: QbitSettings = {
       show_in_selector: true,
     },
     xai: {
-      api_key: null,
-      show_in_selector: true,
-    },
-    zai: {
-      api_key: null,
-      use_coding_endpoint: true,
-      show_in_selector: true,
-    },
-    zai_anthropic: {
       api_key: null,
       show_in_selector: true,
     },

--- a/frontend/mocks.ts
+++ b/frontend/mocks.ts
@@ -440,13 +440,10 @@ let mockSettings = {
       api_key: null,
       show_in_selector: true,
     },
-    zai: {
+    zai_sdk: {
       api_key: null,
-      use_coding_endpoint: true,
-      show_in_selector: true,
-    },
-    zai_anthropic: {
-      api_key: null,
+      base_url: null,
+      model: null,
       show_in_selector: true,
     },
   },
@@ -893,7 +890,7 @@ export function setMockProviderVisibility(
     | "gemini"
     | "groq"
     | "xai"
-    | "zai",
+    | "zai_sdk",
   visible: boolean
 ): void {
   mockSettings.ai[provider].show_in_selector = visible;


### PR DESCRIPTION
## Summary

- Remove `zai` and `zai_anthropic` provider references from frontend TypeScript types
- Fix settings dialog crash when opening (`undefined is not an object (evaluating 'xe.ai.zai.api_key')`)
- The backend consolidated these providers into `zai_sdk` but frontend types weren't updated

## Changes

- **`frontend/lib/settings.ts`** - Remove `ZaiSettings`, `ZaiAnthropicSettings` interfaces and type references
- **`frontend/lib/ai.ts`** - Remove provider config cases and model constants
- **`frontend/lib/models.ts`** - Remove provider groups from model lists
- **`frontend/components/Settings/ProviderSettings.tsx`** - Remove provider configurations
- **`frontend/components/Settings/ModelSelector.tsx`** - Remove availability checks
- **`frontend/components/Settings/SubAgentSettings.tsx`** - Remove provider options
- **`frontend/components/UnifiedInput/InputStatusRow.tsx`** - Remove state and UI for deprecated providers
- **`frontend/mocks.ts`** - Update mock settings

## Test plan

- [x] TypeScript type check passes (`pnpm typecheck`)
- [x] All frontend tests pass (`pnpm test:run`)
- [ ] Open settings dialog without crash
- [ ] Z.AI SDK provider still configurable and functional