### PR TITLE
chore(ci): remove z.ai provider from evals workflow

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,105 @@
+name: Evals
+
+on:
+  # Run on demand
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: 'Specific scenario to run (leave empty for all)'
+        required: false
+        default: ''
+      parallel:
+        description: 'Run scenarios in parallel'
+        type: boolean
+        default: false
+  # Run on PRs and main branch pushes
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Run weekly to keep cache warm and catch regressions
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at midnight UTC
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  evals:
+    name: Evals (${{ matrix.provider }})
+    runs-on: ubuntu-latest
+    # OpenAI evals are optional - the API can be flaky
+    continue-on-error: ${{ matrix.provider == 'openai' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [vertex-claude]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+          shared-key: rust-arm64
+          cache-targets: true
+          save-if: true
+          cache-on-failure: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+
+      - name: Setup Vertex AI credentials
+        run: |
+          echo '${{ secrets.VERTEX_AI_CREDENTIALS }}' > /tmp/vertex-credentials.json
+
+      - name: Build CLI with evals
+        working-directory: backend
+        run: cargo build --no-default-features --features evals --bin qbit-cli
+
+      - name: List scenarios
+        working-directory: backend
+        run: ./target/debug/qbit-cli --list-scenarios
+
+      - name: Run evals
+        working-directory: backend
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          VERTEX_AI_PROJECT_ID: ${{ vars.VERTEX_AI_PROJECT_ID }}
+          VERTEX_AI_LOCATION: ${{ vars.VERTEX_AI_LOCATION || 'us-east5' }}
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/vertex-credentials.json
+        run: |
+          PARALLEL_FLAG=""
+          if [ "${{ github.event.inputs.parallel }}" = "true" ]; then
+            PARALLEL_FLAG="--parallel"
+          fi
+
+          # For PRs, only run the lightweight pr-check scenario with transcript
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ./target/debug/qbit-cli --eval --eval-provider "${{ matrix.provider }}" --scenario pr-check --verbose --output eval-results.json --pretty --transcript
+          elif [ -n "${{ github.event.inputs.scenario }}" ]; then
+            ./target/debug/qbit-cli --eval --eval-provider "${{ matrix.provider }}" --scenario "${{ github.event.inputs.scenario }}" --verbose --output eval-results.json --pretty $PARALLEL_FLAG
+          else
+            ./target/debug/qbit-cli --eval --eval-provider "${{ matrix.provider }}" --verbose --output eval-results.json --pretty $PARALLEL_FLAG
+          fi
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ matrix.provider }}
+          path: backend/eval-results.json
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        run: rm -f /tmp/vertex-credentials.json


### PR DESCRIPTION
## Summary
- Remove z.ai provider from evals workflow matrix due to rate limiting issues
- Keep vertex-claude provider running for continued eval coverage
- Remove unused ZAI_API_KEY environment variable

## Test plan
- [ ] Verify evals workflow runs successfully with vertex-claude provider
