### PR TITLE
feat(editor): detect external file changes and auto-reload open tabs

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1512,6 +1512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,6 +1620,15 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2621,6 +2641,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2834,26 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3116,6 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3235,6 +3296,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.10.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa5a66d07ed97dce782be94dcf5ab4d1b457f4243f7566c7557f15cabc8c799"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +3338,15 @@ dependencies = [
  "serde",
  "tauri-winrt-notification",
  "zbus",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -4275,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4290,6 +4391,8 @@ dependencies = [
  "graph-flow",
  "ignore",
  "insta",
+ "notify",
+ "notify-debouncer-mini",
  "nucleo-matcher",
  "opentelemetry",
  "opentelemetry-langfuse",
@@ -4337,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4377,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4392,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4405,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "rig-core",
  "serde",
@@ -4416,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4433,7 +4536,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4456,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -4465,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4484,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-mcp"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4511,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -4521,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dirs",
  "itoa",
@@ -4540,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4557,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4572,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4585,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4608,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dirs",
  "serde",
@@ -4620,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4642,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4667,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4682,7 +4785,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -4708,14 +4811,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4730,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5143,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5190,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -5221,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "bytes",
  "futures",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -107,6 +107,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.34"
 
+# File watching
+notify = "7"
+notify-debouncer-mini = "0.5"
+
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 

--- a/backend/crates/qbit/Cargo.toml
+++ b/backend/crates/qbit/Cargo.toml
@@ -92,6 +92,8 @@ async-trait.workspace = true
 
 # File walking with gitignore support
 ignore.workspace = true
+notify.workspace = true
+notify-debouncer-mini.workspace = true
 
 
 # Fuzzy matching for path completions

--- a/backend/crates/qbit/src/commands/file_watcher.rs
+++ b/backend/crates/qbit/src/commands/file_watcher.rs
@@ -1,0 +1,194 @@
+//! File watcher for the text editor sidebar.
+//! Watches open files for external changes and emits events to the frontend.
+
+use crate::error::Result;
+use chrono::{DateTime, Utc};
+use notify::RecursiveMode;
+use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
+use parking_lot::Mutex;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+
+/// Event payload sent to the frontend when a watched file changes.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileChangedEvent {
+    pub path: String,
+    pub modified_at: Option<String>,
+}
+
+/// Managed state for the file watcher system.
+pub struct FileWatcherState {
+    inner: Mutex<FileWatcherInner>,
+}
+
+struct FileWatcherInner {
+    /// One debouncer instance that watches all files
+    debouncer: Option<notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>>,
+    /// Set of currently watched paths
+    watched_paths: HashMap<PathBuf, ()>,
+    /// App handle for emitting events
+    app_handle: Option<AppHandle>,
+}
+
+impl FileWatcherState {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(FileWatcherInner {
+                debouncer: None,
+                watched_paths: HashMap::new(),
+                app_handle: None,
+            }),
+        }
+    }
+}
+
+fn resolve_path(path: &str) -> PathBuf {
+    let target = PathBuf::from(path);
+    if target.is_absolute() {
+        target
+    } else {
+        std::env::var("QBIT_WORKSPACE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+            .join(target)
+    }
+}
+
+fn format_modified_time(path: &PathBuf) -> Option<String> {
+    std::fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .map(|t| DateTime::<Utc>::from(t).to_rfc3339())
+}
+
+fn ensure_debouncer(inner: &mut FileWatcherInner) {
+    if inner.debouncer.is_some() {
+        return;
+    }
+
+    let Some(app_handle) = inner.app_handle.clone() else {
+        tracing::warn!("[file-watcher] No app handle set, cannot create debouncer");
+        return;
+    };
+
+    match new_debouncer(Duration::from_millis(300), move |res: std::result::Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
+        match res {
+            Ok(events) => {
+                for event in events {
+                    if event.kind == DebouncedEventKind::Any {
+                        let path = event.path.clone();
+                        let modified_at = format_modified_time(&path);
+                        let payload = FileChangedEvent {
+                            path: path.to_string_lossy().to_string(),
+                            modified_at,
+                        };
+                        tracing::debug!("[file-watcher] File changed: {}", payload.path);
+                        if let Err(e) = app_handle.emit("file-changed", &payload) {
+                            tracing::error!("[file-watcher] Failed to emit file-changed event: {}", e);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("[file-watcher] Watch error: {}", e);
+            }
+        }
+    }) {
+        Ok(debouncer) => {
+            inner.debouncer = Some(debouncer);
+        }
+        Err(e) => {
+            tracing::error!("[file-watcher] Failed to create debouncer: {}", e);
+        }
+    }
+}
+
+/// Start watching a file for external changes.
+#[tauri::command]
+pub async fn watch_file(
+    path: String,
+    state: tauri::State<'_, Arc<FileWatcherState>>,
+    app: AppHandle,
+) -> Result<()> {
+    let resolved = resolve_path(&path);
+
+    if !resolved.exists() {
+        tracing::warn!("[file-watcher] File does not exist: {}", resolved.display());
+        return Ok(());
+    }
+
+    let mut inner = state.inner.lock();
+
+    // Set app handle if not already set
+    if inner.app_handle.is_none() {
+        inner.app_handle = Some(app);
+    }
+
+    // Already watching this path
+    if inner.watched_paths.contains_key(&resolved) {
+        return Ok(());
+    }
+
+    // Ensure we have a debouncer
+    ensure_debouncer(&mut inner);
+
+    if let Some(ref mut debouncer) = inner.debouncer {
+        match debouncer.watcher().watch(&resolved, RecursiveMode::NonRecursive) {
+            Ok(()) => {
+                inner.watched_paths.insert(resolved.clone(), ());
+                tracing::debug!("[file-watcher] Watching: {}", resolved.display());
+            }
+            Err(e) => {
+                tracing::error!("[file-watcher] Failed to watch {}: {}", resolved.display(), e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Stop watching a file.
+#[tauri::command]
+pub async fn unwatch_file(
+    path: String,
+    state: tauri::State<'_, Arc<FileWatcherState>>,
+) -> Result<()> {
+    let resolved = resolve_path(&path);
+    let mut inner = state.inner.lock();
+
+    if inner.watched_paths.remove(&resolved).is_some() {
+        if let Some(ref mut debouncer) = inner.debouncer {
+            if let Err(e) = debouncer.watcher().unwatch(&resolved) {
+                tracing::warn!("[file-watcher] Failed to unwatch {}: {}", resolved.display(), e);
+            }
+        }
+        tracing::debug!("[file-watcher] Unwatched: {}", resolved.display());
+    }
+
+    // If no more watched paths, drop the debouncer to free resources
+    if inner.watched_paths.is_empty() {
+        inner.debouncer = None;
+        tracing::debug!("[file-watcher] No more watched files, dropped debouncer");
+    }
+
+    Ok(())
+}
+
+/// Stop watching all files.
+#[tauri::command]
+pub async fn unwatch_all_files(
+    state: tauri::State<'_, Arc<FileWatcherState>>,
+) -> Result<()> {
+    let mut inner = state.inner.lock();
+
+    inner.watched_paths.clear();
+    inner.debouncer = None;
+    tracing::debug!("[file-watcher] Unwatched all files");
+
+    Ok(())
+}

--- a/backend/crates/qbit/src/commands/mod.rs
+++ b/backend/crates/qbit/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod completions;
 mod files;
+mod file_watcher;
 mod git;
 mod history;
 mod logging;
@@ -11,6 +12,7 @@ mod themes;
 
 pub use completions::*;
 pub use files::*;
+pub use file_watcher::*;
 pub use git::*;
 pub use history::*;
 pub use logging::*;

--- a/backend/crates/qbit/src/lib.rs
+++ b/backend/crates/qbit/src/lib.rs
@@ -107,6 +107,7 @@ use sidecar::{
     sidecar_update_patch_message,
 };
 use state::AppState;
+use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Manager;
@@ -380,6 +381,7 @@ pub fn run_gui() {
         .plugin(tauri_plugin_notification::init())
         .manage(app_state)
         .manage(history_manager)
+        .manage(Arc::new(FileWatcherState::new()))
         .on_window_event(|window, event| {
             // Persist window bounds continuously (debounced) so dev restarts and Cmd+Q are reliable.
             static SAVE_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -617,6 +619,9 @@ pub fn run_gui() {
             write_workspace_file,
             stat_workspace_file,
             read_file_as_base64,
+            watch_file,
+            unwatch_file,
+            unwatch_all_files,
             // Theme commands
             list_themes,
             read_theme,

--- a/frontend/components/FileEditorSidebar/FileConflictBanner.tsx
+++ b/frontend/components/FileEditorSidebar/FileConflictBanner.tsx
@@ -1,0 +1,55 @@
+import { AlertTriangle, Download, X } from "lucide-react";
+import { useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { readWorkspaceFile } from "@/lib/file-editor";
+import { notify } from "@/lib/notify";
+import { useFileEditorSidebarStore } from "@/store/file-editor-sidebar";
+
+interface FileConflictBannerProps {
+  tabId: string;
+  filePath: string;
+}
+
+export function FileConflictBanner({ tabId, filePath }: FileConflictBannerProps) {
+  const handleReload = useCallback(async () => {
+    try {
+      const result = await readWorkspaceFile(filePath);
+      useFileEditorSidebarStore.getState().acceptExternalChange(tabId, result.content, result.modifiedAt);
+    } catch (error) {
+      notify.error(`Failed to reload file: ${error}`);
+    }
+  }, [tabId, filePath]);
+
+  const handleKeep = useCallback(() => {
+    useFileEditorSidebarStore.getState().keepLocalVersion(tabId);
+  }, [tabId]);
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 bg-yellow-500/10 border-b border-yellow-500/30 text-xs">
+      <AlertTriangle className="w-3.5 h-3.5 text-yellow-500 shrink-0" />
+      <span className="text-yellow-200/90 truncate">
+        This file has been modified externally.
+      </span>
+      <div className="flex items-center gap-1 shrink-0 ml-auto">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-5 px-1.5 text-[11px] gap-1 text-yellow-200/90 hover:text-yellow-100"
+          onClick={handleReload}
+        >
+          <Download className="w-3 h-3" />
+          Reload
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-5 px-1.5 text-[11px] gap-1 text-yellow-200/90 hover:text-yellow-100"
+          onClick={handleKeep}
+        >
+          <X className="w-3 h-3" />
+          Keep mine
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/FileEditorSidebar/FileEditorSidebarPanel.tsx
+++ b/frontend/components/FileEditorSidebar/FileEditorSidebarPanel.tsx
@@ -11,11 +11,13 @@ import { Markdown } from "@/components/Markdown/Markdown";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useFileEditorSidebar } from "@/hooks/useFileEditorSidebar";
+import { useFileWatcher } from "@/hooks/useFileWatcher";
 import { useThrottledResize } from "@/hooks/useThrottledResize";
 import { getLanguageExtension } from "@/lib/codemirror-languages";
 import { qbitTheme } from "@/lib/codemirror-theme";
 import { cn } from "@/lib/utils";
 import { useFileEditorSidebarStore } from "@/store/file-editor-sidebar";
+import { FileConflictBanner } from "./FileConflictBanner";
 import { FileBrowser } from "./FileBrowser";
 import { TabBar } from "./TabBar";
 
@@ -264,6 +266,9 @@ export function FileEditorSidebarPanel({
     reorderTabs,
   } = useFileEditorSidebar(workingDirectory || undefined);
 
+  // Watch open files for external changes
+  useFileWatcher();
+
   const [containerWidth, setContainerWidth] = useState(DEFAULT_WIDTH);
   const [languageExtension, setLanguageExtension] = useState<Extension | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -509,6 +514,9 @@ export function FileEditorSidebarPanel({
 
       return (
         <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+          {activeTab.file.externallyModified && (
+            <FileConflictBanner tabId={activeTab.id} filePath={activeTab.file.path} />
+          )}
           <CodeMirror
             ref={editorRef}
             value={activeTab.file.content}

--- a/frontend/hooks/useFileWatcher.ts
+++ b/frontend/hooks/useFileWatcher.ts
@@ -1,0 +1,123 @@
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useRef } from "react";
+import { readWorkspaceFile, unwatchAllFiles, unwatchFile, watchFile } from "@/lib/file-editor";
+import {
+  fileTabIdFromPath,
+  useFileEditorSidebarStore,
+} from "@/store/file-editor-sidebar";
+
+interface FileChangedPayload {
+  path: string;
+  modifiedAt: string | null;
+}
+
+/**
+ * Watches open file tabs for external filesystem changes.
+ * - Auto-reloads files that have no pending local edits.
+ * - Marks files as externally modified when local edits exist (triggers conflict banner).
+ */
+export function useFileWatcher() {
+  const watchedPathsRef = useRef(new Set<string>());
+
+  // Sync watches with open file tabs
+  useEffect(() => {
+    const store = useFileEditorSidebarStore.getState();
+    const currentPaths = new Set<string>();
+
+    // Collect all open file tab paths
+    for (const tab of Object.values(store.tabs)) {
+      if (tab.type === "file") {
+        currentPaths.add(tab.file.path);
+      }
+    }
+
+    // Watch new files
+    for (const path of currentPaths) {
+      if (!watchedPathsRef.current.has(path)) {
+        watchFile(path).catch(() => {});
+        watchedPathsRef.current.add(path);
+      }
+    }
+
+    // Unwatch closed files
+    for (const path of watchedPathsRef.current) {
+      if (!currentPaths.has(path)) {
+        unwatchFile(path).catch(() => {});
+        watchedPathsRef.current.delete(path);
+      }
+    }
+  });
+
+  // Subscribe to store changes to watch/unwatch as tabs open/close
+  useEffect(() => {
+    const unsub = useFileEditorSidebarStore.subscribe((state) => {
+      const currentPaths = new Set<string>();
+
+      for (const tab of Object.values(state.tabs)) {
+        if (tab.type === "file") {
+          currentPaths.add(tab.file.path);
+        }
+      }
+
+      // Watch new files
+      for (const path of currentPaths) {
+        if (!watchedPathsRef.current.has(path)) {
+          watchFile(path).catch(() => {});
+          watchedPathsRef.current.add(path);
+        }
+      }
+
+      // Unwatch closed files
+      for (const path of watchedPathsRef.current) {
+        if (!currentPaths.has(path)) {
+          unwatchFile(path).catch(() => {});
+          watchedPathsRef.current.delete(path);
+        }
+      }
+    });
+
+    return () => {
+      unsub();
+      // Cleanup: unwatch all on unmount
+      unwatchAllFiles().catch(() => {});
+      watchedPathsRef.current.clear();
+    };
+  }, []);
+
+  // Listen for file-changed events from the backend
+  useEffect(() => {
+    const unlisten = listen<FileChangedPayload>("file-changed", async (event) => {
+      const { path, modifiedAt } = event.payload;
+      const store = useFileEditorSidebarStore.getState();
+      const tabId = fileTabIdFromPath(path);
+      const tab = store.tabs[tabId];
+
+      if (!tab || tab.type !== "file") return;
+
+      const file = tab.file;
+
+      // Skip if the modifiedAt matches our last known save time
+      // (this means WE wrote the file, not an external change)
+      if (modifiedAt && file.lastSavedAt && modifiedAt === file.lastSavedAt) {
+        return;
+      }
+
+      if (file.dirty) {
+        // File has unsaved local changes — show conflict banner
+        store.markExternallyModified(tabId);
+      } else {
+        // No local changes — auto-reload silently
+        try {
+          const result = await readWorkspaceFile(path);
+          store.acceptExternalChange(tabId, result.content, result.modifiedAt);
+        } catch {
+          // File may have been deleted; ignore
+        }
+      }
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+}

--- a/frontend/lib/file-editor.ts
+++ b/frontend/lib/file-editor.ts
@@ -47,3 +47,15 @@ export interface DirEntry {
 export async function listDirectory(path: string): Promise<DirEntry[]> {
   return invoke("list_directory", { path });
 }
+
+export async function watchFile(path: string): Promise<void> {
+  return invoke("watch_file", { path });
+}
+
+export async function unwatchFile(path: string): Promise<void> {
+  return invoke("unwatch_file", { path });
+}
+
+export async function unwatchAllFiles(): Promise<void> {
+  return invoke("unwatch_all_files");
+}


### PR DESCRIPTION
## Summary

- Add file watching to the text editor sidebar using the `notify` crate with debounced events (300ms)
- Auto-reload files when modified externally and no local edits are pending
- Show a conflict banner with "Reload" / "Keep mine" options when the user has unsaved local changes

## Changes

**Backend (Rust):**
- Added `notify` + `notify-debouncer-mini` workspace dependencies
- New `file_watcher.rs` module with `watch_file`, `unwatch_file`, `unwatch_all_files` Tauri commands
- Emits `file-changed` event with path and modifiedAt timestamp
- `FileWatcherState` managed state with lazy debouncer initialization

**Frontend (TypeScript/React):**
- `EditorFileState.externallyModified` flag + `markExternallyModified`, `acceptExternalChange`, `keepLocalVersion` store actions
- `useFileWatcher` hook — syncs watches with open tabs, listens for `file-changed` events
- `FileConflictBanner` component — yellow warning bar above the editor
- `watchFile`, `unwatchFile`, `unwatchAllFiles` invoke wrappers

## Test plan

- [x] `cargo check` passes
- [x] `tsc --noEmit` passes (zero errors)
- [x] Frontend tests pass (887/888, 1 pre-existing flaky timing test)
- [x] E2E tests pass (116 passed, 21 skipped)
- [ ] Manual: open a file in editor, modify it externally → auto-reloads
- [ ] Manual: open a file, make local edits, modify externally → conflict banner appears
- [ ] Manual: click "Reload" → replaces with disk content
- [ ] Manual: click "Keep mine" → dismisses banner, keeps local edits