### PR TITLE
feat(sub-agents): add overall and idle timeout to prevent stuck sub-agents

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "rig-core",
  "serde",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-mcp"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dirs",
  "itoa",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dirs",
  "serde",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4682,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -4708,14 +4708,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "bytes",
  "futures",

--- a/backend/crates/qbit-sub-agents/src/defaults.rs
+++ b/backend/crates/qbit-sub-agents/src/defaults.rs
@@ -247,7 +247,9 @@ pub fn create_default_sub_agents() -> Vec<SubAgentDefinition> {
             "ast_grep".to_string(),
             "ast_grep_replace".to_string(),
         ])
-        .with_max_iterations(20),
+        .with_max_iterations(20)
+        .with_timeout(600)
+        .with_idle_timeout(180),
         SubAgentDefinition::new(
             "analyzer",
             "Analyzer",
@@ -267,7 +269,9 @@ pub fn create_default_sub_agents() -> Vec<SubAgentDefinition> {
             "indexer_get_metrics".to_string(),
             "indexer_detect_language".to_string(),
         ])
-        .with_max_iterations(30),
+        .with_max_iterations(30)
+        .with_timeout(300)
+        .with_idle_timeout(120),
         SubAgentDefinition::new(
             "explorer",
             "Explorer",
@@ -282,7 +286,9 @@ pub fn create_default_sub_agents() -> Vec<SubAgentDefinition> {
             "ast_grep".to_string(),
             "find_files".to_string(),
         ])
-        .with_max_iterations(15),
+        .with_max_iterations(15)
+        .with_timeout(180)
+        .with_idle_timeout(90),
         SubAgentDefinition::new(
             "researcher",
             "Research Agent",
@@ -327,7 +333,9 @@ What to do based on the research
             "web_fetch".to_string(),
             "read_file".to_string(),
         ])
-        .with_max_iterations(25),
+        .with_max_iterations(25)
+        .with_timeout(600)
+        .with_idle_timeout(180),
         SubAgentDefinition::new(
             "executor",
             "Executor",
@@ -377,7 +385,9 @@ Final summary of what was accomplished.
             "read_file".to_string(),
             "list_directory".to_string(),
         ])
-        .with_max_iterations(30),
+        .with_max_iterations(30)
+        .with_timeout(600)
+        .with_idle_timeout(180),
     ]
 }
 

--- a/backend/crates/qbit-sub-agents/src/definition.rs
+++ b/backend/crates/qbit-sub-agents/src/definition.rs
@@ -73,6 +73,14 @@ pub struct SubAgentDefinition {
     /// When set, this sub-agent uses a different model than the main agent.
     /// None = inherit the main agent's model.
     pub model_override: Option<(String, String)>,
+
+    /// Overall timeout for the entire sub-agent execution in seconds.
+    /// None = no timeout. Default: 600 (10 minutes).
+    pub timeout_secs: Option<u64>,
+
+    /// Idle timeout - max seconds without any progress (LLM chunk, tool result).
+    /// None = no idle timeout. Default: 180 (3 minutes).
+    pub idle_timeout_secs: Option<u64>,
 }
 
 impl SubAgentDefinition {
@@ -91,6 +99,8 @@ impl SubAgentDefinition {
             allowed_tools: Vec::new(),
             max_iterations: 50,
             model_override: None,
+            timeout_secs: Some(600),
+            idle_timeout_secs: Some(180),
         }
     }
 
@@ -103,6 +113,18 @@ impl SubAgentDefinition {
     /// Set maximum iterations
     pub fn with_max_iterations(mut self, max: usize) -> Self {
         self.max_iterations = max;
+        self
+    }
+
+    /// Set overall timeout in seconds
+    pub fn with_timeout(mut self, secs: u64) -> Self {
+        self.timeout_secs = Some(secs);
+        self
+    }
+
+    /// Set idle timeout in seconds
+    pub fn with_idle_timeout(mut self, secs: u64) -> Self {
+        self.idle_timeout_secs = Some(secs);
         self
     }
 
@@ -208,6 +230,8 @@ mod tests {
         assert!(agent.allowed_tools.is_empty());
         assert_eq!(agent.max_iterations, 50); // default
         assert!(agent.model_override.is_none()); // default
+        assert_eq!(agent.timeout_secs, Some(600)); // default: 10 minutes
+        assert_eq!(agent.idle_timeout_secs, Some(180)); // default: 3 minutes
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds **overall timeout** (wraps entire sub-agent execution with `tokio::time::timeout`) and **idle timeout** (tracks last activity via `AtomicU64`, aborts if no stream chunks or tool results arrive within the idle window) to sub-agent execution
- When either timeout fires, a `SubAgentError` event is emitted and the sub-agent returns `success: false` — no frontend changes needed
- Per-agent defaults: explorer (3min/90s), analyzer (5min/2min), coder/researcher/executor (10min/3min)
- New builder methods `with_timeout()` and `with_idle_timeout()` on `SubAgentDefinition`

## Test plan

- [x] `cargo check -p qbit-sub-agents` — compiles clean
- [x] `cargo check -p qbit-ai` — compiles clean
- [x] `cargo test -p qbit-sub-agents` — 42 tests pass
- [x] `cargo test -p qbit-ai` — 325 tests pass
- [x] `just test-e2e` — 116 passed, 21 skipped, 0 failed

Closes Q-184