### PR TITLE
fix(e2e): update tests for Home tab and add missing mock handlers

### DIFF
--- a/e2e/ai-prompt-submission.spec.ts
+++ b/e2e/ai-prompt-submission.spec.ts
@@ -3,11 +3,18 @@ import { waitForAppReady as waitForAppReadyBase } from "./helpers/app";
 
 async function waitForAppReady(page: Page) {
   await waitForAppReadyBase(page);
-  await expect(page.locator('[data-testid="unified-input"]')).toBeVisible({ timeout: 5000 });
+  // Use :visible to find the textarea in the currently active tab
+  await expect(page.locator('[data-testid="unified-input"]:visible').first()).toBeVisible({
+    timeout: 10000,
+  });
 }
 
+/**
+ * Get the UnifiedInput textarea element.
+ * Uses :visible to find the textarea in the currently active tab.
+ */
 function getInputTextarea(page: Page) {
-  return page.locator('[data-testid="unified-input"]');
+  return page.locator('[data-testid="unified-input"]:visible').first();
 }
 
 function getAgentModeButton(page: Page) {

--- a/e2e/copy-buttons.spec.ts
+++ b/e2e/copy-buttons.spec.ts
@@ -48,9 +48,10 @@ type AiEventType =
 async function waitForAppReady(page: Page) {
   await waitForAppReadyBase(page);
 
-  // Wait for the unified input textarea to be visible (use specific selector to avoid xterm textarea)
-  await expect(page.locator('[data-slot="popover-anchor"] textarea')).toBeVisible({
-    timeout: 5000,
+  // Wait for the unified input textarea to be visible in the active tab
+  // Use :visible to find the textarea in the currently active tab
+  await expect(page.locator('[data-testid="unified-input"]:visible').first()).toBeVisible({
+    timeout: 10000,
   });
 
   // Ensure mock functions are available
@@ -68,9 +69,10 @@ function getAgentModeButton(page: Page) {
 
 /**
  * Get the UnifiedInput textarea element.
+ * Uses :visible to find the textarea in the currently active tab.
  */
 function getInputTextarea(page: Page) {
-  return page.locator('[data-testid="unified-input"]');
+  return page.locator('[data-testid="unified-input"]:visible').first();
 }
 
 /**

--- a/e2e/diagnostic.spec.ts
+++ b/e2e/diagnostic.spec.ts
@@ -1,0 +1,643 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppReady } from "./helpers/app";
+
+/**
+ * Diagnostic test to understand the 34 textareas issue
+ */
+test.describe("Diagnostic Tests", () => {
+  test("track mount/unmount console logs", async ({ page }) => {
+    // Capture console messages
+    const unifiedInputLogs: string[] = [];
+    const paneLeafLogs: string[] = [];
+    const errorLogs: string[] = [];
+
+    page.on("console", (msg) => {
+      const text = msg.text();
+      const type = msg.type();
+
+      if (text.includes("[UnifiedInput]")) {
+        unifiedInputLogs.push(text);
+      }
+      if (text.includes("[PaneLeaf]")) {
+        paneLeafLogs.push(text);
+      }
+      if (type === "error") {
+        errorLogs.push(text);
+      }
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("domcontentloaded");
+
+    // Wait for mock mode
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __MOCK_BROWSER_MODE__?: boolean }).__MOCK_BROWSER_MODE__ === true,
+      { timeout: 15000 }
+    );
+
+    // Wait for the app to stabilize and collect logs
+    await page.waitForTimeout(3000);
+
+    console.log("=== PaneLeaf mount/unmount logs ===");
+    console.log(`Total: ${paneLeafLogs.length}`);
+    for (const log of paneLeafLogs.slice(0, 10)) {
+      console.log(`  ${log}`);
+    }
+    const paneLeafMounts = paneLeafLogs.filter((l) => l.includes("MOUNT")).length;
+    const paneLeafUnmounts = paneLeafLogs.filter((l) => l.includes("UNMOUNT")).length;
+    console.log(`  PaneLeaf mounts: ${paneLeafMounts}, unmounts: ${paneLeafUnmounts}`);
+
+    console.log("\n=== UnifiedInput mount/unmount logs ===");
+    console.log(`Total: ${unifiedInputLogs.length}`);
+    for (const log of unifiedInputLogs.slice(0, 10)) {
+      console.log(`  ${log}`);
+    }
+    const mountCount = unifiedInputLogs.filter((l) => l.includes("MOUNT")).length;
+    const unmountCount = unifiedInputLogs.filter((l) => l.includes("UNMOUNT")).length;
+    console.log(`  UnifiedInput mounts: ${mountCount}, unmounts: ${unmountCount}`);
+
+    console.log("\n=== Console Errors ===");
+    console.log(`Total errors: ${errorLogs.length}`);
+    for (const log of errorLogs.slice(0, 10)) {
+      console.log(`  ${log.slice(0, 200)}`);
+    }
+
+    // In a stable app, there should be very few mount/unmount cycles
+    expect(mountCount).toBeLessThan(10);
+  });
+
+  test("track requestAnimationFrame calls", async ({ page }) => {
+    await waitForAppReady(page);
+
+    // Track RAF calls with stack traces to identify sources
+    const rafTracking = await page.evaluate(async () => {
+      return new Promise<{
+        rafCalls: number;
+        setTimeoutCalls: number;
+        stackSamples: string[];
+        sourceCounts: Record<string, number>;
+      }>((resolve) => {
+        const results = {
+          rafCalls: 0,
+          setTimeoutCalls: 0,
+          stackSamples: [] as string[],
+          sourceCounts: {} as Record<string, number>,
+        };
+
+        // Patch RAF with stack trace sampling
+        const origRAF = window.requestAnimationFrame;
+        window.requestAnimationFrame = (callback) => {
+          results.rafCalls++;
+
+          // Sample stack traces (first 20, then every 100th)
+          if (results.rafCalls <= 20 || results.rafCalls % 100 === 0) {
+            try {
+              const stack = new Error().stack || "";
+              const lines = stack.split("\n").slice(2, 5);
+              const source = lines.join(" <- ").replace(/\s+/g, " ").slice(0, 200);
+              if (results.stackSamples.length < 10) {
+                results.stackSamples.push(source);
+              }
+
+              // Count by first function name
+              const match = lines[0]?.match(/at\s+(\S+)/);
+              const funcName = match?.[1] || "unknown";
+              results.sourceCounts[funcName] = (results.sourceCounts[funcName] || 0) + 1;
+            } catch {
+              // Ignore stack trace errors
+            }
+          }
+
+          return origRAF.call(window, callback);
+        };
+
+        // Patch setTimeout (count only short timeouts)
+        const origSetTimeout = window.setTimeout;
+        (window as unknown as { setTimeout: typeof setTimeout }).setTimeout = (
+          callback: TimerHandler,
+          delay?: number,
+          ...args: unknown[]
+        ) => {
+          if (typeof delay === "number" && delay < 100) {
+            results.setTimeoutCalls++;
+          }
+          return origSetTimeout.call(window, callback, delay, ...args);
+        };
+
+        // Wait 2 seconds
+        origSetTimeout(() => {
+          // Restore originals
+          window.requestAnimationFrame = origRAF;
+          (window as unknown as { setTimeout: typeof setTimeout }).setTimeout = origSetTimeout;
+          resolve(results);
+        }, 2000);
+      });
+    });
+
+    console.log("Animation/timer tracking over 2 seconds:");
+    console.log(`  requestAnimationFrame calls: ${rafTracking.rafCalls}`);
+    console.log(`  Short setTimeout calls (<100ms): ${rafTracking.setTimeoutCalls}`);
+    console.log(`  RAF source counts: ${JSON.stringify(rafTracking.sourceCounts, null, 2)}`);
+    console.log(
+      `  Stack samples: ${JSON.stringify(rafTracking.stackSamples.slice(0, 5), null, 2)}`
+    );
+
+    // If there are excessive RAF calls, something is looping
+    // 60fps would be ~120 calls in 2 seconds, allow some margin
+    expect(rafTracking.rafCalls).toBeLessThan(500);
+  });
+
+  test("track store updates", async ({ page }) => {
+    await waitForAppReady(page);
+
+    // Track how many times the store updates
+    const storeUpdates = await page.evaluate(async () => {
+      return new Promise<{
+        updateCount: number;
+        updateSources: string[];
+      }>((resolve) => {
+        const results = {
+          updateCount: 0,
+          updateSources: [] as string[],
+        };
+
+        // Get the store and subscribe to changes
+        const store = (
+          window as unknown as {
+            __QBIT_STORE__?: { subscribe: (fn: () => void) => () => void; getState: () => unknown };
+          }
+        ).__QBIT_STORE__;
+        if (!store) {
+          resolve(results);
+          return;
+        }
+
+        let lastState = JSON.stringify(store.getState());
+        const unsubscribe = store.subscribe(() => {
+          results.updateCount++;
+          const newState = JSON.stringify(store.getState());
+          if (results.updateSources.length < 10) {
+            // Try to figure out what changed
+            try {
+              const oldObj = JSON.parse(lastState);
+              const newObj = JSON.parse(newState);
+              for (const key of Object.keys(newObj)) {
+                if (JSON.stringify(oldObj[key]) !== JSON.stringify(newObj[key])) {
+                  results.updateSources.push(key);
+                  break;
+                }
+              }
+            } catch {
+              results.updateSources.push("parse-error");
+            }
+          }
+          lastState = newState;
+        });
+
+        // Wait 2 seconds
+        setTimeout(() => {
+          unsubscribe();
+          resolve(results);
+        }, 2000);
+      });
+    });
+
+    console.log("Store update tracking over 2 seconds:");
+    console.log(`  Total updates: ${storeUpdates.updateCount}`);
+    console.log(`  Update sources (first 10): ${storeUpdates.updateSources.join(", ")}`);
+
+    // If there are continuous store updates, something is wrong
+    expect(storeUpdates.updateCount).toBeLessThan(10);
+  });
+
+  test("track DOM mutations with MutationObserver", async ({ page }) => {
+    await waitForAppReady(page);
+
+    // Set up MutationObserver to track only unified-input related mutations
+    const mutations = await page.evaluate(async () => {
+      return new Promise<{
+        total: number;
+        childListCount: number;
+        attributeCount: number;
+        unifiedInputAdditions: number;
+        unifiedInputRemovals: number;
+        xtermAdditions: number;
+        xtermRemovals: number;
+        samples: string[];
+        attrMutationTargets: Record<string, number>;
+        attrNames: Record<string, number>;
+      }>((resolve) => {
+        const results = {
+          total: 0,
+          childListCount: 0,
+          attributeCount: 0,
+          unifiedInputAdditions: 0,
+          unifiedInputRemovals: 0,
+          xtermAdditions: 0,
+          xtermRemovals: 0,
+          samples: [] as string[],
+          attrMutationTargets: {} as Record<string, number>,
+          attrNames: {} as Record<string, number>,
+        };
+
+        // Helper to check if an element contains unified-input
+        const hasUnifiedInput = (el: Element): boolean => {
+          return (
+            el.querySelector?.('[data-testid="unified-input"]') !== null ||
+            (el instanceof HTMLTextAreaElement &&
+              el.getAttribute("data-testid") === "unified-input")
+          );
+        };
+
+        // Helper to check if an element contains xterm textarea
+        const hasXtermTextarea = (el: Element): boolean => {
+          return (
+            el.querySelector?.(".xterm-helper-textarea") !== null ||
+            el.classList?.contains("xterm-helper-textarea")
+          );
+        };
+
+        const observer = new MutationObserver((mutations) => {
+          for (const mutation of mutations) {
+            results.total++;
+            if (mutation.type === "childList") {
+              results.childListCount++;
+              // Check for additions
+              for (const node of Array.from(mutation.addedNodes)) {
+                if (node instanceof Element) {
+                  if (hasUnifiedInput(node)) {
+                    results.unifiedInputAdditions++;
+                    if (results.samples.length < 10) {
+                      results.samples.push(
+                        `ADD unified-input: ${node.tagName} to ${mutation.target instanceof Element ? mutation.target.className.slice(0, 30) : "unknown"}`
+                      );
+                    }
+                  } else if (hasXtermTextarea(node)) {
+                    results.xtermAdditions++;
+                  }
+                }
+              }
+              // Check for removals
+              for (const node of Array.from(mutation.removedNodes)) {
+                if (node instanceof Element) {
+                  if (hasUnifiedInput(node)) {
+                    results.unifiedInputRemovals++;
+                    if (results.samples.length < 10) {
+                      results.samples.push(
+                        `REMOVE unified-input: ${node.tagName} from ${mutation.target instanceof Element ? mutation.target.className.slice(0, 30) : "unknown"}`
+                      );
+                    }
+                  } else if (hasXtermTextarea(node)) {
+                    results.xtermRemovals++;
+                  }
+                }
+              }
+            } else if (mutation.type === "attributes") {
+              results.attributeCount++;
+              // Track which elements are getting attribute mutations
+              const target = mutation.target as Element;
+              const targetKey = `${target.tagName}${target.className ? `.${target.className.split(" ")[0]}` : ""}`;
+              results.attrMutationTargets[targetKey] =
+                (results.attrMutationTargets[targetKey] || 0) + 1;
+              // Track which attributes are being mutated
+              const attrName = mutation.attributeName || "unknown";
+              results.attrNames[attrName] = (results.attrNames[attrName] || 0) + 1;
+            }
+          }
+        });
+
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true,
+          attributes: true,
+          attributeOldValue: true,
+        });
+
+        // Wait 2 seconds
+        setTimeout(() => {
+          observer.disconnect();
+          resolve(results);
+        }, 2000);
+      });
+    });
+
+    console.log("DOM Mutation results over 2 seconds:");
+    console.log(`  Total mutations: ${mutations.total}`);
+    console.log(`  Child list mutations: ${mutations.childListCount}`);
+    console.log(`  Attribute mutations: ${mutations.attributeCount}`);
+    console.log(`  UnifiedInput additions: ${mutations.unifiedInputAdditions}`);
+    console.log(`  UnifiedInput removals: ${mutations.unifiedInputRemovals}`);
+    console.log(`  Xterm additions: ${mutations.xtermAdditions}`);
+    console.log(`  Xterm removals: ${mutations.xtermRemovals}`);
+    console.log(`  Attribute mutation targets: ${JSON.stringify(mutations.attrMutationTargets)}`);
+    console.log(`  Attribute names: ${JSON.stringify(mutations.attrNames)}`);
+    console.log(`  Samples: ${JSON.stringify(mutations.samples, null, 2)}`);
+
+    // If there are continuous mutations, something is wrong
+    // In a stable app, there should be very few mutations when idle
+    expect(mutations.unifiedInputAdditions).toBeLessThan(5);
+    expect(mutations.unifiedInputRemovals).toBeLessThan(5);
+  });
+
+  test("check render loop by tracking React keys", async ({ page }) => {
+    await waitForAppReady(page);
+
+    // Track if React is continuously re-keying elements
+    const keyChanges = await page.evaluate(async () => {
+      return new Promise<{
+        uniqueKeys: Set<string>;
+        keyChangeCount: number;
+        elementReplaceCount: number;
+      }>((resolve) => {
+        const results = {
+          uniqueKeys: new Set<string>(),
+          keyChangeCount: 0,
+          elementReplaceCount: 0,
+        };
+
+        let lastTextarea: HTMLTextAreaElement | null = null;
+        const interval = setInterval(() => {
+          const textarea = document.querySelector(
+            '[data-testid="unified-input"]'
+          ) as HTMLTextAreaElement;
+          if (textarea) {
+            // Check for React key
+            const reactKey = (
+              textarea as unknown as {
+                _reactRootContainer?: unknown;
+                __reactFiber$?: { key?: string };
+              }
+            ).__reactFiber$?.key;
+            if (reactKey) {
+              results.uniqueKeys.add(reactKey);
+              results.keyChangeCount++;
+            }
+            // Check if element reference changed
+            if (lastTextarea && textarea !== lastTextarea) {
+              results.elementReplaceCount++;
+            }
+            lastTextarea = textarea;
+          }
+        }, 100);
+
+        setTimeout(() => {
+          clearInterval(interval);
+          resolve({
+            uniqueKeys: results.uniqueKeys,
+            keyChangeCount: results.uniqueKeys.size,
+            elementReplaceCount: results.elementReplaceCount,
+          });
+        }, 2000);
+      });
+    });
+
+    console.log("React key tracking over 2 seconds:");
+    console.log(`  Unique keys seen: ${keyChanges.keyChangeCount}`);
+    console.log(`  Element replacements: ${keyChanges.elementReplaceCount}`);
+
+    // If elements are being replaced continuously, that's a problem
+    expect(keyChanges.elementReplaceCount).toBeLessThan(5);
+  });
+
+  test("identify parent re-renders", async ({ page }) => {
+    await waitForAppReady(page);
+
+    // Track which parent elements are changing
+    const parentChanges = await page.evaluate(async () => {
+      return new Promise<{
+        parentPath: string[];
+        parentChanges: number;
+        textareaChanges: number;
+      }>((resolve) => {
+        const results = {
+          parentPath: [] as string[],
+          parentChanges: 0,
+          textareaChanges: 0,
+        };
+
+        let lastTextarea: HTMLTextAreaElement | null = null;
+        let lastParentSignature = "";
+
+        const interval = setInterval(() => {
+          const textarea = document.querySelector(
+            '[data-testid="unified-input"]'
+          ) as HTMLTextAreaElement;
+          if (textarea) {
+            // Get parent path
+            const parentPath: string[] = [];
+            let el: HTMLElement | null = textarea.parentElement;
+            while (el && parentPath.length < 10) {
+              const id = el.id ? `#${el.id}` : "";
+              const classes = el.className
+                ? `.${el.className.split(" ").slice(0, 2).join(".")}`
+                : "";
+              parentPath.push(`${el.tagName}${id}${classes}`);
+              el = el.parentElement;
+            }
+
+            const signature = parentPath.join(" > ");
+            if (lastParentSignature && signature !== lastParentSignature) {
+              results.parentChanges++;
+            }
+            lastParentSignature = signature;
+            results.parentPath = parentPath;
+
+            if (lastTextarea && textarea !== lastTextarea) {
+              results.textareaChanges++;
+            }
+            lastTextarea = textarea;
+          }
+        }, 100);
+
+        setTimeout(() => {
+          clearInterval(interval);
+          resolve(results);
+        }, 2000);
+      });
+    });
+
+    console.log("Parent tracking over 2 seconds:");
+    console.log(`  Parent path: ${parentChanges.parentPath.slice(0, 5).join(" > ")}`);
+    console.log(`  Parent structure changes: ${parentChanges.parentChanges}`);
+    console.log(`  Textarea element changes: ${parentChanges.textareaChanges}`);
+
+    expect(parentChanges.textareaChanges).toBeLessThan(5);
+  });
+
+  test("count elements and check store state", async ({ page }) => {
+    await waitForAppReady(page);
+
+    // Get the number of textareas in the DOM
+    const textareaCount = await page.locator("textarea").count();
+    console.log(`Total textareas in DOM: ${textareaCount}`);
+
+    // Get details about ALL textareas to understand their source
+    const allTextareaDetails = await page.evaluate(() => {
+      const textareas = document.querySelectorAll("textarea");
+      return Array.from(textareas)
+        .slice(0, 10)
+        .map((ta) => {
+          const testId = ta.getAttribute("data-testid");
+          const classes = ta.className;
+          const parent = ta.parentElement;
+          const parentClasses = parent?.className || "";
+          return {
+            testId,
+            classes: classes.slice(0, 100),
+            parentClasses: parentClasses.slice(0, 100),
+            placeholder: ta.placeholder?.slice(0, 50),
+            id: ta.id,
+            name: ta.name,
+          };
+        });
+    });
+    console.log("First 10 textareas details:", JSON.stringify(allTextareaDetails, null, 2));
+
+    // Get unified-input textareas specifically
+    const unifiedInputCount = await page.locator('[data-testid="unified-input"]').count();
+    console.log(`UnifiedInput textareas: ${unifiedInputCount}`);
+
+    // Check visibility of each textarea
+    const visibilityData = await page.evaluate(() => {
+      const textareas = document.querySelectorAll('[data-testid="unified-input"]');
+      return Array.from(textareas).map((ta, i) => {
+        const rect = ta.getBoundingClientRect();
+        const style = window.getComputedStyle(ta);
+        return {
+          index: i,
+          width: rect.width,
+          height: rect.height,
+          display: style.display,
+          visibility: style.visibility,
+          opacity: style.opacity,
+          inViewport:
+            rect.top >= 0 &&
+            rect.left >= 0 &&
+            rect.bottom <= window.innerHeight &&
+            rect.right <= window.innerWidth,
+        };
+      });
+    });
+    console.log("Textarea visibility data:", JSON.stringify(visibilityData, null, 2));
+
+    // Get store state
+    const storeState = await page.evaluate(() => {
+      const store = (window as unknown as { __QBIT_STORE__?: { getState: () => unknown } })
+        .__QBIT_STORE__;
+      if (!store) return null;
+      const state = store.getState() as {
+        sessions: Record<string, { id: string; tabType?: string; name: string }>;
+        tabLayouts: Record<string, { root: unknown; focusedPaneId: string }>;
+        activeSessionId: string | null;
+        homeTabId: string | null;
+      };
+      return {
+        sessionCount: Object.keys(state.sessions).length,
+        sessionIds: Object.keys(state.sessions),
+        sessions: Object.entries(state.sessions).map(([id, s]) => ({
+          id,
+          tabType: s.tabType,
+          name: s.name,
+        })),
+        tabLayoutCount: Object.keys(state.tabLayouts).length,
+        tabLayoutIds: Object.keys(state.tabLayouts),
+        activeSessionId: state.activeSessionId,
+        homeTabId: state.homeTabId,
+      };
+    });
+    console.log("Store state:", JSON.stringify(storeState, null, 2));
+
+    // Count pane sections
+    const paneCount = await page.locator("section[aria-label*='Pane']").count();
+    console.log(`Pane sections: ${paneCount}`);
+
+    // Expectations based on normal initialization:
+    // - 2 sessions (Home + Terminal)
+    // - 2 tab layouts
+    // - 1 UnifiedInput (only Terminal tab renders it, Home tab renders HomeView)
+    expect(storeState?.sessionCount).toBeLessThanOrEqual(3); // Allow for some variation
+    expect(unifiedInputCount).toBeLessThanOrEqual(5); // Should be 1-2, but allow for render cycles
+
+    // If we have too many textareas, log the DOM structure
+    if (unifiedInputCount > 5) {
+      const domStructure = await page.evaluate(() => {
+        const textareas = document.querySelectorAll('[data-testid="unified-input"]');
+        return Array.from(textareas).map((ta) => {
+          const parents: string[] = [];
+          let el = ta.parentElement;
+          while (el && parents.length < 5) {
+            parents.push(
+              `${el.tagName}${el.id ? `#${el.id}` : ""}${el.className ? `.${el.className.split(" ").slice(0, 2).join(".")}` : ""}`
+            );
+            el = el.parentElement;
+          }
+          return parents;
+        });
+      });
+      console.log("DOM structure of textareas:", JSON.stringify(domStructure, null, 2));
+    }
+  });
+
+  test("check textarea stability", async ({ page }) => {
+    await waitForAppReady(page);
+
+    // Count how many times the textarea reference changes over time
+    const changes: { time: number; id: string | null }[] = [];
+    let lastId: string | null = null;
+
+    for (let i = 0; i < 20; i++) {
+      const currentId = await page.evaluate(() => {
+        const textarea = document.querySelector('[data-testid="unified-input"]');
+        if (!textarea) return null;
+        // Create a unique identifier based on the element's position
+        const rect = textarea.getBoundingClientRect();
+        return `${rect.x}-${rect.y}-${rect.width}-${rect.height}`;
+      });
+
+      if (currentId !== lastId) {
+        changes.push({ time: Date.now(), id: currentId });
+        lastId = currentId;
+      }
+      await page.waitForTimeout(100);
+    }
+
+    console.log(`Textarea reference changes: ${changes.length} changes over 2 seconds`);
+    console.log("Changes:", JSON.stringify(changes, null, 2));
+
+    // The textarea should be stable - at most 1-2 changes during initial render
+    expect(changes.length).toBeLessThanOrEqual(3);
+  });
+
+  test("check for React StrictMode effects", async ({ page }) => {
+    // This test checks if StrictMode is causing issues
+    await page.goto("/");
+    await page.waitForLoadState("domcontentloaded");
+
+    // Wait for mock mode flag
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __MOCK_BROWSER_MODE__?: boolean }).__MOCK_BROWSER_MODE__ === true,
+      { timeout: 15000 }
+    );
+
+    // Wait a bit for React to settle
+    await page.waitForTimeout(2000);
+
+    // Count textareas at different intervals
+    const counts: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const count = await page.locator('[data-testid="unified-input"]').count();
+      counts.push(count);
+      await page.waitForTimeout(500);
+    }
+    console.log("Textarea counts over time:", counts);
+
+    // Check if count is stable
+    const stable = counts.every((c) => c === counts[0]);
+    console.log(`Textarea count stable: ${stable}, values: ${counts.join(", ")}`);
+
+    // The count should stabilize
+    expect(counts[counts.length - 1]).toBeLessThanOrEqual(5);
+  });
+});

--- a/e2e/input-mode-focus.spec.ts
+++ b/e2e/input-mode-focus.spec.ts
@@ -14,15 +14,19 @@ import { waitForAppReady as waitForAppReadyBase } from "./helpers/app";
 async function waitForAppReady(page: Page) {
   await waitForAppReadyBase(page);
 
-  // Wait for the unified input textarea to be visible
-  await expect(page.locator('[data-testid="unified-input"]')).toBeVisible({ timeout: 5000 });
+  // Wait for the unified input textarea to be visible in the active tab
+  // Use :visible to find the textarea in the currently active tab
+  await expect(page.locator('[data-testid="unified-input"]:visible').first()).toBeVisible({
+    timeout: 10000,
+  });
 }
 
 /**
  * Get the UnifiedInput textarea element.
+ * Uses :visible to find the textarea in the currently active tab.
  */
 function getInputTextarea(page: Page) {
-  return page.locator('[data-testid="unified-input"]');
+  return page.locator('[data-testid="unified-input"]:visible').first();
 }
 
 /**
@@ -195,15 +199,15 @@ test.describe("Input Mode Focus", () => {
       });
     }
 
-    // With only one tab, there's only one textarea
+    // Initially we have Home + Terminal tabs, and Terminal's textarea is focused
     const textarea = getInputTextarea(page);
     await expect(textarea).toBeFocused();
 
-    // Create a second tab (becomes active)
+    // Create a third tab (becomes active)
     await newTabButton.click();
 
-    const secondTab = page.getByRole("tab").nth(1);
-    await expect(secondTab).toBeVisible();
+    const thirdTab = page.getByRole("tab").nth(2);
+    await expect(thirdTab).toBeVisible();
 
     // After creating a new tab, a UnifiedInput textarea should be focused
     await page.waitForFunction(
@@ -216,8 +220,8 @@ test.describe("Input Mode Focus", () => {
     );
     expect(await isUnifiedInputFocused()).toBe(true);
 
-    // Verify we have 2 tabs
+    // Verify we have 3 tabs (Home + Terminal + new tab)
     const tabs = page.getByRole("tab");
-    await expect(tabs).toHaveCount(2);
+    await expect(tabs).toHaveCount(3);
   });
 });

--- a/e2e/sub-agent-timeline.spec.ts
+++ b/e2e/sub-agent-timeline.spec.ts
@@ -70,9 +70,10 @@ type AiEventType =
 async function waitForAppReady(page: Page) {
   await waitForAppReadyBase(page);
 
-  // Wait for the unified input textarea to be visible (use specific selector to avoid xterm textarea)
-  await expect(page.locator('[data-slot="popover-anchor"] textarea')).toBeVisible({
-    timeout: 5000,
+  // Wait for the unified input textarea to be visible in the active tab
+  // Use :visible to find the textarea in the currently active tab
+  await expect(page.locator('[data-testid="unified-input"]:visible').first()).toBeVisible({
+    timeout: 10000,
   });
 
   // Ensure mock functions are available
@@ -90,9 +91,10 @@ function getAgentModeButton(page: Page) {
 
 /**
  * Get the UnifiedInput textarea element.
+ * Uses :visible to find the textarea in the currently active tab.
  */
 function getInputTextarea(page: Page) {
-  return page.locator('[data-testid="unified-input"]');
+  return page.locator('[data-testid="unified-input"]:visible').first();
 }
 
 test.describe("Sub-Agent Timeline Ordering", () => {

--- a/e2e/tab-close-pane-cleanup.spec.ts
+++ b/e2e/tab-close-pane-cleanup.spec.ts
@@ -17,8 +17,11 @@ import { waitForAppReady as waitForAppReadyBase } from "./helpers/app";
 async function waitForAppReady(page: Page) {
   await waitForAppReadyBase(page);
 
-  // Wait for the unified input textarea to be visible (exclude xterm's hidden textarea)
-  await expect(page.locator("textarea:not(.xterm-helper-textarea)")).toBeVisible({ timeout: 5000 });
+  // Wait for the unified input textarea to be visible in the active tab
+  // Use :visible to find the textarea in the currently active tab
+  await expect(page.locator('[data-testid="unified-input"]:visible').first()).toBeVisible({
+    timeout: 10000,
+  });
 }
 
 /**
@@ -59,21 +62,27 @@ async function createNewTab(page: Page): Promise<void> {
 }
 
 /**
- * Close the first tab by hovering to reveal the close button.
+ * Close the first closable tab by hovering to reveal the close button.
+ * Note: Home tab doesn't have a close button, so we skip it.
  */
-async function closeFirstTab(page: Page): Promise<void> {
+async function closeFirstClosableTab(page: Page): Promise<void> {
   // The tab structure wraps the trigger and close button in a parent div with class "group"
-  const tabWrapper = page
-    .locator(".group")
-    .filter({ has: page.locator('[role="tab"]') })
-    .first();
-  await tabWrapper.hover();
-  // Wait for the close button to become visible on hover
-  await page.waitForTimeout(100);
-  const closeButton = tabWrapper.locator('button[title="Close tab"]');
-  await closeButton.click();
-  // Wait for the tab to close
-  await page.waitForTimeout(200);
+  // We need to find a tab wrapper that HAS a close button (Home tab doesn't have one)
+  const tabWrappers = page.locator(".group").filter({ has: page.locator('[role="tab"]') });
+
+  const count = await tabWrappers.count();
+  for (let i = 0; i < count; i++) {
+    const wrapper = tabWrappers.nth(i);
+    await wrapper.hover();
+    await page.waitForTimeout(100);
+    const closeButton = wrapper.locator('button[title="Close tab"]');
+    if (await closeButton.isVisible()) {
+      await closeButton.click();
+      await page.waitForTimeout(200);
+      return;
+    }
+  }
+  throw new Error("No closable tab found");
 }
 
 /**
@@ -147,167 +156,193 @@ test.describe("Tab Close with Split Panes Cleanup", () => {
   });
 
   test("closing a single-pane tab cleans up the session", async ({ page }) => {
-    // Get initial state
+    // Get initial state (Home + Terminal tabs)
     const initialState = await getStoreState(page);
     expect(initialState).not.toBeNull();
     const initialTabCount = await getTabCount(page);
-    expect(initialTabCount).toBe(1);
+    expect(initialTabCount).toBe(2); // Home + Terminal
 
-    // Create a second tab so we have something to switch to
+    // Create a third tab so we have something to switch to
     await createNewTab(page);
-    expect(await getTabCount(page)).toBe(2);
+    expect(await getTabCount(page)).toBe(3);
 
-    // Get the state after creating second tab
-    const stateWithTwoTabs = await getStoreState(page);
-    expect(stateWithTwoTabs?.sessionIds.length).toBe(2);
+    // Get the state after creating third tab
+    const stateWithThreeTabs = await getStoreState(page);
+    expect(stateWithThreeTabs?.sessionIds.length).toBe(3);
 
-    // Close the first tab
-    await closeFirstTab(page);
+    // Close the first closable tab (Terminal - Home can't be closed)
+    await closeFirstClosableTab(page);
 
     // Wait for cleanup to complete
     await page.waitForTimeout(300);
 
     // Verify tab was closed
-    expect(await getTabCount(page)).toBe(1);
+    expect(await getTabCount(page)).toBe(2);
 
     // Verify state was cleaned up
     const finalState = await getStoreState(page);
-    expect(finalState?.sessionIds.length).toBe(1);
+    expect(finalState?.sessionIds.length).toBe(2);
   });
 
   test("split pane creates additional session", async ({ page }) => {
-    // Get initial state
+    // Get initial state (Home + Terminal sessions)
     const initialState = await getStoreState(page);
-    expect(initialState?.sessionIds.length).toBe(1);
+    expect(initialState?.sessionIds.length).toBe(2);
 
     // Split the pane via store manipulation
     await createSplitPane(page, "vertical");
 
     // Verify a new session was created
     const stateAfterSplit = await getStoreState(page);
-    expect(stateAfterSplit?.sessionIds.length).toBe(2);
+    expect(stateAfterSplit?.sessionIds.length).toBe(3);
 
-    // But still only one tab (the split pane is within the tab)
-    expect(await getTabCount(page)).toBe(1);
+    // Still only two tabs (the split pane is within the active tab)
+    expect(await getTabCount(page)).toBe(2);
   });
 
   test("closing tab with split panes cleans up all sessions", async ({ page }) => {
-    // Create a split pane in the first tab
+    // Create a split pane in the active Terminal tab
     await createSplitPane(page, "vertical");
 
-    // Verify we have 2 sessions (root + split pane)
+    // Verify we have 3 sessions (Home + Terminal root + split pane)
     let state = await getStoreState(page);
-    expect(state?.sessionIds.length).toBe(2);
-    const sessionsInFirstTab = [...(state?.sessionIds ?? [])];
+    expect(state?.sessionIds.length).toBe(3);
+    // Remember sessions that are NOT Home tab (we'll be closing the Terminal tab with splits)
+    const terminalTabSessions = state?.sessionIds.filter((id) => !id.startsWith("home-")) ?? [];
 
-    // Create a second tab so we have somewhere to go after closing
+    // Create a third tab so we have somewhere to go after closing
     await createNewTab(page);
 
-    // Now we should have 3 sessions total (2 in first tab, 1 in second tab)
+    // Now we should have 4 sessions total (Home + 2 in Terminal tab + 1 in new tab)
     state = await getStoreState(page);
-    expect(state?.sessionIds.length).toBe(3);
-    expect(await getTabCount(page)).toBe(2);
+    expect(state?.sessionIds.length).toBe(4);
+    expect(await getTabCount(page)).toBe(3);
 
-    // Close the first tab (which has the split panes)
-    await closeFirstTab(page);
+    // Close the first tab (Home tab, not the one with splits)
+    // Actually, let's close the Terminal tab (second tab) with splits
+    // The tab wrapper is the second one (index 1)
+    const tabWrapper = page
+      .locator(".group")
+      .filter({ has: page.locator('[role="tab"]') })
+      .nth(1); // Second tab (Terminal with splits)
+    await tabWrapper.hover();
+    await page.waitForTimeout(100);
+    const closeButton = tabWrapper.locator('button[title="Close tab"]');
+    await closeButton.click();
 
     // Wait for cleanup to complete
     await page.waitForTimeout(500);
 
-    // Verify only one tab remains
-    expect(await getTabCount(page)).toBe(1);
+    // Verify two tabs remain (Home + new tab)
+    expect(await getTabCount(page)).toBe(2);
 
     // Verify the split pane sessions were cleaned up
     const finalState = await getStoreState(page);
-    expect(finalState?.sessionIds.length).toBe(1);
+    expect(finalState?.sessionIds.length).toBe(2);
 
-    // The remaining session should NOT be one from the closed tab
-    for (const closedSessionId of sessionsInFirstTab) {
+    // The Terminal tab sessions should NOT remain
+    for (const closedSessionId of terminalTabSessions) {
       expect(finalState?.sessionIds).not.toContain(closedSessionId);
     }
   });
 
   test("closing tab with multiple splits cleans up all sessions", async ({ page }) => {
-    // Create multiple splits in the first tab
+    // Create multiple splits in the active Terminal tab
     // First vertical split
     await createSplitPane(page, "vertical");
 
     // Second horizontal split
     await createSplitPane(page, "horizontal");
 
-    // Verify we have 3 sessions (root + 2 splits)
+    // Verify we have 4 sessions (Home + Terminal root + 2 splits)
     let state = await getStoreState(page);
-    expect(state?.sessionIds.length).toBe(3);
-    const sessionsInFirstTab = [...(state?.sessionIds ?? [])];
+    expect(state?.sessionIds.length).toBe(4);
+    // Remember Terminal tab sessions (we'll be closing this tab)
+    const terminalTabSessions = state?.sessionIds.filter((id) => !id.startsWith("home-")) ?? [];
 
-    // Create a second tab
+    // Create a third tab
     await createNewTab(page);
 
-    // Now we should have 4 sessions total
+    // Now we should have 5 sessions total
     state = await getStoreState(page);
-    expect(state?.sessionIds.length).toBe(4);
+    expect(state?.sessionIds.length).toBe(5);
 
-    // Close the first tab
-    await closeFirstTab(page);
+    // Close the Terminal tab (second tab, index 1) with the splits
+    const tabWrapper = page
+      .locator(".group")
+      .filter({ has: page.locator('[role="tab"]') })
+      .nth(1);
+    await tabWrapper.hover();
+    await page.waitForTimeout(100);
+    const closeButton = tabWrapper.locator('button[title="Close tab"]');
+    await closeButton.click();
     await page.waitForTimeout(500);
 
-    // Verify cleanup
+    // Verify cleanup (Home + new tab remain)
     const finalState = await getStoreState(page);
-    expect(finalState?.sessionIds.length).toBe(1);
+    expect(finalState?.sessionIds.length).toBe(2);
 
-    // None of the closed sessions should remain
-    for (const closedSessionId of sessionsInFirstTab) {
+    // None of the Terminal tab sessions should remain
+    for (const closedSessionId of terminalTabSessions) {
       expect(finalState?.sessionIds).not.toContain(closedSessionId);
     }
   });
 
   test("tab layout is removed when tab is closed", async ({ page }) => {
-    // Create a split in the first tab
+    // Create a split in the active Terminal tab
     await createSplitPane(page, "vertical");
 
-    // Get the tab layout ID (same as root session ID)
+    // Get the tab layout IDs (Home + Terminal)
     let state = await getStoreState(page);
-    expect(state?.tabLayoutIds.length).toBe(1);
-    const firstTabLayoutId = state?.tabLayoutIds[0];
+    expect(state?.tabLayoutIds.length).toBe(2);
+    // Find the Terminal tab layout (not starting with "home-")
+    const terminalTabLayoutId = state?.tabLayoutIds.find((id) => !id.startsWith("home-"));
 
-    // Create a second tab
+    // Create a third tab
     await createNewTab(page);
 
-    // Should have 2 tab layouts now
+    // Should have 3 tab layouts now
     state = await getStoreState(page);
-    expect(state?.tabLayoutIds.length).toBe(2);
+    expect(state?.tabLayoutIds.length).toBe(3);
 
-    // Close the first tab
-    await closeFirstTab(page);
+    // Close the Terminal tab (second tab, index 1)
+    const tabWrapper = page
+      .locator(".group")
+      .filter({ has: page.locator('[role="tab"]') })
+      .nth(1);
+    await tabWrapper.hover();
+    await page.waitForTimeout(100);
+    const closeButton = tabWrapper.locator('button[title="Close tab"]');
+    await closeButton.click();
     await page.waitForTimeout(500);
 
-    // Verify the tab layout was removed
+    // Verify the tab layout was removed (Home + new tab remain)
     const finalState = await getStoreState(page);
-    expect(finalState?.tabLayoutIds.length).toBe(1);
-    expect(finalState?.tabLayoutIds).not.toContain(firstTabLayoutId);
+    expect(finalState?.tabLayoutIds.length).toBe(2);
+    expect(finalState?.tabLayoutIds).not.toContain(terminalTabLayoutId);
   });
 
   test("active session switches to remaining tab after close", async ({ page }) => {
-    // Create a second tab
+    // Create a third tab (Home + Terminal already exist)
     await createNewTab(page);
 
-    // Verify we have 2 tabs
-    expect(await getTabCount(page)).toBe(2);
+    // Verify we have 3 tabs
+    expect(await getTabCount(page)).toBe(3);
 
-    // Click on first tab to make sure it's active
-    await page.locator('[role="tab"]').first().click();
+    // Click on second tab (Terminal) to make sure it's active (Home can't be closed)
+    await page.locator('[role="tab"]').nth(1).click();
     await page.waitForTimeout(100);
 
-    // Close the first tab
-    await closeFirstTab(page);
+    // Close the first closable tab (Terminal - Home can't be closed)
+    await closeFirstClosableTab(page);
 
-    // Should have 1 tab remaining
-    await expect(page.locator('[role="tab"]')).toHaveCount(1);
+    // Should have 2 tabs remaining
+    await expect(page.locator('[role="tab"]')).toHaveCount(2);
 
-    // The remaining tab should be selected (aria-selected is the reliable indicator)
+    // One of the remaining tabs should be selected (aria-selected is the reliable indicator)
     // Note: Radix uses aria-selected="true" for selected tabs
-    const remainingTab = page.locator('[role="tab"]');
-    await expect(remainingTab).toHaveAttribute("aria-selected", "true", { timeout: 5000 });
+    const selectedTab = page.locator('[role="tab"][aria-selected="true"]');
+    await expect(selectedTab).toBeVisible({ timeout: 5000 });
 
     // Also verify the store's activeSessionId was updated
     const finalState = await getStoreState(page);

--- a/e2e/tab-completion.spec.ts
+++ b/e2e/tab-completion.spec.ts
@@ -18,15 +18,19 @@ import { waitForAppReady as waitForAppReadyBase } from "./helpers/app";
 async function waitForAppReady(page: Page) {
   await waitForAppReadyBase(page);
 
-  // Wait for the unified input textarea to be visible (exclude xterm's hidden textarea)
-  await expect(page.locator("textarea:not(.xterm-helper-textarea)")).toBeVisible({ timeout: 5000 });
+  // Wait for the unified input textarea to be visible in the active tab
+  // Use :visible to find the textarea in the currently active tab
+  await expect(page.locator('[data-testid="unified-input"]:visible').first()).toBeVisible({
+    timeout: 10000,
+  });
 }
 
 /**
  * Get the UnifiedInput textarea element.
+ * Uses :visible to find the textarea in the currently active tab.
  */
 function getInputTextarea(page: Page) {
-  return page.locator('[data-testid="unified-input"]');
+  return page.locator('[data-testid="unified-input"]:visible').first();
 }
 
 /**

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -69,7 +69,6 @@ function App() {
   const [currentPage, setCurrentPage] = useState<PageRoute>("main");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [cmdKeyPressed, setCmdKeyPressed] = useState(false);
-  const initializingRef = useRef(false);
   // Ref to track focused session ID for callbacks (updated below after useFocusedSessionId)
   const focusedSessionIdRef = useRef<string | null>(null);
 
@@ -289,11 +288,15 @@ function App() {
   useEffect(() => {
     async function init() {
       try {
-        // Prevent double-initialization from React StrictMode in development
-        if (initializingRef.current) {
+        // Check if sessions already exist (prevents double-init in React StrictMode).
+        // StrictMode unmounts/remounts, but the Zustand store persists. If sessions
+        // exist, initialization was already completed on a previous mount.
+        const currentSessions = useStore.getState().sessions;
+        if (Object.keys(currentSessions).length > 0) {
+          logger.info("[App] Sessions already exist, skipping initialization...");
+          setIsLoading(false);
           return;
         }
-        initializingRef.current = true;
 
         logger.info("[App] Starting initialization...");
 

--- a/frontend/mocks.ts
+++ b/frontend/mocks.ts
@@ -1655,6 +1655,75 @@ export function setupMocks(): void {
       }
 
       // =========================================================================
+      // Home View Commands
+      // =========================================================================
+      case "list_projects_for_home":
+        // Return mock projects for the home view
+        return [
+          {
+            path: "/home/user/projects/qbit",
+            name: "qbit",
+            branches: [
+              {
+                name: "main",
+                path: "/home/user/projects/qbit",
+                file_count: 0,
+                insertions: 0,
+                deletions: 0,
+                last_activity: "2h ago",
+              },
+              {
+                name: "feature/home-view",
+                path: "/home/user/projects/qbit-feature-home-view",
+                file_count: 3,
+                insertions: 42,
+                deletions: 12,
+                last_activity: "1h ago",
+              },
+            ],
+            warnings: 0,
+            last_activity: "1h ago",
+          },
+        ];
+
+      case "list_recent_directories": {
+        // Return mock recent directories
+        return [
+          {
+            path: "/home/user/projects/qbit",
+            name: "qbit",
+            branch: "main",
+            file_count: 0,
+            insertions: 0,
+            deletions: 0,
+            last_accessed: "2h ago",
+          },
+          {
+            path: "/home/user/projects/other-project",
+            name: "other-project",
+            branch: "develop",
+            file_count: 5,
+            insertions: 100,
+            deletions: 50,
+            last_accessed: "1d ago",
+          },
+        ];
+      }
+
+      case "list_git_branches":
+        // Return mock git branches
+        return ["main", "develop", "feature/new-feature"];
+
+      case "create_git_worktree":
+        // Return mock worktree creation result
+        return {
+          path: "/home/user/projects/qbit-new-branch",
+          branch: "new-branch",
+          init_script_run: false,
+          init_script_output: null,
+        };
+
+      // =========================================================================
       // Settings Commands
       // =========================================================================
       case "get_settings":

--- a/justfile
+++ b/justfile
@@ -99,11 +99,12 @@ generate-types:
 # Code Quality
 # ============================================
 
-# Run all checks (format, lint, typecheck, rust tests)
+# Run all checks (format, lint, typecheck, tests)
 check:
     @echo "Running checks silently..."
     @just fmt
     @just check-fe
+    @just test-fe
     @just check-rust
     @just test-rust
     @echo "OK"


### PR DESCRIPTION
## Summary
- Add mock handlers for `list_projects_for_home`, `list_recent_directories`, `list_git_branches`, and `create_git_worktree` to fix HomeView errors that caused ErrorBoundary recovery loops
- Update all E2E tests to account for Home tab being present (2 initial tabs instead of 1)
- Create `closeFirstClosableTab` helper function since Home tab doesn't have a close button
- Add `diagnostic.spec.ts` for debugging mount/unmount stability issues
- Include `test-fe` in `just check` recipe for comprehensive CI checks
- Fix lint issues (template literals, optional chaining, unused imports)

## Test plan
- [x] `just check` passes (lint, typecheck, frontend tests, rust tests)
- [x] `just test-e2e` passes (107 passed, 21 skipped)