### PR TITLE
fix(rig-openai-responses): use structured types for tool calls and results

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5870,7 +5870,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ast-grep"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-cli-output"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "qbit-core",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "rig-core 0.29.0",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-directory-ops"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6022,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-file-ops"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-history"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -6080,7 +6080,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-hitl"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-indexer"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6136,7 +6136,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-loop-detection"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "serde",
@@ -6147,7 +6147,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-planner"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "proptest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "dirs 5.0.1",
  "itoa",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-runtime"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "async-trait",
  "atty",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6224,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6254,7 +6254,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -6295,7 +6295,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6346,7 +6346,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tool-policy"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6376,7 +6376,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6401,14 +6401,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7061,7 +7061,7 @@ checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7190,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "async-stream",
  "bytes",


### PR DESCRIPTION
## Summary

- Refactors the OpenAI Responses API adapter to use proper structured types (`Item::FunctionCallOutput`, `Item::FunctionCall`, `Item::Reasoning`) instead of converting tool calls and results to text format
- Fixes tool calling functionality for reasoning models (GPT-5, o-series) which require structured types with `call_id` linkage
- Preserves reasoning structure with `Reasoning::multi()` for proper round-tripping back to OpenAI

## Changes

- `convert_user_content`: Changed from `Option<EasyInputContent>` to `Vec<InputItem>` to support `Item::FunctionCallOutput` for tool results
- Added `convert_assistant_content_to_items`: Handles structured conversion of assistant content (text messages, tool calls, reasoning)
- Tool results now use `FunctionCallOutputItemParam` with proper `call_id` linkage
- Tool calls now use `FunctionToolCall` with serialized JSON arguments
- Reasoning now uses `ReasoningItem` with `SummaryPart` structure preservation

## Test plan

- [x] All 8 unit tests pass (`cargo test -p rig-openai-responses`)
- [x] `cargo check` passes for the workspace
- [ ] Integration test with actual OpenAI API (manual verification recommended)