### PR TITLE
feat(settings): add version display to Advanced settings

### DIFF
--- a/frontend/components/Settings/AdvancedSettings.tsx
+++ b/frontend/components/Settings/AdvancedSettings.tsx
@@ -1,3 +1,5 @@
+import { getVersion } from "@tauri-apps/api/app";
+import { useEffect, useState } from "react";
 import { Switch } from "@/components/ui/switch";
 import type { AdvancedSettings as AdvancedSettingsType, PrivacySettings } from "@/lib/settings";
 
@@ -47,6 +49,18 @@ export function AdvancedSettings({
   onChange,
   onPrivacyChange,
 }: AdvancedSettingsProps) {
+  const [version, setVersion] = useState<string>("...");
+
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      setVersion("dev");
+    } else {
+      getVersion()
+        .then(setVersion)
+        .catch(() => setVersion("unknown"));
+    }
+  }, []);
+
   const logLevelOptions = [
     { value: "error", label: "Error" },
     { value: "warn", label: "Warn" },
@@ -156,6 +170,14 @@ export function AdvancedSettings({
             checked={privacy.log_prompts}
             onCheckedChange={(checked) => onPrivacyChange({ ...privacy, log_prompts: checked })}
           />
+        </div>
+      </div>
+
+      {/* Version */}
+      <div className="pt-4 border-t border-[var(--border-medium)]">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Version</span>
+          <span className="text-sm font-mono text-muted-foreground">{version}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Adds the current build version to the Advanced section of the Settings dialog, displaying "dev" when in development mode or the actual version number in production builds.

## Changes
- Added version display at the bottom of Advanced settings tab
- Uses `@tauri-apps/api/app` `getVersion()` API for production builds
- Detects dev mode via Vite's `import.meta.env.DEV`
- Falls back to "unknown" if version fetch fails
- Styled with monospace font and muted colors to match existing UI

## Breaking Changes
None

## Test Plan
- [ ] Run `just dev` and open Settings > Advanced - should show "dev"
- [ ] Build production app with `just build` and verify actual version is displayed
- [ ] Verify version appears at bottom of Advanced tab with proper styling

## Release Notes
The Advanced settings tab now displays the current application version, making it easy to identify which build you're running.

## Checklist
- [x] TypeScript types check (`pnpm typecheck`)
- [x] Conventional commit format followed