### PR TITLE
fix(thinking): render markdown headers on separate lines

### DIFF
--- a/frontend/components/ThinkingBlock/ThinkingBlock.tsx
+++ b/frontend/components/ThinkingBlock/ThinkingBlock.tsx
@@ -19,17 +19,19 @@ interface ThinkingBlockUIProps {
  */
 const MARKDOWN_COMPONENTS = {
   // Compact headings for thinking content
+  // Use <div> instead of <p> to avoid invalid HTML nesting (<p> cannot contain <p>),
+  // which causes browsers to auto-close elements and break block layout.
   h1: ({ children }: { children?: React.ReactNode }) => (
-    <p className="font-bold text-muted-foreground mt-2 mb-1 first:mt-0">{children}</p>
+    <div className="font-bold text-muted-foreground mt-2 mb-1 first:mt-0">{children}</div>
   ),
   h2: ({ children }: { children?: React.ReactNode }) => (
-    <p className="font-bold text-muted-foreground mt-2 mb-1 first:mt-0">{children}</p>
+    <div className="font-bold text-muted-foreground mt-2 mb-1 first:mt-0">{children}</div>
   ),
   h3: ({ children }: { children?: React.ReactNode }) => (
-    <p className="font-semibold text-muted-foreground mt-1.5 mb-1 first:mt-0">{children}</p>
+    <div className="font-semibold text-muted-foreground mt-1.5 mb-1 first:mt-0">{children}</div>
   ),
   h4: ({ children }: { children?: React.ReactNode }) => (
-    <p className="font-semibold text-muted-foreground mt-1.5 mb-1 first:mt-0">{children}</p>
+    <div className="font-semibold text-muted-foreground mt-1.5 mb-1 first:mt-0">{children}</div>
   ),
   // Compact paragraphs
   p: ({ children }: { children?: React.ReactNode }) => (


### PR DESCRIPTION
## Summary

- Fixed markdown headers in thinking blocks appearing "smooshed" inline at the end of previous lines instead of on their own lines
- Changed heading custom components (`h1`–`h4`) in `ThinkingBlock` from `<p>` to `<div>` to avoid invalid HTML nesting (`<p>` cannot contain `<p>`), which caused browsers to auto-close elements and break block layout

## Test plan

- [x] Biome lint passes
- [x] E2E tests pass (116 passed, 21 skipped)
- [ ] Manually verify thinking block headers render on separate lines with extended thinking models