### PR TITLE
feat(rig-openai-responses): add image support for OpenAI reasoning models

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ast-grep"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5848,7 +5848,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-cli-output"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "qbit-core",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "rig-core 0.29.0",
@@ -5871,7 +5871,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-directory-ops"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-file-ops"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-hitl"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-indexer"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5995,7 +5995,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-loop-detection"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "serde",
@@ -6006,7 +6006,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -6017,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-planner"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "proptest",
@@ -6031,7 +6031,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "dirs 5.0.1",
  "itoa",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-runtime"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-trait",
  "atty",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6083,7 +6083,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6113,7 +6113,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6177,7 +6177,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6204,7 +6204,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tool-policy"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6234,7 +6234,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6259,11 +6259,11 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.12"
+version = "0.2.13"
 
 [[package]]
 name = "qbit-web"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6280,7 +6280,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6907,7 +6907,7 @@ checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6989,6 +6989,7 @@ name = "rig-openai-responses"
 version = "0.1.0"
 dependencies = [
  "async-openai",
+ "base64 0.22.1",
  "futures",
  "rig-core 0.29.0",
  "serde",
@@ -7015,7 +7016,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-stream",
  "bytes",

--- a/backend/crates/rig-openai-responses/Cargo.toml
+++ b/backend/crates/rig-openai-responses/Cargo.toml
@@ -21,3 +21,4 @@ serde_json = "1.0"
 # Utilities
 tracing = "0.1"
 thiserror = "2.0"
+base64 = "0.22"


### PR DESCRIPTION
## Summary

- Fix image handling for OpenAI reasoning models (o1, o3, o4, gpt-5)
- Images were being silently dropped when sending messages to reasoning models
- Add `convert_user_content()` function to properly handle multimodal content

## Problem

The `extract_user_text()` function in `rig-openai-responses` only handled `Text` and `ToolResult` content types, ignoring `Image` content entirely. This meant images sent to reasoning models were silently dropped.

## Solution

- Added new `convert_user_content()` function that handles all content types including images
- Converts rig's `UserContent::Image` to async-openai's `InputImageContent` format
- Uses `EasyInputContent::ContentList` when images are present (required by the OpenAI Responses API for multimodal content)
- Added `base64` dependency for encoding raw image bytes
- Added unit tests for text-only and image content conversion

## Affected Models

All OpenAI reasoning models now properly support images:
- o1, o1-preview, o1-mini
- o3, o3-mini
- o4-mini
- gpt-5, gpt-5.1, gpt-5.2, gpt-5-mini, gpt-5-nano

## Test Plan

- [x] Unit tests pass (`cargo test -p rig-openai-responses`)
- [x] Clippy passes with no warnings
- [x] E2E tests pass (119 tests)