### PR TITLE
refactor(file-editor): use single shared instance across all tabs

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -97,10 +97,7 @@ function App() {
       setGitPanelOpen(false);
     } else {
       // Sync store state when closing - this prevents the effect from re-opening
-      const focusedId = focusedSessionIdRef.current;
-      if (focusedId) {
-        useFileEditorSidebarStore.getState().setOpen(focusedId, false);
-      }
+      useFileEditorSidebarStore.getState().setOpen(false);
     }
     setFileEditorPanelOpen(open);
   }, []);
@@ -140,9 +137,7 @@ function App() {
 
   // Subscribe to file editor sidebar store to sync open state
   // This allows openFile() calls from anywhere to open the sidebar
-  const fileEditorStoreOpen = useFileEditorSidebarStore((state) =>
-    focusedSessionId ? state.sessions[focusedSessionId]?.open : false
-  );
+  const fileEditorStoreOpen = useFileEditorSidebarStore((state) => state.open);
   useEffect(() => {
     if (fileEditorStoreOpen && !fileEditorPanelOpen) {
       handleFileEditorPanelOpenChange(true);
@@ -960,9 +955,8 @@ function App() {
           {/* Context Panel - integrated side panel, uses sidecar's current session */}
           <ContextPanel open={contextPanelOpen} onOpenChange={handleContextPanelOpenChange} />
 
-          {/* File Editor Panel - right side code editor */}
+          {/* File Editor Panel - right side code editor (shared across all tabs) */}
           <FileEditorSidebarPanel
-            sessionId={focusedSessionId}
             open={fileEditorPanelOpen}
             onOpenChange={handleFileEditorPanelOpenChange}
             workingDirectory={workingDirectory}

--- a/frontend/components/CommandBlock/StaticTerminalOutput.tsx
+++ b/frontend/components/CommandBlock/StaticTerminalOutput.tsx
@@ -68,7 +68,7 @@ export function StaticTerminalOutput({
   // Store the detected path for resolution
   const pendingDetectedRef = useRef<DetectedPath | null>(null);
 
-  const { openFile } = useFileEditorSidebar(sessionId ?? null, workingDirectory);
+  const { openFile } = useFileEditorSidebar(workingDirectory);
 
   // Calculate rows needed for content (pre-render estimate)
   const lineCount = output.split("\n").length;

--- a/frontend/components/FilePathLink/FilePathLink.tsx
+++ b/frontend/components/FilePathLink/FilePathLink.tsx
@@ -16,8 +16,6 @@ interface FilePathLinkProps {
   detected: DetectedPath;
   /** Working directory for path resolution */
   workingDirectory: string;
-  /** Session ID for file editor */
-  sessionId: string;
   /** The text to display (may differ from detected.raw if we only wrap part of it) */
   children: ReactNode;
   /** Pre-resolved absolute path (if known from index) */
@@ -27,7 +25,6 @@ interface FilePathLinkProps {
 export function FilePathLink({
   detected,
   workingDirectory,
-  sessionId,
   children,
   absolutePath,
 }: FilePathLinkProps) {
@@ -35,7 +32,7 @@ export function FilePathLink({
   const [loading, setLoading] = useState(false);
   const [resolvedPaths, setResolvedPaths] = useState<ResolvedPath[]>([]);
 
-  const { openFile } = useFileEditorSidebar(sessionId, workingDirectory);
+  const { openFile } = useFileEditorSidebar(workingDirectory);
 
   const handleClick = useCallback(async () => {
     if (open) {

--- a/frontend/components/Markdown/Markdown.tsx
+++ b/frontend/components/Markdown/Markdown.tsx
@@ -76,7 +76,6 @@ function processTextWithFilePaths(text: string, context: MarkdownContextValue): 
       <FilePathLink
         key={`path-${idx}`}
         detected={detected}
-        sessionId={sessionId}
         workingDirectory={workingDirectory}
         absolutePath={detected.absolutePath}
       >


### PR DESCRIPTION
## Summary

- Previously each tab maintained its own file editor state (open files, recent files, editor settings)
- Now the file editor uses a single global state shared across all tabs
- Files remain open when switching between main app tabs

## Changes

- Flatten `sessions` map to single global state in `file-editor-sidebar.ts` store
- Remove `sessionId` parameters from `useFileEditorSidebar` hook
- Remove `sessionId` prop from `FileEditorSidebarPanel` component
- Update consumers (`FilePathLink`, `StaticTerminalOutput`, `Markdown`) to use simplified hook

## Test plan

- [ ] Open file editor panel and open a file
- [ ] Switch to a different tab
- [ ] Verify file is still open in editor panel
- [ ] Verify editor settings (vim mode, wrap, etc.) persist across tab switches