### PR TITLE
chore(deps): update Cargo.lock for 0.2.10 release

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ast-grep"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-cli-output"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "qbit-core",
@@ -5857,7 +5857,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "rig-core 0.29.0",
@@ -5869,7 +5869,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-directory-ops"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5905,7 +5905,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-file-ops"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5947,7 +5947,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-hitl"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-indexer"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "reqwest 0.12.28",
  "rig-anthropic-vertex",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-loop-detection"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "serde",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-planner"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "proptest",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "dirs 5.0.1",
  "itoa",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-runtime"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "async-trait",
  "atty",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6079,7 +6079,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6185,7 +6185,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6201,7 +6201,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tool-policy"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6215,7 +6215,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6240,11 +6240,11 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.9"
+version = "0.2.10"
 
 [[package]]
 name = "qbit-web"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6261,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6888,7 +6888,7 @@ checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "async-stream",
  "bytes",


### PR DESCRIPTION
## Summary
Updates the Cargo.lock file to reflect version 0.2.10 across all workspace crates after the release-please version bump.

## Changes
- Updated version references from 0.2.9 to 0.2.10 for all qbit workspace crates in Cargo.lock

## Breaking Changes
None

## Test Plan
- [ ] Build passes with `cargo build`
- [ ] Tests pass with `just test-rust`

## Release Notes
Internal lockfile update for v0.2.10 release.

## Checklist
- [x] Conventional commit format followed