### PR TITLE
fix(rig-anthropic-vertex): handle citations_delta stream events from Claude web search

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "rig-core",
  "serde",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-mcp"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "dirs",
  "itoa",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "dirs",
  "serde",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4682,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -4708,14 +4708,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "bytes",
  "futures",

--- a/backend/crates/rig-anthropic-vertex/src/streaming.rs
+++ b/backend/crates/rig-anthropic-vertex/src/streaming.rs
@@ -276,6 +276,10 @@ impl StreamingResponse {
                     self.accumulated_signature.push_str(&signature);
                     None
                 }
+                ContentDelta::CitationsDelta { citation: _ } => {
+                    // Citations are metadata for source attribution, not streamed content
+                    None
+                }
             },
             StreamEvent::ContentBlockStart {
                 content_block,


### PR DESCRIPTION
## Summary

- Fix streaming parser crash when Claude models use built-in web search functionality
- Add `CitationsDelta` variant to handle citation metadata events from the API
- Citations are silently consumed as metadata (text content streams normally via `TextDelta`)

## Test plan

- [x] Added unit test for `citations_delta` JSON deserialization
- [x] All existing tests pass (`cargo test -p rig-anthropic-vertex --lib`)
- [ ] Manual test: Use a Claude model with web search enabled and verify no parse errors