### PR TITLE
feat(ui): add langfuse tracing badge to footer bar

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5870,7 +5870,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ast-grep"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-cli-output"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "qbit-core",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "rig-core 0.29.0",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-directory-ops"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6022,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-file-ops"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-history"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -6080,7 +6080,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-hitl"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-indexer"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6136,7 +6136,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-loop-detection"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "serde",
@@ -6147,7 +6147,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-planner"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "proptest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "dirs 5.0.1",
  "itoa",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-runtime"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "atty",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6224,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6254,7 +6254,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -6295,7 +6295,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6346,7 +6346,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tool-policy"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6376,7 +6376,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6401,14 +6401,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7061,7 +7061,7 @@ checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7190,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-stream",
  "bytes",

--- a/backend/crates/qbit/src/settings/commands.rs
+++ b/backend/crates/qbit/src/settings/commands.rs
@@ -6,6 +6,7 @@
 use tauri::State;
 
 use crate::state::AppState;
+use crate::telemetry::TelemetryStatsSnapshot;
 use qbit_settings::QbitSettings;
 
 /// Get all settings.
@@ -130,4 +131,13 @@ pub async fn get_window_state(
 #[tauri::command]
 pub fn is_langfuse_active(state: State<'_, AppState>) -> bool {
     state.langfuse_active
+}
+
+/// Get telemetry statistics.
+///
+/// Returns a snapshot of telemetry stats if Langfuse tracing is active.
+/// This includes counts of spans started/ended since app startup.
+#[tauri::command]
+pub fn get_telemetry_stats(state: State<'_, AppState>) -> Option<TelemetryStatsSnapshot> {
+    state.telemetry_stats.as_ref().map(|stats| stats.snapshot())
 }

--- a/backend/crates/qbit/src/state.rs
+++ b/backend/crates/qbit/src/state.rs
@@ -10,6 +10,7 @@ use crate::indexer::IndexerState;
 use crate::pty::PtyManager;
 use crate::settings::SettingsManager;
 use crate::sidecar::{SidecarConfig, SidecarState};
+use crate::telemetry::TelemetryStats;
 
 pub struct AppState {
     pub pty_manager: Arc<PtyManager>,
@@ -25,6 +26,8 @@ pub struct AppState {
     pub sidecar_state: Arc<SidecarState>,
     /// Whether Langfuse tracing is active (enabled and properly configured).
     pub langfuse_active: bool,
+    /// Telemetry statistics (only populated when Langfuse is active).
+    pub telemetry_stats: Option<Arc<TelemetryStats>>,
 }
 
 impl AppState {
@@ -34,7 +37,8 @@ impl AppState {
     ///
     /// # Arguments
     /// * `langfuse_active` - Whether Langfuse tracing is enabled and properly configured.
-    pub async fn new(langfuse_active: bool) -> Self {
+    /// * `telemetry_stats` - Optional telemetry stats for monitoring (only when Langfuse is active).
+    pub async fn new(langfuse_active: bool, telemetry_stats: Option<Arc<TelemetryStats>>) -> Self {
         // Initialize settings manager first (needed by TavilyState in the future)
         let settings_manager = Arc::new(
             SettingsManager::new()
@@ -68,6 +72,7 @@ impl AppState {
             sidecar_config,
             sidecar_state,
             langfuse_active,
+            telemetry_stats,
         }
     }
 }

--- a/frontend/lib/settings.ts
+++ b/frontend/lib/settings.ts
@@ -417,6 +417,28 @@ export async function isLangfuseActive(): Promise<boolean> {
   return invoke("is_langfuse_active");
 }
 
+/**
+ * Telemetry statistics snapshot.
+ */
+export interface TelemetryStats {
+  /** Total spans that have started */
+  spans_started: number;
+  /** Total spans that have ended (queued for export) */
+  spans_ended: number;
+  /** Timestamp (Unix millis) when tracking started */
+  started_at: number;
+}
+
+/**
+ * Get telemetry statistics.
+ *
+ * Returns a snapshot of telemetry stats if Langfuse tracing is active,
+ * or null if not enabled.
+ */
+export async function getTelemetryStats(): Promise<TelemetryStats | null> {
+  return invoke("get_telemetry_stats");
+}
+
 // =============================================================================
 // Provider Visibility Helper
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds an OpenTelemetry icon badge to the footer status row when Langfuse tracing is enabled
- Badge appears to the right of the context window usage badge
- Uses purple color scheme (#7c3aed) to match OpenTelemetry/Langfuse branding

## Test plan
- [ ] Enable Langfuse tracing in settings and verify badge appears
- [ ] Disable Langfuse tracing and verify badge disappears
- [ ] Verify badge shows tooltip "Langfuse tracing enabled" on hover