### PR TITLE
feat(tabs): add right-click context menu with duplicate tab

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -182,6 +182,14 @@ function App() {
     createTerminalTab();
   }, [createTerminalTab]);
 
+  // Duplicate a tab by creating a new one in the same directory
+  const handleDuplicateTab = useCallback(
+    (workingDirectory: string) => {
+      createTerminalTab(workingDirectory);
+    },
+    [createTerminalTab]
+  );
+
   // Split the currently focused pane
   const handleSplitPane = useCallback(
     async (direction: SplitDirection) => {
@@ -595,6 +603,7 @@ function App() {
         {/* Tab bar */}
         <TabBar
           onNewTab={handleNewTab}
+          onDuplicateTab={handleDuplicateTab}
           onToggleFileEditorPanel={toggleFileEditorPanel}
           onOpenHistory={() => setSessionBrowserOpen(true)}
           onOpenSettings={openSettingsTab}

--- a/frontend/components/TabBar/TabBar.performance.test.tsx
+++ b/frontend/components/TabBar/TabBar.performance.test.tsx
@@ -106,7 +106,7 @@ describe("TabBar Performance Optimization Tests", () => {
       const { TabBar } = await import("./TabBar");
 
       // Render TabBar with 3 sessions
-      render(<TabBar onNewTab={vi.fn()} />);
+      render(<TabBar onNewTab={vi.fn()} onDuplicateTab={vi.fn()} />);
 
       // The test passes if the component renders without errors
       // The actual subscription reduction is verified by code inspection
@@ -125,7 +125,7 @@ describe("TabBar Performance Optimization Tests", () => {
       const { TabBar } = await import("./TabBar");
 
       // Render TabBar
-      const { container } = render(<TabBar onNewTab={vi.fn()} />);
+      const { container } = render(<TabBar onNewTab={vi.fn()} onDuplicateTab={vi.fn()} />);
 
       // Component should render
       expect(container).toBeDefined();
@@ -141,7 +141,7 @@ describe("TabBar Performance Optimization Tests", () => {
 
       const { TabBar } = await import("./TabBar");
 
-      const { container } = render(<TabBar onNewTab={vi.fn()} />);
+      const { container } = render(<TabBar onNewTab={vi.fn()} onDuplicateTab={vi.fn()} />);
 
       expect(container).toBeDefined();
     });
@@ -161,7 +161,7 @@ describe("TabBar Performance Optimization Tests", () => {
 
       const { TabBar } = await import("./TabBar");
 
-      const { container } = render(<TabBar onNewTab={vi.fn()} />);
+      const { container } = render(<TabBar onNewTab={vi.fn()} onDuplicateTab={vi.fn()} />);
 
       // The test verifies the component renders correctly with memo
       expect(container).toBeDefined();
@@ -185,12 +185,14 @@ describe("TabBar Performance Optimization Tests", () => {
       const { TabBar } = await import("./TabBar");
 
       // First render
-      const { rerender, container } = render(<TabBar onNewTab={vi.fn()} />);
+      const { rerender, container } = render(
+        <TabBar onNewTab={vi.fn()} onDuplicateTab={vi.fn()} />
+      );
 
       expect(container).toBeDefined();
 
       // Second render - with memo and stable callbacks, this should be efficient
-      rerender(<TabBar onNewTab={vi.fn()} />);
+      rerender(<TabBar onNewTab={vi.fn()} onDuplicateTab={vi.fn()} />);
 
       expect(container).toBeDefined();
     });
@@ -206,7 +208,7 @@ describe("TabBar Performance Optimization Tests", () => {
 
       const { TabBar } = await import("./TabBar");
 
-      const { container } = render(<TabBar onNewTab={vi.fn()} />);
+      const { container } = render(<TabBar onNewTab={vi.fn()} onDuplicateTab={vi.fn()} />);
 
       // Modify unrelated state
       useStore.getState().updateAgentStreaming("session-1", "Hello");
@@ -225,7 +227,7 @@ describe("TabBar Performance Optimization Tests", () => {
 
       const { TabBar } = await import("./TabBar");
 
-      const { container } = render(<TabBar onNewTab={vi.fn()} />);
+      const { container } = render(<TabBar onNewTab={vi.fn()} onDuplicateTab={vi.fn()} />);
 
       expect(container).toBeDefined();
     });


### PR DESCRIPTION
## Summary

- Adds a right-click context menu to terminal tabs with **Duplicate Tab** and **Close Tab** options
- Duplicate Tab creates a new terminal tab in the same working directory as the source tab
- Uses the existing `ContextMenu` Radix UI primitives already available in the codebase

## Test plan

- [ ] Right-click a terminal tab → context menu appears with "Duplicate Tab" and "Close Tab"
- [ ] Click "Duplicate Tab" → a new tab opens in the same directory as the original
- [ ] Click "Close Tab" → the tab closes (same behavior as the X button)
- [ ] Right-click the home tab → no context menu appears (disabled)
- [ ] Right-click a settings tab → only "Close Tab" appears (no duplicate option)
- [ ] All existing tab interactions (click, double-click rename, close button) still work