### PR TITLE
feat(ai): add JSON repair for malformed LLM tool call arguments

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4026,6 +4026,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "llm_json"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6a0ee634dc2211a67b3ee239fac8098647352fc73a39b50c57fbf7fb7a2928"
+dependencies = [
+ "clap",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5770,6 +5781,7 @@ dependencies = [
  "qbit-core",
  "qbit-hitl",
  "qbit-indexer",
+ "qbit-json-repair",
  "qbit-llm-providers",
  "qbit-loop-detection",
  "qbit-planner",
@@ -5993,6 +6005,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "qbit-json-repair"
+version = "0.2.16"
+dependencies = [
+ "llm_json",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "qbit-llm-providers"
 version = "0.2.16"
 dependencies = [
@@ -6180,6 +6201,7 @@ dependencies = [
  "chrono",
  "futures",
  "qbit-core",
+ "qbit-json-repair",
  "qbit-llm-providers",
  "qbit-tools",
  "qbit-udiff",
@@ -7029,6 +7051,7 @@ dependencies = [
  "async-openai",
  "base64 0.22.1",
  "futures",
+ "qbit-json-repair",
  "rig-core 0.29.0",
  "serde",
  "serde_json",
@@ -7059,6 +7082,8 @@ dependencies = [
  "async-stream",
  "bytes",
  "futures",
+ "qbit-json-repair",
+ "regex",
  "reqwest 0.12.28",
  "rig-core 0.29.0",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "crates/qbit-benchmarks",
     "crates/qbit-swebench",
     "crates/qbit-history",
+    "crates/qbit-json-repair",
 ]
 resolver = "2"
 

--- a/backend/crates/qbit-ai/Cargo.toml
+++ b/backend/crates/qbit-ai/Cargo.toml
@@ -31,6 +31,9 @@ qbit-sub-agents = { workspace = true }
 qbit-skills = { workspace = true }
 qbit-shell-exec = { workspace = true }
 
+# JSON repair for malformed LLM output
+qbit-json-repair = { path = "../qbit-json-repair" }
+
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/backend/crates/qbit-ai/src/agentic_loop.rs
+++ b/backend/crates/qbit-ai/src/agentic_loop.rs
@@ -2050,9 +2050,7 @@ where
                             if let (Some(prev_id), Some(prev_name)) =
                                 (current_tool_id.take(), current_tool_name.take())
                             {
-                                let args: serde_json::Value =
-                                    serde_json::from_str(&current_tool_args)
-                                        .unwrap_or(serde_json::Value::Null);
+                                let args = qbit_json_repair::parse_tool_args(&current_tool_args);
                                 tool_calls_to_execute.push(ToolCall {
                                     id: prev_id.clone(),
                                     call_id: Some(prev_id),
@@ -2183,9 +2181,7 @@ where
                             if let (Some(id), Some(name)) =
                                 (current_tool_id.take(), current_tool_name.take())
                             {
-                                let args: serde_json::Value =
-                                    serde_json::from_str(&current_tool_args)
-                                        .unwrap_or(serde_json::Value::Null);
+                                let args = qbit_json_repair::parse_tool_args(&current_tool_args);
                                 tool_calls_to_execute.push(ToolCall {
                                     id: id.clone(),
                                     call_id: Some(id),
@@ -2243,8 +2239,7 @@ where
 
         // Finalize any remaining tool call that wasn't closed by FinalResponse
         if let (Some(id), Some(name)) = (current_tool_id.take(), current_tool_name.take()) {
-            let args: serde_json::Value =
-                serde_json::from_str(&current_tool_args).unwrap_or(serde_json::Value::Null);
+            let args = qbit_json_repair::parse_tool_args(&current_tool_args);
             tool_calls_to_execute.push(ToolCall {
                 id: id.clone(),
                 call_id: Some(id),

--- a/backend/crates/qbit-json-repair/Cargo.toml
+++ b/backend/crates/qbit-json-repair/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "qbit-json-repair"
+version.workspace = true
+edition.workspace = true
+description = "JSON repair utilities for LLM tool call arguments"
+
+[dependencies]
+llm_json = "1.0"
+serde_json = { workspace = true }
+tracing = { workspace = true }

--- a/backend/crates/qbit-json-repair/src/lib.rs
+++ b/backend/crates/qbit-json-repair/src/lib.rs
@@ -1,0 +1,129 @@
+//! JSON repair utilities for LLM tool call arguments
+//!
+//! LLMs (especially GLM models) sometimes produce malformed JSON that fails
+//! to parse. This module provides repair functionality using the llm_json crate.
+
+use serde_json::Value;
+use tracing::debug;
+
+/// Parse tool call arguments with automatic repair for malformed JSON.
+///
+/// Attempts standard parsing first, then falls back to repair if that fails.
+/// Returns empty object `{}` if both parsing and repair fail.
+pub fn parse_tool_args(args: &str) -> Value {
+    // Fast path: try standard parsing first
+    if let Ok(value) = serde_json::from_str(args) {
+        return value;
+    }
+
+    // Slow path: attempt repair
+    debug!("JSON parse failed, attempting repair");
+    repair_and_parse(args).unwrap_or_else(|| {
+        debug!("JSON repair failed, returning empty object");
+        serde_json::json!({})
+    })
+}
+
+/// Parse tool call arguments, returning None on failure instead of default.
+///
+/// Useful when you need to handle parse failures explicitly.
+pub fn parse_tool_args_opt(args: &str) -> Option<Value> {
+    // Fast path: try standard parsing first
+    if let Ok(value) = serde_json::from_str(args) {
+        return Some(value);
+    }
+
+    // Slow path: attempt repair
+    repair_and_parse(args)
+}
+
+/// Repair malformed JSON string and return the fixed string.
+///
+/// Returns None if repair fails.
+pub fn repair_json(args: &str) -> Option<String> {
+    llm_json::repair_json(args, &Default::default()).ok()
+}
+
+/// Repair and parse JSON in one step.
+fn repair_and_parse(args: &str) -> Option<Value> {
+    match llm_json::loads(args, &Default::default()) {
+        Ok(value) => {
+            debug!("JSON repair succeeded");
+            Some(value)
+        }
+        Err(e) => {
+            debug!("JSON repair failed: {}", e);
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_json_passthrough() {
+        let json = r#"{"name": "test", "value": 123}"#;
+        let result = parse_tool_args(json);
+        assert_eq!(result["name"], "test");
+        assert_eq!(result["value"], 123);
+    }
+
+    #[test]
+    fn test_unquoted_keys() {
+        let json = r#"{name: "test", value: 123}"#;
+        let result = parse_tool_args(json);
+        assert_eq!(result["name"], "test");
+    }
+
+    #[test]
+    fn test_single_quotes() {
+        let json = r#"{'name': 'test'}"#;
+        let result = parse_tool_args(json);
+        assert_eq!(result["name"], "test");
+    }
+
+    #[test]
+    fn test_trailing_comma() {
+        let json = r#"{"name": "test",}"#;
+        let result = parse_tool_args(json);
+        assert_eq!(result["name"], "test");
+    }
+
+    #[test]
+    fn test_python_booleans() {
+        let json = r#"{"active": True, "disabled": False}"#;
+        let result = parse_tool_args(json);
+        assert_eq!(result["active"], true);
+        assert_eq!(result["disabled"], false);
+    }
+
+    #[test]
+    fn test_unclosed_object() {
+        let json = r#"{"name": "test""#;
+        let result = parse_tool_args(json);
+        // Should repair by closing the object
+        assert_eq!(result["name"], "test");
+    }
+
+    #[test]
+    fn test_missing_value_quotes() {
+        // This pattern was seen in GLM output
+        let json = r#"{"explanation":Explore notification-related code}"#;
+        let result = parse_tool_args(json);
+        // Should repair the unquoted string value
+        assert!(!result.is_null());
+    }
+
+    #[test]
+    fn test_invalid_returns_something() {
+        // Note: llm_json is very aggressive at repair and may produce
+        // unexpected results from truly malformed input. The important
+        // thing is that it doesn't panic.
+        let json = "not json at all {{{";
+        let result = parse_tool_args(json);
+        // Result may be repaired unexpectedly; just verify we get a value
+        assert!(result.is_object() || result.is_null());
+    }
+}

--- a/backend/crates/qbit-sub-agents/Cargo.toml
+++ b/backend/crates/qbit-sub-agents/Cargo.toml
@@ -38,5 +38,8 @@ qbit-tools = { workspace = true }
 # LLM provider configuration (for model capability checks)
 qbit-llm-providers = { workspace = true }
 
+# JSON repair for malformed LLM output
+qbit-json-repair = { path = "../qbit-json-repair" }
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/backend/crates/qbit-sub-agents/src/executor.rs
+++ b/backend/crates/qbit-sub-agents/src/executor.rs
@@ -358,8 +358,7 @@ where
                         if let (Some(prev_id), Some(prev_name)) =
                             (current_tool_id.take(), current_tool_name.take())
                         {
-                            let args: serde_json::Value = serde_json::from_str(&current_tool_args)
-                                .unwrap_or(serde_json::Value::Null);
+                            let args = qbit_json_repair::parse_tool_args(&current_tool_args);
                             tracing::debug!(
                                 "[sub-agent] Finalizing previous tool call: {} with args: {}",
                                 prev_name,
@@ -427,8 +426,7 @@ where
         // Finalize any remaining pending tool call after stream ends
         if let (Some(prev_id), Some(prev_name)) = (current_tool_id.take(), current_tool_name.take())
         {
-            let args: serde_json::Value =
-                serde_json::from_str(&current_tool_args).unwrap_or(serde_json::Value::Null);
+            let args = qbit_json_repair::parse_tool_args(&current_tool_args);
             tracing::debug!(
                 "[sub-agent] Finalizing final tool call: {} with args: {}",
                 prev_name,

--- a/backend/crates/rig-openai-responses/Cargo.toml
+++ b/backend/crates/rig-openai-responses/Cargo.toml
@@ -22,3 +22,6 @@ serde_json = "1.0"
 tracing = "0.1"
 thiserror = "2.0"
 base64 = "0.22"
+
+# JSON repair for malformed LLM output
+qbit-json-repair = { path = "../qbit-json-repair" }

--- a/backend/crates/rig-openai-responses/src/completion.rs
+++ b/backend/crates/rig-openai-responses/src/completion.rs
@@ -268,8 +268,7 @@ impl CompletionModel {
                     }
                 }
                 OutputItem::FunctionCall(fc) => {
-                    let arguments: serde_json::Value =
-                        serde_json::from_str(&fc.arguments).unwrap_or(serde_json::json!({}));
+                    let arguments = qbit_json_repair::parse_tool_args(&fc.arguments);
                     // fc.id is Option<String>, use empty string as fallback
                     let id = fc.id.clone().unwrap_or_default();
                     content.push(AssistantContent::ToolCall(ToolCall {

--- a/backend/crates/rig-zai-sdk/Cargo.toml
+++ b/backend/crates/rig-zai-sdk/Cargo.toml
@@ -28,6 +28,12 @@ thiserror.workspace = true
 # Logging
 tracing.workspace = true
 
+# JSON repair for malformed LLM output
+qbit-json-repair = { path = "../qbit-json-repair" }
+
+# Regex for parsing pseudo-XML tool calls
+regex.workspace = true
+
 # Bytes utilities
 bytes.workspace = true
 

--- a/backend/crates/rig-zai-sdk/src/lib.rs
+++ b/backend/crates/rig-zai-sdk/src/lib.rs
@@ -41,6 +41,7 @@ mod client;
 mod completion;
 mod error;
 mod streaming;
+mod text_tool_parser;
 mod types;
 
 pub use client::Client;

--- a/backend/crates/rig-zai-sdk/src/text_tool_parser.rs
+++ b/backend/crates/rig-zai-sdk/src/text_tool_parser.rs
@@ -1,0 +1,169 @@
+//! Parser for pseudo-XML tool calls embedded in text content.
+//!
+//! GLM models sometimes output tool calls in a pseudo-XML format within their text/reasoning
+//! content instead of using the structured tool calling API. This module parses those patterns.
+//!
+//! Example format:
+//! ```text
+//! <tool_call>read_file<arg_key>path</arg_key><arg_value>file.txt</arg_value></tool_call>
+//! ```
+
+use regex::Regex;
+use serde_json::{json, Value};
+use std::sync::LazyLock;
+use tracing::debug;
+
+/// Regex pattern to match the pseudo-XML tool call format
+static TOOL_CALL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"<tool_call>([^<]+)((?:<arg_key>[^<]*</arg_key><arg_value>[^<]*</arg_value>)*)</tool_call>")
+        .expect("Invalid tool call regex")
+});
+
+/// Regex pattern to extract arg_key/arg_value pairs
+static ARG_PAIR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"<arg_key>([^<]*)</arg_key><arg_value>([^<]*)</arg_value>")
+        .expect("Invalid arg pair regex")
+});
+
+/// A parsed tool call extracted from text content.
+#[derive(Debug, Clone)]
+pub struct ParsedToolCall {
+    /// The function name
+    pub name: String,
+    /// The arguments as a JSON object
+    pub arguments: Value,
+}
+
+/// Parse pseudo-XML tool calls from text content.
+///
+/// Returns a list of parsed tool calls and the remaining text with tool calls removed.
+pub fn parse_tool_calls_from_text(text: &str) -> (Vec<ParsedToolCall>, String) {
+    let mut tool_calls = Vec::new();
+    let mut remaining_text = text.to_string();
+
+    for cap in TOOL_CALL_REGEX.captures_iter(text) {
+        let full_match = cap.get(0).unwrap().as_str();
+        let name = cap.get(1).unwrap().as_str().trim().to_string();
+        let args_str = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+
+        // Parse argument pairs
+        let mut args = serde_json::Map::new();
+        for arg_cap in ARG_PAIR_REGEX.captures_iter(args_str) {
+            let key = arg_cap.get(1).unwrap().as_str().to_string();
+            let value_str = arg_cap.get(2).unwrap().as_str();
+
+            // Try to parse as number, otherwise keep as string
+            let value: Value = if let Ok(n) = value_str.parse::<i64>() {
+                json!(n)
+            } else if let Ok(n) = value_str.parse::<f64>() {
+                json!(n)
+            } else if value_str == "true" {
+                json!(true)
+            } else if value_str == "false" {
+                json!(false)
+            } else if value_str == "null" {
+                Value::Null
+            } else {
+                json!(value_str)
+            };
+
+            args.insert(key, value);
+        }
+
+        debug!(
+            "Parsed pseudo-XML tool call: {} with {} arguments",
+            name,
+            args.len()
+        );
+
+        tool_calls.push(ParsedToolCall {
+            name,
+            arguments: Value::Object(args),
+        });
+
+        // Remove the tool call from the text
+        remaining_text = remaining_text.replace(full_match, "");
+    }
+
+    // Clean up the remaining text (trim and collapse multiple spaces/newlines)
+    let remaining_text = remaining_text
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    (tool_calls, remaining_text)
+}
+
+/// Check if text contains any pseudo-XML tool calls.
+pub fn contains_pseudo_xml_tool_calls(text: &str) -> bool {
+    TOOL_CALL_REGEX.is_match(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_single_tool_call() {
+        let text = "Let me read the file:<tool_call>read_file<arg_key>path</arg_key><arg_value>src/main.rs</arg_value></tool_call>";
+        let (tool_calls, remaining) = parse_tool_calls_from_text(text);
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].name, "read_file");
+        assert_eq!(tool_calls[0].arguments["path"], "src/main.rs");
+        assert_eq!(remaining, "Let me read the file:");
+    }
+
+    #[test]
+    fn test_parse_tool_call_with_multiple_args() {
+        let text = "<tool_call>read_file<arg_key>path</arg_key><arg_value>file.txt</arg_value><arg_key>line_start</arg_key><arg_value>1</arg_value><arg_key>line_end</arg_key><arg_value>100</arg_value></tool_call>";
+        let (tool_calls, _) = parse_tool_calls_from_text(text);
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].name, "read_file");
+        assert_eq!(tool_calls[0].arguments["path"], "file.txt");
+        assert_eq!(tool_calls[0].arguments["line_start"], 1);
+        assert_eq!(tool_calls[0].arguments["line_end"], 100);
+    }
+
+    #[test]
+    fn test_parse_multiple_tool_calls() {
+        let text = "First<tool_call>func1<arg_key>a</arg_key><arg_value>1</arg_value></tool_call>Middle<tool_call>func2<arg_key>b</arg_key><arg_value>2</arg_value></tool_call>Last";
+        let (tool_calls, remaining) = parse_tool_calls_from_text(text);
+
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[0].name, "func1");
+        assert_eq!(tool_calls[1].name, "func2");
+        // The remaining text is trimmed and filtered for empty lines, so it becomes a single line
+        assert_eq!(remaining, "FirstMiddleLast");
+    }
+
+    #[test]
+    fn test_no_tool_calls() {
+        let text = "Just regular text without any tool calls";
+        let (tool_calls, remaining) = parse_tool_calls_from_text(text);
+
+        assert!(tool_calls.is_empty());
+        assert_eq!(remaining, text);
+    }
+
+    #[test]
+    fn test_contains_check() {
+        assert!(contains_pseudo_xml_tool_calls(
+            "<tool_call>test<arg_key>a</arg_key><arg_value>b</arg_value></tool_call>"
+        ));
+        assert!(!contains_pseudo_xml_tool_calls("no tool calls here"));
+    }
+
+    #[test]
+    fn test_boolean_and_null_values() {
+        let text = "<tool_call>test<arg_key>enabled</arg_key><arg_value>true</arg_value><arg_key>disabled</arg_key><arg_value>false</arg_value><arg_key>empty</arg_key><arg_value>null</arg_value></tool_call>";
+        let (tool_calls, _) = parse_tool_calls_from_text(text);
+
+        assert_eq!(tool_calls[0].arguments["enabled"], true);
+        assert_eq!(tool_calls[0].arguments["disabled"], false);
+        assert!(tool_calls[0].arguments["empty"].is_null());
+    }
+}


### PR DESCRIPTION
This pull request introduces robust handling for malformed JSON in LLM tool call arguments across multiple backend components, and adds support for extracting pseudo-XML tool calls from Z.AI responses. The most important changes are the addition of a new `qbit-json-repair` crate for automatic JSON repair, its integration into several agent and completion modules, and enhancements to the Z.AI SDK for pseudo-XML tool call extraction.

**JSON Repair Integration:**

- Added the new `qbit-json-repair` crate, which uses the `llm_json` library to repair and parse malformed JSON from LLM outputs. This crate provides utility functions to parse tool call arguments robustly, including fallback repair and comprehensive tests. [[1]](diffhunk://#diff-708fc369be7cfd6d2a7c0502014d49bdfe5eed795123e9411b5cef43fd410196R1-R10) [[2]](diffhunk://#diff-1927fb635433a8de23c7a319cff26f5a2d630ec2a568cf92b85c0e8b0bdbba52R1-R129)
- Replaced all direct `serde_json::from_str` calls for tool call argument parsing in `qbit-ai`, `qbit-sub-agents`, and `rig-openai-responses` with `qbit_json_repair::parse_tool_args`, ensuring resilience to malformed JSON from LLMs. [[1]](diffhunk://#diff-5220546bb40fa117a7fa5eb717194bdf8b9d25399b4ee197b4ea52f5ef44734cL2053-R2053) [[2]](diffhunk://#diff-5220546bb40fa117a7fa5eb717194bdf8b9d25399b4ee197b4ea52f5ef44734cL2186-R2184) [[3]](diffhunk://#diff-5220546bb40fa117a7fa5eb717194bdf8b9d25399b4ee197b4ea52f5ef44734cL2246-R2242) [[4]](diffhunk://#diff-781a39ff771eca3e71758a777dcdc1332f0da8321d491c4d1812a2d2cc4374eaL361-R361) [[5]](diffhunk://#diff-781a39ff771eca3e71758a777dcdc1332f0da8321d491c4d1812a2d2cc4374eaL430-R429) [[6]](diffhunk://#diff-81dd97d468ab45383554ac4995a36b849322aeb85d4436a88449efed01c01b10L271-R271)
- Updated dependencies in relevant `Cargo.toml` files to include the new crate. [[1]](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1R40) [[2]](diffhunk://#diff-c8948ea1190c630244cb71e0a18836f7ba50dfc79dba64aba14dee9ca7301109R34-R36) [[3]](diffhunk://#diff-400ea1fdd635587ee0ca9ca8db3f885b6ab5acbef8d6844156d103157ffe42ddR41-R43) [[4]](diffhunk://#diff-e57eba4b637ef261856b910c30325b85c4ab5cca9f31791fd312eb58193768a8R25-R27) [[5]](diffhunk://#diff-7898b7f8a5a97472c5f598e4eca1e55ff1248ee903e06ca064a7c030b5f45563R31-R36)

**Z.AI SDK: Pseudo-XML Tool Call Extraction:**

- Enhanced the Z.AI SDK to detect and extract pseudo-XML tool calls embedded in both reasoning and text content of completions, supporting both non-streaming and streaming responses. This includes new buffer management, tool call extraction logic, and chunk queuing for streaming. [[1]](diffhunk://#diff-b3b2cc62aea3dcf70d91321bff63ba6fc67c6596ad8d6c8f0e636a0a41db8526R17) [[2]](diffhunk://#diff-b3b2cc62aea3dcf70d91321bff63ba6fc67c6596ad8d6c8f0e636a0a41db8526R216-R303) [[3]](diffhunk://#diff-b3b2cc62aea3dcf70d91321bff63ba6fc67c6596ad8d6c8f0e636a0a41db8526L429-R496) [[4]](diffhunk://#diff-8dcfedeb0eff70e825213c74d42f07925486a546ae415b57823e8870e5dd89bbR44) [[5]](diffhunk://#diff-3b897ce83e9d9de38c008edaea49aac43b2443340d5fd76820ac554fa6f07e6eR9) [[6]](diffhunk://#diff-3b897ce83e9d9de38c008edaea49aac43b2443340d5fd76820ac554fa6f07e6eR24-R31) [[7]](diffhunk://#diff-3b897ce83e9d9de38c008edaea49aac43b2443340d5fd76820ac554fa6f07e6eR58-R130)

These changes significantly improve the system's robustness to LLM output errors and expand its ability to interpret tool calls, even when embedded in non-standard formats.