### PR TITLE
fix(ui): limit thinking blocks to one at a time in timeline

### DIFF
--- a/frontend/store/index.ts
+++ b/frontend/store/index.ts
@@ -1309,8 +1309,12 @@ export const useStore = create<QbitState>()(
           if (lastBlock && lastBlock.type === "thinking") {
             lastBlock.content += content;
           } else {
+            // Remove any previous thinking blocks so only one is visible at a time
+            state.streamingBlocks[sessionId] = blocks.filter(
+              (b) => b.type !== "thinking"
+            );
             // Start new thinking block
-            blocks.push({ type: "thinking", content });
+            state.streamingBlocks[sessionId].push({ type: "thinking", content });
           }
         }),
 


### PR DESCRIPTION
## Summary
- Ensures only one thinking/reasoning block is visible in the timeline at a time
- When a new thinking block is created, previous thinking blocks are removed from streamingBlocks

## Test plan
- [ ] Start an agent conversation with a model that uses extended thinking (e.g., Claude with reasoning)
- [ ] Verify that when a new thinking block appears, any previous thinking blocks are removed
- [ ] Confirm only one thinking block is visible at any time during streaming