### PR TITLE
docs(readme): add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ EOF
 
 ## Installation
 
+### Homebrew (macOS)
+
+```bash
+brew tap qbit-ai/tap && brew install --cask qbit
+```
+
 ### Download (macOS)
 
 1. Download the latest `.dmg` from [Releases](https://github.com/qbit-ai/qbit/releases)


### PR DESCRIPTION
## Summary
Adds Homebrew as an installation option for macOS users, making it easier to install Qbit with a single command.

## Changes
- Added Homebrew installation section to README.md
- Positioned as the first installation option (before manual download)

## Breaking Changes
None

## Test Plan
- [x] Verify the Homebrew command is correct: `brew tap qbit-ai/tap && brew install --cask qbit`
- [x] README renders correctly on GitHub

## Release Notes
Users can now install Qbit on macOS via Homebrew: `brew tap qbit-ai/tap && brew install --cask qbit`

## Checklist
- [x] Documentation updated
- [x] Conventional commit format followed