### PR TITLE
feat(path-completion): enhance tab completion with fuzzy matching and file type icons

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5689,6 +5689,7 @@ dependencies = [
  "graph-flow",
  "ignore",
  "insta",
+ "nucleo-matcher",
  "opentelemetry",
  "opentelemetry-langfuse",
  "opentelemetry-otlp",

--- a/backend/crates/qbit/Cargo.toml
+++ b/backend/crates/qbit/Cargo.toml
@@ -132,6 +132,9 @@ ignore.workspace = true
 glob.workspace = true
 regex.workspace = true
 
+# Fuzzy matching for path completions
+nucleo-matcher = "0.3"
+
 # TOML settings file support
 toml.workspace = true
 

--- a/e2e/copy-buttons.spec.ts
+++ b/e2e/copy-buttons.spec.ts
@@ -49,7 +49,9 @@ async function waitForAppReady(page: Page) {
   await waitForAppReadyBase(page);
 
   // Wait for the unified input textarea to be visible (use specific selector to avoid xterm textarea)
-  await expect(page.locator('textarea[data-slot="popover-anchor"]')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('[data-slot="popover-anchor"] textarea')).toBeVisible({
+    timeout: 5000,
+  });
 
   // Ensure mock functions are available
   await page.waitForFunction(() => typeof window.__MOCK_EMIT_AI_EVENT__ === "function", {
@@ -69,7 +71,7 @@ function getAgentModeButton(page: Page) {
  * Uses a specific selector to avoid matching xterm's internal textarea.
  */
 function getInputTextarea(page: Page) {
-  return page.locator('textarea[data-slot="popover-anchor"]');
+  return page.locator('[data-slot="popover-anchor"] textarea');
 }
 
 /**

--- a/e2e/sub-agent-timeline.spec.ts
+++ b/e2e/sub-agent-timeline.spec.ts
@@ -71,7 +71,9 @@ async function waitForAppReady(page: Page) {
   await waitForAppReadyBase(page);
 
   // Wait for the unified input textarea to be visible (use specific selector to avoid xterm textarea)
-  await expect(page.locator('textarea[data-slot="popover-anchor"]')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('[data-slot="popover-anchor"] textarea')).toBeVisible({
+    timeout: 5000,
+  });
 
   // Ensure mock functions are available
   await page.waitForFunction(() => typeof window.__MOCK_EMIT_AI_EVENT__ === "function", {
@@ -91,7 +93,7 @@ function getAgentModeButton(page: Page) {
  * Uses a specific selector to avoid matching xterm's internal textarea.
  */
 function getInputTextarea(page: Page) {
-  return page.locator('textarea[data-slot="popover-anchor"]');
+  return page.locator('[data-slot="popover-anchor"] textarea');
 }
 
 test.describe("Sub-Agent Timeline Ordering", () => {

--- a/frontend/components/PathCompletionPopup/PathCompletionPopup.tsx
+++ b/frontend/components/PathCompletionPopup/PathCompletionPopup.tsx
@@ -1,5 +1,46 @@
-import { File, Folder, Link2 } from "lucide-react";
+import {
+  Archive,
+  Cog,
+  Database,
+  File,
+  FileCode,
+  FileImage,
+  FileJson,
+  FileText,
+  FileType,
+  Folder,
+  Link2,
+  Lock,
+  Terminal,
+} from "lucide-react";
 import { useEffect, useRef } from "react";
+import { FaJava } from "react-icons/fa";
+import {
+  SiC,
+  SiCplusplus,
+  SiCss3,
+  SiDocker,
+  SiGit,
+  SiGnubash,
+  SiGo,
+  SiHtml5,
+  SiJavascript,
+  SiKotlin,
+  SiLua,
+  SiMarkdown,
+  SiPhp,
+  SiPython,
+  SiReact,
+  SiRuby,
+  SiRust,
+  SiSass,
+  SiSvg,
+  SiSwift,
+  SiToml,
+  SiTypescript,
+  SiYaml,
+  SiZig,
+} from "react-icons/si";
 import type { PathCompletion } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 
@@ -7,26 +48,209 @@ interface PathCompletionPopupProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   completions: PathCompletion[];
+  totalCount: number;
   selectedIndex: number;
   onSelect: (completion: PathCompletion) => void;
   children: React.ReactNode;
 }
 
-function getIcon(entryType: PathCompletion["entry_type"]) {
+const iconClass = "h-4 w-4 shrink-0";
+
+/** Get appropriate icon based on file extension */
+function getFileIcon(name: string) {
+  const lowerName = name.toLowerCase();
+  const ext = lowerName.split(".").pop() ?? "";
+
+  // Special filenames
+  if (lowerName === "dockerfile" || lowerName.startsWith("dockerfile.")) {
+    return <SiDocker className={cn(iconClass, "text-[#2496ED]")} />;
+  }
+  if (lowerName === "makefile" || lowerName === "justfile") {
+    return <Cog className={cn(iconClass, "text-orange-500")} />;
+  }
+  if (lowerName.includes("lock") || lowerName.endsWith("-lock.yaml")) {
+    return <Lock className={cn(iconClass, "text-yellow-600")} />;
+  }
+  if (lowerName.startsWith(".git") || lowerName === ".gitignore") {
+    return <SiGit className={cn(iconClass, "text-[#F05032]")} />;
+  }
+  if (lowerName.startsWith(".env")) {
+    return <Cog className={cn(iconClass, "text-yellow-500")} />;
+  }
+  if (lowerName === "cargo.toml" || lowerName === "cargo.lock") {
+    return <SiRust className={cn(iconClass, "text-[#CE422B]")} />;
+  }
+  if (lowerName === "package.json" || lowerName === "package-lock.json") {
+    return <FileJson className={cn(iconClass, "text-[#CB3837]")} />;
+  }
+  if (lowerName === "tsconfig.json" || lowerName.startsWith("tsconfig.")) {
+    return <SiTypescript className={cn(iconClass, "text-[#3178C6]")} />;
+  }
+
+  // By extension
+  switch (ext) {
+    // JavaScript/TypeScript
+    case "js":
+    case "mjs":
+    case "cjs":
+      return <SiJavascript className={cn(iconClass, "text-[#F7DF1E]")} />;
+    case "jsx":
+      return <SiReact className={cn(iconClass, "text-[#61DAFB]")} />;
+    case "ts":
+    case "mts":
+    case "cts":
+      return <SiTypescript className={cn(iconClass, "text-[#3178C6]")} />;
+    case "tsx":
+      return <SiReact className={cn(iconClass, "text-[#61DAFB]")} />;
+
+    // Web
+    case "html":
+    case "htm":
+      return <SiHtml5 className={cn(iconClass, "text-[#E34F26]")} />;
+    case "css":
+      return <SiCss3 className={cn(iconClass, "text-[#1572B6]")} />;
+    case "scss":
+    case "sass":
+      return <SiSass className={cn(iconClass, "text-[#CC6699]")} />;
+    case "less":
+      return <SiCss3 className={cn(iconClass, "text-[#1D365D]")} />;
+
+    // Data formats
+    case "json":
+    case "jsonc":
+      return <FileJson className={cn(iconClass, "text-yellow-500")} />;
+    case "yaml":
+    case "yml":
+      return <SiYaml className={cn(iconClass, "text-[#CB171E]")} />;
+    case "toml":
+      return <SiToml className={cn(iconClass, "text-[#9C4121]")} />;
+    case "xml":
+      return <FileCode className={cn(iconClass, "text-orange-400")} />;
+    case "csv":
+      return <Database className={cn(iconClass, "text-green-500")} />;
+    case "sql":
+      return <Database className={cn(iconClass, "text-blue-400")} />;
+
+    // Documentation
+    case "md":
+    case "mdx":
+      return <SiMarkdown className={cn(iconClass, "text-foreground")} />;
+    case "txt":
+      return <FileText className={cn(iconClass, "text-muted-foreground")} />;
+    case "pdf":
+      return <FileType className={cn(iconClass, "text-red-500")} />;
+
+    // Images
+    case "png":
+    case "jpg":
+    case "jpeg":
+    case "gif":
+    case "webp":
+    case "ico":
+    case "bmp":
+      return <FileImage className={cn(iconClass, "text-purple-500")} />;
+    case "svg":
+      return <SiSvg className={cn(iconClass, "text-[#FFB13B]")} />;
+
+    // Programming languages
+    case "py":
+    case "pyw":
+      return <SiPython className={cn(iconClass, "text-[#3776AB]")} />;
+    case "rs":
+      return <SiRust className={cn(iconClass, "text-[#CE422B]")} />;
+    case "go":
+      return <SiGo className={cn(iconClass, "text-[#00ADD8]")} />;
+    case "rb":
+      return <SiRuby className={cn(iconClass, "text-[#CC342D]")} />;
+    case "java":
+      return <FaJava className={cn(iconClass, "text-[#ED8B00]")} />;
+    case "c":
+    case "h":
+      return <SiC className={cn(iconClass, "text-[#A8B9CC]")} />;
+    case "cpp":
+    case "cc":
+    case "cxx":
+    case "hpp":
+      return <SiCplusplus className={cn(iconClass, "text-[#00599C]")} />;
+    case "php":
+      return <SiPhp className={cn(iconClass, "text-[#777BB4]")} />;
+    case "swift":
+      return <SiSwift className={cn(iconClass, "text-[#F05138]")} />;
+    case "kt":
+    case "kts":
+      return <SiKotlin className={cn(iconClass, "text-[#7F52FF]")} />;
+    case "lua":
+      return <SiLua className={cn(iconClass, "text-[#2C2D72]")} />;
+    case "zig":
+      return <SiZig className={cn(iconClass, "text-[#F7A41D]")} />;
+
+    // Shell/Scripts
+    case "sh":
+    case "bash":
+    case "zsh":
+    case "fish":
+      return <SiGnubash className={cn(iconClass, "text-[#4EAA25]")} />;
+    case "ps1":
+    case "bat":
+    case "cmd":
+      return <Terminal className={cn(iconClass, "text-[#5391FE]")} />;
+
+    // Config
+    case "ini":
+    case "conf":
+    case "cfg":
+      return <Cog className={cn(iconClass, "text-gray-500")} />;
+
+    // Archives
+    case "zip":
+    case "tar":
+    case "gz":
+    case "rar":
+    case "7z":
+      return <Archive className={cn(iconClass, "text-yellow-600")} />;
+
+    default:
+      return <File className={cn(iconClass, "text-muted-foreground")} />;
+  }
+}
+
+function getIcon(entryType: PathCompletion["entry_type"], name: string) {
   switch (entryType) {
     case "directory":
-      return <Folder className="h-4 w-4 text-blue-500" />;
+      return <Folder className={cn(iconClass, "text-blue-500")} />;
     case "symlink":
-      return <Link2 className="h-4 w-4 text-cyan-500" />;
+      return <Link2 className={cn(iconClass, "text-cyan-500")} />;
     default:
-      return <File className="h-4 w-4 text-muted-foreground" />;
+      return getFileIcon(name);
   }
+}
+
+/** Renders a name with matched characters highlighted */
+function HighlightedName({ name, indices }: { name: string; indices: number[] }) {
+  if (indices.length === 0) {
+    return <span>{name}</span>;
+  }
+
+  const indexSet = new Set(indices);
+  const chars = [...name];
+
+  return (
+    <span>
+      {chars.map((char, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: Characters are static, never reordered
+        <span key={i} className={indexSet.has(i) ? "text-primary font-semibold" : ""}>
+          {char}
+        </span>
+      ))}
+    </span>
+  );
 }
 
 export function PathCompletionPopup({
   open,
   onOpenChange,
   completions,
+  totalCount,
   selectedIndex,
   onSelect,
   children,
@@ -71,15 +295,27 @@ export function PathCompletionPopup({
       {children}
       {open && (
         <div
-          ref={listRef}
-          className="absolute bottom-full left-0 mb-2 w-[350px] z-50 bg-popover border border-border rounded-md shadow-md overflow-hidden"
+          data-testid="path-completion-popup"
+          className="absolute bottom-full left-0 mb-2 min-w-[300px] max-w-[500px] z-50 bg-popover border border-border rounded-md shadow-md overflow-hidden"
         >
+          {/* Result count badge - shown when there are more matches than displayed */}
+          {totalCount > completions.length && (
+            <div className="px-3 py-1 text-xs text-muted-foreground border-b border-border bg-muted/30">
+              Showing {completions.length} of {totalCount} matches
+            </div>
+          )}
+
           {completions.length === 0 ? (
-            <div className="py-3 text-center text-sm text-muted-foreground">
+            <div className="py-3 text-center text-[13px] text-muted-foreground">
               No completions found
             </div>
           ) : (
-            <div className="max-h-[200px] overflow-y-auto py-1" role="listbox">
+            <div
+              ref={listRef}
+              className="max-h-[530px] overflow-y-scroll py-1"
+              style={{ scrollbarGutter: "stable" }}
+              role="listbox"
+            >
               {completions.map((completion, index) => (
                 <div
                   key={completion.insert_text}
@@ -100,9 +336,9 @@ export function PathCompletionPopup({
                     index === selectedIndex ? "bg-primary/10" : "hover:bg-card"
                   )}
                 >
-                  {getIcon(completion.entry_type)}
-                  <span className="font-mono text-sm text-foreground truncate">
-                    {completion.name}
+                  {getIcon(completion.entry_type, completion.name)}
+                  <span className="font-mono text-[13px] text-foreground truncate">
+                    <HighlightedName name={completion.name} indices={completion.match_indices} />
                   </span>
                 </div>
               ))}

--- a/frontend/hooks/usePathCompletion.ts
+++ b/frontend/hooks/usePathCompletion.ts
@@ -10,11 +10,13 @@ interface UsePathCompletionOptions {
 
 export function usePathCompletion({ sessionId, partialPath, enabled }: UsePathCompletionOptions) {
   const [completions, setCompletions] = useState<PathCompletion[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (!enabled) {
       setCompletions([]);
+      setTotalCount(0);
       return;
     }
 
@@ -22,12 +24,18 @@ export function usePathCompletion({ sessionId, partialPath, enabled }: UsePathCo
     setIsLoading(true);
 
     listPathCompletions(sessionId, partialPath, 20)
-      .then((results) => {
-        if (!cancelled) setCompletions(results);
+      .then((response) => {
+        if (!cancelled) {
+          setCompletions(response.completions);
+          setTotalCount(response.total_count);
+        }
       })
       .catch((error) => {
         logger.error("Path completion error:", error);
-        if (!cancelled) setCompletions([]);
+        if (!cancelled) {
+          setCompletions([]);
+          setTotalCount(0);
+        }
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -38,5 +46,5 @@ export function usePathCompletion({ sessionId, partialPath, enabled }: UsePathCo
     };
   }, [sessionId, partialPath, enabled]);
 
-  return { completions, isLoading };
+  return { completions, totalCount, isLoading };
 }

--- a/frontend/lib/tauri.ts
+++ b/frontend/lib/tauri.ts
@@ -142,14 +142,21 @@ export interface PathCompletion {
   name: string;
   insert_text: string;
   entry_type: PathEntryType;
+  score: number;
+  match_indices: number[];
+}
+
+export interface PathCompletionResponse {
+  completions: PathCompletion[];
+  total_count: number;
 }
 
 export async function listPathCompletions(
   sessionId: string,
   partialPath: string,
   limit?: number
-): Promise<PathCompletion[]> {
-  return invoke("list_path_completions", {
+): Promise<PathCompletionResponse> {
+  return invoke<PathCompletionResponse>("list_path_completions", {
     sessionId,
     partialPath,
     limit,

--- a/frontend/mocks.ts
+++ b/frontend/mocks.ts
@@ -1153,7 +1153,18 @@ export function setupMocks(): void {
           return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
         });
 
-        return filtered.slice(0, limit);
+        const totalCount = filtered.length;
+        const limited = filtered.slice(0, limit);
+
+        // Return PathCompletionResponse format with score and match_indices
+        return {
+          completions: limited.map((c) => ({
+            ...c,
+            score: 0,
+            match_indices: [] as number[],
+          })),
+          total_count: totalCount,
+        };
       }
 
       // =========================================================================

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
     "react-syntax-highlighter": "^16.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.0(react@19.2.0)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@19.2.0)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.7)(react@19.2.0)
@@ -2364,6 +2367,11 @@ packages:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
     peerDependencies:
       react: ^19.2.0
+
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -5086,6 +5094,10 @@ snapshots:
     dependencies:
       react: 19.2.0
       scheduler: 0.27.0
+
+  react-icons@5.5.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
 
   react-is@17.0.2: {}
 


### PR DESCRIPTION
## Summary

- Add nucleo-matcher for fuzzy path matching with score-based ranking
- Implement match character highlighting to show which characters matched the query
- Add file type-specific icons using react-icons (Rust, TypeScript, Python, Go, etc.)
- Increase popup height from 400px to 530px for better visibility
- Add wrap-around navigation (down at bottom goes to top, up at top goes to bottom)
- Add vim-style keyboard shortcuts: Ctrl+N/J (down), Ctrl+P/K (up)
- Keep popup open when selecting directories for continuous navigation
- Show result count badge when matches exceed display limit ("Showing X of Y matches")
- Match popup font size (13px) to textarea for visual consistency

## Test plan

- [x] `just check` passes
- [x] `just test-e2e` passes (119 tests)
- [x] `pnpm test` passes (503 tests)
- [x] Manual testing:
  - Press Tab in terminal mode to open completion popup
  - Verify fuzzy matching works (e.g., "cmpltns" matches "completions.rs")
  - Verify matched characters are highlighted
  - Verify file type icons display correctly (Rust files show Rust icon, etc.)
  - Verify Ctrl+N/P/J/K navigation works
  - Verify wrap-around navigation at list boundaries
  - Verify selecting a directory keeps popup open with directory contents