### PR TITLE
feat(models): add Claude Opus 4.6 support on Vertex AI

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5870,7 +5870,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ast-grep"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-cli-output"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "qbit-core",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "rig-core 0.29.0",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-directory-ops"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6022,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-file-ops"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-history"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -6080,7 +6080,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-hitl"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-indexer"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6136,7 +6136,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-loop-detection"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "serde",
@@ -6147,7 +6147,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-planner"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "proptest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "dirs 5.0.1",
  "itoa",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-runtime"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "async-trait",
  "atty",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6224,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6254,7 +6254,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -6295,7 +6295,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6346,7 +6346,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tool-policy"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6376,7 +6376,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6401,14 +6401,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7061,7 +7061,7 @@ checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7190,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "async-stream",
  "bytes",

--- a/backend/crates/qbit-models/src/capabilities.rs
+++ b/backend/crates/qbit-models/src/capabilities.rs
@@ -91,6 +91,19 @@ impl ModelCapabilities {
         }
     }
 
+    /// Create capabilities for Claude Opus 4.6 (1M context beta, 128k output).
+    pub fn anthropic_opus_4_6() -> Self {
+        Self {
+            supports_temperature: true,
+            supports_thinking_history: true,
+            supports_vision: true,
+            supports_web_search: true,
+            context_window: 1_000_000,  // 1M context (beta)
+            max_output_tokens: 128_000, // 128k output
+            ..Default::default()
+        }
+    }
+
     /// Create capabilities for OpenAI GPT-4 series models.
     pub fn openai_gpt4_defaults() -> Self {
         Self {

--- a/backend/crates/qbit-models/src/providers.rs
+++ b/backend/crates/qbit-models/src/providers.rs
@@ -12,6 +12,13 @@ use crate::registry::ModelDefinition;
 pub fn vertex_ai_models() -> Vec<ModelDefinition> {
     vec![
         ModelDefinition {
+            id: "claude-opus-4-6@default",
+            display_name: "Claude Opus 4.6",
+            provider: AiProvider::VertexAi,
+            capabilities: ModelCapabilities::anthropic_opus_4_6(),
+            aliases: &[],
+        },
+        ModelDefinition {
             id: "claude-opus-4-5@20251101",
             display_name: "Claude Opus 4.5",
             provider: AiProvider::VertexAi,

--- a/backend/crates/rig-anthropic-vertex/src/lib.rs
+++ b/backend/crates/rig-anthropic-vertex/src/lib.rs
@@ -38,6 +38,8 @@ pub use types::*;
 
 /// Available Claude models on Vertex AI
 pub mod models {
+    /// Claude Opus 4.6 - Latest most powerful model
+    pub const CLAUDE_OPUS_4_6: &str = "claude-opus-4-6@default";
     /// Claude Opus 4.5 - Most powerful model
     pub const CLAUDE_OPUS_4_5: &str = "claude-opus-4-5@20251101";
     /// Claude Sonnet 4.5 - Balanced performance

--- a/frontend/lib/ai.ts
+++ b/frontend/lib/ai.ts
@@ -711,6 +711,7 @@ export interface VertexAiConfig {
  * Available Claude models on Vertex AI.
  */
 export const VERTEX_AI_MODELS = {
+  CLAUDE_OPUS_4_6: "claude-opus-4-6@default",
   CLAUDE_OPUS_4_5: "claude-opus-4-5@20251101",
   CLAUDE_SONNET_4_5: "claude-sonnet-4-5@20250929",
   CLAUDE_HAIKU_4_5: "claude-haiku-4-5@20251001",

--- a/frontend/lib/models.ts
+++ b/frontend/lib/models.ts
@@ -316,6 +316,7 @@ export const PROVIDER_GROUPS: ProviderGroup[] = [
     providerName: "Vertex AI",
     icon: "🔷",
     models: [
+      { id: VERTEX_AI_MODELS.CLAUDE_OPUS_4_6, name: "Claude Opus 4.6" },
       { id: VERTEX_AI_MODELS.CLAUDE_OPUS_4_5, name: "Claude Opus 4.5" },
       { id: VERTEX_AI_MODELS.CLAUDE_SONNET_4_5, name: "Claude Sonnet 4.5" },
       { id: VERTEX_AI_MODELS.CLAUDE_HAIKU_4_5, name: "Claude Haiku 4.5" },
@@ -695,6 +696,7 @@ export const PROVIDER_GROUPS_NESTED: ProviderGroupNested[] = [
     providerName: "Vertex AI",
     icon: "🔷",
     models: [
+      { id: VERTEX_AI_MODELS.CLAUDE_OPUS_4_6, name: "Claude Opus 4.6" },
       { id: VERTEX_AI_MODELS.CLAUDE_OPUS_4_5, name: "Claude Opus 4.5" },
       { id: VERTEX_AI_MODELS.CLAUDE_SONNET_4_5, name: "Claude Sonnet 4.5" },
       { id: VERTEX_AI_MODELS.CLAUDE_HAIKU_4_5, name: "Claude Haiku 4.5" },


### PR DESCRIPTION
## Summary

- Add Claude Opus 4.6 (`claude-opus-4-6@default`) model support for the Vertex AI Anthropic provider
- Custom capabilities: 1M context window (beta), 128k max output tokens, web search enabled
- Registered across backend (capabilities, providers, rig-anthropic-vertex) and frontend (model lists, provider groups)

## Changes

### Backend
- `qbit-models/src/capabilities.rs` — new `anthropic_opus_4_6()` capabilities constructor
- `qbit-models/src/providers.rs` — new `ModelDefinition` in `vertex_ai_models()`
- `rig-anthropic-vertex/src/lib.rs` — new `CLAUDE_OPUS_4_6` model constant

### Frontend
- `frontend/lib/ai.ts` — added to `VERTEX_AI_MODELS`
- `frontend/lib/models.ts` — added to `PROVIDER_GROUPS` and `PROVIDER_GROUPS_NESTED`

## Test plan

- [ ] Verify Opus 4.6 appears in the model selector under Vertex AI
- [ ] Verify agent conversations work with Opus 4.6 selected
- [ ] Verify web search tool functions correctly with Opus 4.6
- [ ] Verify extended thinking works with Opus 4.6