### PR TITLE
chore(cicd): secure env vars

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -15,6 +17,8 @@ env:
 jobs:
   check:
     runs-on: linux-arm64
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,10 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -27,10 +27,14 @@ env:
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
 
+permissions: {}
+
 jobs:
   evals:
     name: Evals (${{ matrix.provider }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # OpenAI evals are optional - the API can be flaky
     continue-on-error: ${{ matrix.provider == 'openai' }}
     strategy:

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -10,9 +10,13 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   update-cask:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Set tag name
         id: tag


### PR DESCRIPTION
1. added explicit permissions blocks to all four workflow files:

permissions: {} at the workflow level (denies all permissions by default)
permissions: contents: read at the job level (grants minimal read access needed for checkout)
This follows the principle of least privilege - each job only gets the contents: read permission required for actions/checkout@v4. The [update-homebrew.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) workflow uses a separate HOMEBREW_TAP_TOKEN secret for pushing to the tap repository, so it doesn't need additional write permissions on the current repository.

2. prevents script injection attacks because environment variables are set before the shell script runs, rather than being interpolated directly into the script text where malicious input could break out of strings and execute arbitrary commands.