### PR TITLE
feat(file-browser): add hidden files toggle, editable path bar, and quick open

### DIFF
--- a/CURRENT-TASK.md
+++ b/CURRENT-TASK.md
@@ -1,0 +1,66 @@
+# Q-183: File Browser Updates — Implementation Plan
+
+## Feature 1: Show Hidden Files Toggle
+
+**Problem**: The backend `list_directory` command hard-skips all dotfiles (`name.starts_with('.')`) with no way to override this.
+
+**Changes**:
+
+1. **Backend** (`backend/crates/qbit/src/commands/files.rs`):
+   - Add a `show_hidden: bool` parameter to `list_directory`
+   - Only skip `name.starts_with('.')` entries when `show_hidden` is `false`
+
+2. **Frontend lib** (`frontend/lib/file-editor.ts`):
+   - Update `listDirectory` to accept and pass `showHidden?: boolean`
+
+3. **Frontend store** (`frontend/store/file-editor-sidebar.ts`):
+   - Add `showHiddenFiles: boolean` to state (default `false`)
+   - Add `setShowHiddenFiles` action
+   - Persist it in the `partialize` section
+
+4. **Frontend UI** (`frontend/components/FileEditorSidebar/FileBrowser.tsx`):
+   - Add a toggle button (eye icon) in the toolbar next to Refresh
+   - Pass `showHidden` through to `listDirectory`
+   - Add `showHiddenFiles` and `onToggleHiddenFiles` props
+
+5. **Wire up** in `FileEditorSidebarPanel.tsx`: read from store, pass to `FileBrowser`
+
+---
+
+## Feature 2: Editable Path Bar
+
+**Problem**: The footer currently shows the path as read-only text. Users want to type/paste a path directly.
+
+**Changes**:
+
+1. **Frontend** (`frontend/components/FileEditorSidebar/FileEditorSidebarPanel.tsx`):
+   - Replace the read-only `<span>` path display in the footer with an editable `<input>`
+   - The input shows the current path and allows editing
+   - On `Enter`, navigate to the typed path (call `setBrowserPath`)
+   - On `Escape`, revert to current path
+   - Style it as a minimal input that looks like text until focused
+
+---
+
+## Feature 3: Open File Hotkey with Fuzzy Search
+
+**Problem**: No quick way to open a file by name. Users want a `Cmd+P` style fuzzy finder.
+
+**Changes**:
+
+1. **Frontend — New modal component** (`frontend/components/QuickOpenDialog/`):
+   - Uses `searchFiles` from `@/lib/indexer` for fuzzy file search
+   - Shows results in a scrollable list with keyboard navigation (up/down/enter)
+   - On selection, opens the file in the file editor sidebar
+
+2. **Hotkey** (`frontend/hooks/useKeyboardHandlerContext.ts`):
+   - Add `Cmd+P` handler that opens the quick-open dialog
+   - Add `openQuickOpen` callback to `KeyboardHandlerContext`
+
+3. **App wiring** (`frontend/App.tsx`):
+   - Add `quickOpenDialogOpen` state
+   - Pass opener to keyboard context
+   - Render `QuickOpenDialog` component
+
+4. **Command Palette** (`frontend/components/CommandPalette/CommandPalette.tsx`):
+   - Add "Open File" entry with `Cmd+P` shortcut

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "rig-core",
  "serde",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-mcp"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dirs",
  "itoa",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dirs",
  "serde",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4682,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -4708,14 +4708,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "bytes",
  "futures",

--- a/backend/crates/qbit/src/commands/files.rs
+++ b/backend/crates/qbit/src/commands/files.rs
@@ -283,7 +283,7 @@ pub struct DirEntry {
 /// List entries in a directory for the file browser.
 /// Returns files and directories, sorted with directories first.
 #[tauri::command]
-pub async fn list_directory(path: String) -> Result<Vec<DirEntry>> {
+pub async fn list_directory(path: String, show_hidden: Option<bool>) -> Result<Vec<DirEntry>> {
     let dir_path = if path.is_empty() {
         workspace_root()
     } else {
@@ -312,8 +312,8 @@ pub async fn list_directory(path: String) -> Result<Vec<DirEntry>> {
     while let Some(entry) = read_dir.next_entry().await? {
         let name = entry.file_name().to_string_lossy().to_string();
 
-        // Skip hidden files (starting with .)
-        if name.starts_with('.') {
+        // Skip hidden files (starting with .) unless show_hidden is true
+        if !show_hidden.unwrap_or(false) && name.starts_with('.') {
             continue;
         }
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -47,6 +47,11 @@ const MockDevTools = lazy(() =>
     default: m.MockDevTools,
   }))
 );
+const QuickOpenDialog = lazy(() =>
+  import("./components/QuickOpenDialog").then((m) => ({
+    default: m.QuickOpenDialog,
+  }))
+);
 
 import { MockDevToolsProvider } from "./components/MockDevTools";
 import { useAiEvents } from "./hooks/useAiEvents";
@@ -99,6 +104,7 @@ function App() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [quickOpenDialogOpen, setQuickOpenDialogOpen] = useState(false);
   const [sessionBrowserOpen, setSessionBrowserOpen] = useState(false);
   const [contextPanelOpen, setContextPanelOpen] = useState(false);
   const [gitPanelOpen, setGitPanelOpen] = useState(false);
@@ -460,6 +466,7 @@ function App() {
     handleClosePane,
     handleNavigatePane,
     setCommandPaletteOpen,
+    setQuickOpenDialogOpen,
     setSidecarPanelOpen,
   };
 
@@ -682,7 +689,17 @@ function App() {
           onSplitPaneRight={() => handleSplitPane("vertical")}
           onSplitPaneDown={() => handleSplitPane("horizontal")}
           onClosePane={handleClosePane}
+          onOpenQuickOpen={() => setQuickOpenDialogOpen(true)}
         />
+
+        {/* Quick Open Dialog (Cmd+P) */}
+        <Suspense fallback={null}>
+          <QuickOpenDialog
+            open={quickOpenDialogOpen}
+            onOpenChange={setQuickOpenDialogOpen}
+            workingDirectory={workingDirectory}
+          />
+        </Suspense>
 
         {/* Lazy-loaded dialogs and panels - wrapped in Suspense with null fallback
             since they render nothing when closed anyway */}

--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -50,6 +50,7 @@ interface CommandPaletteProps {
   onToggleFileEditorPanel?: () => void;
   onOpenContextPanel?: () => void;
   onOpenSettings?: () => void;
+  onOpenQuickOpen?: () => void;
   // Pane management
   onSplitPaneRight?: () => void;
   onSplitPaneDown?: () => void;
@@ -80,6 +81,7 @@ export function CommandPalette({
   onToggleFileEditorPanel,
   onOpenContextPanel,
   onOpenSettings,
+  onOpenQuickOpen,
   onSplitPaneRight,
   onSplitPaneDown,
   onClosePane,
@@ -286,6 +288,13 @@ export function CommandPalette({
 
         {/* Code Search & Analysis */}
         <CommandGroup heading="Code Search">
+          {onOpenQuickOpen && (
+            <CommandItem onSelect={() => runCommand(onOpenQuickOpen)}>
+              <FileText className="mr-2 h-4 w-4" />
+              <span>Open File</span>
+              <CommandShortcut>⌘P</CommandShortcut>
+            </CommandItem>
+          )}
           <CommandItem onSelect={() => runCommand(handleSearchCode)} disabled={isSearching}>
             <Search className="mr-2 h-4 w-4" />
             <span>Search Code</span>

--- a/frontend/components/FileEditorSidebar/FileBrowser.tsx
+++ b/frontend/components/FileEditorSidebar/FileBrowser.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Home, RefreshCw } from "lucide-react";
+import { ChevronRight, Eye, EyeOff, Home, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { type DirEntry, listDirectory } from "@/lib/file-editor";
@@ -10,6 +10,8 @@ interface FileBrowserProps {
   workingDirectory?: string;
   onNavigate: (path: string) => void;
   onOpenFile: (path: string) => void;
+  showHiddenFiles: boolean;
+  onToggleHiddenFiles: () => void;
 }
 
 function formatFileSize(bytes: number): string {
@@ -50,24 +52,29 @@ export function FileBrowser({
   workingDirectory,
   onNavigate,
   onOpenFile,
+  showHiddenFiles,
+  onToggleHiddenFiles,
 }: FileBrowserProps) {
   const [entries, setEntries] = useState<DirEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const loadDirectory = useCallback(async (path: string) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await listDirectory(path);
-      setEntries(result);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setEntries([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const loadDirectory = useCallback(
+    async (path: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await listDirectory(path, showHiddenFiles);
+        setEntries(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setEntries([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [showHiddenFiles]
+  );
 
   useEffect(() => {
     loadDirectory(currentPath || workingDirectory || "");
@@ -132,6 +139,15 @@ export function FileBrowser({
           title="Refresh"
         >
           <RefreshCw className={cn("w-3.5 h-3.5", loading && "animate-spin")} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn("h-6 w-6", showHiddenFiles && "bg-primary/20 text-primary")}
+          onClick={onToggleHiddenFiles}
+          title={showHiddenFiles ? "Hide hidden files" : "Show hidden files"}
+        >
+          {showHiddenFiles ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
         </Button>
 
         {/* Breadcrumbs */}

--- a/frontend/components/FileEditorSidebar/FileEditorSidebarPanel.tsx
+++ b/frontend/components/FileEditorSidebar/FileEditorSidebarPanel.tsx
@@ -160,6 +160,83 @@ function MarkdownPreview({ content }: { content: string }) {
   );
 }
 
+function EditablePathBar({
+  value,
+  onNavigate,
+}: {
+  value: string;
+  onNavigate: (path: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Sync draft when value changes externally (while not editing)
+  useEffect(() => {
+    if (!editing) {
+      setDraft(value);
+    }
+  }, [value, editing]);
+
+  const startEditing = () => {
+    setDraft(value);
+    setEditing(true);
+    // Focus the input after it renders
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+  };
+
+  const commit = () => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== value) {
+      onNavigate(trimmed);
+    } else {
+      setDraft(value);
+    }
+  };
+
+  const cancel = () => {
+    setEditing(false);
+    setDraft(value);
+  };
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={startEditing}
+        className="font-mono text-[11px] truncate text-left hover:text-foreground transition-colors cursor-text min-w-0"
+        title={`${value}\nClick to edit path`}
+      >
+        {value || "Browser"}
+      </button>
+    );
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          commit();
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          cancel();
+        }
+      }}
+      onBlur={commit}
+      className="font-mono text-[11px] bg-transparent border-b border-primary/50 outline-none text-foreground min-w-0 w-full"
+    />
+  );
+}
+
 function FileOpenPrompt({
   workingDirectory,
   onOpen,
@@ -244,6 +321,7 @@ export function FileEditorSidebarPanel({
     wrap,
     lineNumbers,
     relativeLineNumbers,
+    showHiddenFiles,
     recentFiles,
     width,
     openFile,
@@ -260,6 +338,7 @@ export function FileEditorSidebarPanel({
     setBrowserPath,
     setVimMode,
     setVimModeState,
+    setShowHiddenFiles,
     toggleMarkdownPreview,
     reorderTabs,
   } = useFileEditorSidebar(workingDirectory || undefined);
@@ -494,6 +573,8 @@ export function FileEditorSidebarPanel({
             }
           }}
           onOpenFile={(path) => openFile(path)}
+          showHiddenFiles={showHiddenFiles}
+          onToggleHiddenFiles={() => setShowHiddenFiles(!showHiddenFiles)}
         />
       );
     }
@@ -636,16 +717,17 @@ export function FileEditorSidebarPanel({
 
       {/* Footer */}
       <div className="px-3 py-2 border-t border-border text-xs text-muted-foreground flex items-center justify-between">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex-1 flex items-center gap-2 min-w-0">
           {vimMode && activeTab?.type === "file" && (
             <Badge variant="outline" className="text-[11px] font-mono uppercase">
               {vimModeState ?? "normal"}
             </Badge>
           )}
           {activeTab?.type === "browser" && (
-            <span className="font-mono text-[11px] truncate">
-              {activeTab.browser.currentPath || workingDirectory || "Browser"}
-            </span>
+            <EditablePathBar
+              value={activeTab.browser.currentPath || workingDirectory || ""}
+              onNavigate={(path) => setBrowserPath(activeTab.id, path)}
+            />
           )}
         </div>
         <div className="flex items-center gap-2 shrink-0">

--- a/frontend/components/QuickOpenDialog/QuickOpenDialog.tsx
+++ b/frontend/components/QuickOpenDialog/QuickOpenDialog.tsx
@@ -1,0 +1,192 @@
+import { FileText } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useFileEditorSidebar } from "@/hooks/useFileEditorSidebar";
+import { type FileInfo, listWorkspaceFiles } from "@/lib/tauri";
+import { cn } from "@/lib/utils";
+
+interface QuickOpenDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workingDirectory?: string;
+}
+
+export function QuickOpenDialog({
+  open,
+  onOpenChange,
+  workingDirectory,
+}: QuickOpenDialogProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<FileInfo[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isSearching, setIsSearching] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const { openFile } = useFileEditorSidebar(workingDirectory);
+
+  // Reset state when opening
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setResults([]);
+      setSelectedIndex(0);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  // Search files as user types
+  useEffect(() => {
+    if (!open || !query.trim() || !workingDirectory) {
+      setResults([]);
+      setSelectedIndex(0);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const files = await listWorkspaceFiles(workingDirectory, query, 50);
+        if (!cancelled) {
+          setResults(files);
+          setSelectedIndex(0);
+        }
+      } catch {
+        if (!cancelled) {
+          setResults([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsSearching(false);
+        }
+      }
+    }, 100);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [open, query, workingDirectory]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (listRef.current) {
+      const selected = listRef.current.querySelector(`[data-index="${selectedIndex}"]`);
+      selected?.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
+  const handleSelect = useCallback(
+    (file: FileInfo) => {
+      onOpenChange(false);
+      const fullPath = workingDirectory
+        ? `${workingDirectory.replace(/\/$/, "")}/${file.relative_path}`
+        : file.relative_path;
+      void openFile(fullPath);
+    },
+    [onOpenChange, openFile, workingDirectory]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const selected = results[selectedIndex];
+        if (selected) {
+          handleSelect(selected);
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onOpenChange(false);
+      }
+    },
+    [results, selectedIndex, handleSelect, onOpenChange]
+  );
+
+  if (!open) return null;
+
+  return createPortal(
+    <>
+      {/* Backdrop */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop dismiss */}
+      <div
+        className="fixed inset-0 z-50 bg-black/50"
+        onClick={() => onOpenChange(false)}
+      />
+
+      {/* Dialog */}
+      <div className="fixed left-1/2 top-[20%] -translate-x-1/2 z-50 w-[500px] max-w-[90vw]">
+        <div className="bg-popover border border-border rounded-lg shadow-xl overflow-hidden">
+          {/* Search input */}
+          <div className="flex items-center border-b border-border px-3">
+            <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Search files by name..."
+              className="flex-1 bg-transparent py-3 px-2 text-sm outline-none text-foreground placeholder:text-muted-foreground"
+            />
+            {isSearching && (
+              <span className="text-xs text-muted-foreground animate-pulse">...</span>
+            )}
+          </div>
+
+          {/* Results */}
+          <div ref={listRef} className="max-h-[300px] overflow-y-auto py-1" role="listbox">
+            {query && results.length === 0 && !isSearching && (
+              <div className="py-6 text-center text-sm text-muted-foreground">No files found</div>
+            )}
+            {results.map((file, index) => (
+              <div
+                key={file.relative_path}
+                role="option"
+                aria-selected={index === selectedIndex}
+                data-index={index}
+                onClick={() => handleSelect(file)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSelect(file);
+                }}
+                tabIndex={-1}
+                className={cn(
+                  "flex items-center gap-2 px-3 py-1.5 cursor-pointer transition-colors",
+                  index === selectedIndex ? "bg-primary/10" : "hover:bg-muted/50"
+                )}
+              >
+                <FileText className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                <span className="text-sm text-foreground truncate">{file.name}</span>
+                {file.relative_path !== file.name && (
+                  <span className="text-xs text-muted-foreground truncate ml-auto">
+                    {file.relative_path.slice(0, -(file.name.length + 1))}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Footer hint */}
+          <div className="px-3 py-1.5 border-t border-border text-[11px] text-muted-foreground flex items-center gap-3">
+            <span>
+              <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">↑↓</kbd> navigate
+            </span>
+            <span>
+              <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">↵</kbd> open
+            </span>
+            <span>
+              <kbd className="px-1 py-0.5 bg-muted rounded text-[10px]">esc</kbd> close
+            </span>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body
+  );
+}

--- a/frontend/components/QuickOpenDialog/index.ts
+++ b/frontend/components/QuickOpenDialog/index.ts
@@ -1,0 +1,1 @@
+export { QuickOpenDialog } from "./QuickOpenDialog";

--- a/frontend/hooks/useFileEditorSidebar.ts
+++ b/frontend/hooks/useFileEditorSidebar.ts
@@ -108,6 +108,9 @@ export function useFileEditorSidebar(workingDirectory?: string) {
       setRelativeLineNumbers: (enabled: boolean) => {
         useFileEditorSidebarStore.getState().setRelativeLineNumbers(enabled);
       },
+      setShowHiddenFiles: (enabled: boolean) => {
+        useFileEditorSidebarStore.getState().setShowHiddenFiles(enabled);
+      },
       addRecentFile: (path: string) => {
         useFileEditorSidebarStore.getState().addRecentFile(path);
       },
@@ -244,6 +247,7 @@ export function useFileEditorSidebar(workingDirectory?: string) {
     wrap: state.wrap,
     lineNumbers: state.lineNumbers,
     relativeLineNumbers: state.relativeLineNumbers,
+    showHiddenFiles: state.showHiddenFiles,
     recentFiles: state.recentFiles,
     status: state.status,
     activeTabId: state.activeTabId,
@@ -273,6 +277,7 @@ export function useFileEditorSidebar(workingDirectory?: string) {
     setWrap: actions.setWrap,
     setLineNumbers: actions.setLineNumbers,
     setRelativeLineNumbers: actions.setRelativeLineNumbers,
+    setShowHiddenFiles: actions.setShowHiddenFiles,
     toggleMarkdownPreview: actions.toggleMarkdownPreview,
   };
 }

--- a/frontend/hooks/useKeyboardHandlerContext.ts
+++ b/frontend/hooks/useKeyboardHandlerContext.ts
@@ -38,6 +38,7 @@ export interface KeyboardHandlerContext {
 
   // Setters (for local state)
   setCommandPaletteOpen: (open: boolean) => void;
+  setQuickOpenDialogOpen: (open: boolean) => void;
   setSidecarPanelOpen: (open: boolean) => void;
 }
 
@@ -54,6 +55,7 @@ const defaultContext: KeyboardHandlerContext = {
   handleClosePane: async () => {},
   handleNavigatePane: () => {},
   setCommandPaletteOpen: () => {},
+  setQuickOpenDialogOpen: () => {},
   setSidecarPanelOpen: () => {},
 };
 
@@ -193,6 +195,13 @@ export function createKeyboardHandler(
           currentRenderMode === "fullterm" ? "timeline" : "fullterm"
         );
       }
+      return;
+    }
+
+    // Cmd+P for quick open file (without Shift)
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "p") {
+      e.preventDefault();
+      ctx.setQuickOpenDialogOpen(true);
       return;
     }
 

--- a/frontend/lib/file-editor.ts
+++ b/frontend/lib/file-editor.ts
@@ -44,6 +44,6 @@ export interface DirEntry {
   modifiedAt?: string;
 }
 
-export async function listDirectory(path: string): Promise<DirEntry[]> {
-  return invoke("list_directory", { path });
+export async function listDirectory(path: string, showHidden?: boolean): Promise<DirEntry[]> {
+  return invoke("list_directory", { path, showHidden });
 }

--- a/frontend/store/file-editor-sidebar.ts
+++ b/frontend/store/file-editor-sidebar.ts
@@ -50,6 +50,7 @@ interface FileEditorSidebarState {
   // Recent files for quick access
   recentFiles: string[];
   // Editor settings (shared across file tabs)
+  showHiddenFiles: boolean;
   vimMode: boolean;
   vimModeState: "normal" | "insert" | "visual";
   wrap: boolean;
@@ -81,6 +82,7 @@ interface FileEditorSidebarState {
   setWrap: (enabled: boolean) => void;
   setLineNumbers: (enabled: boolean) => void;
   setRelativeLineNumbers: (enabled: boolean) => void;
+  setShowHiddenFiles: (enabled: boolean) => void;
   addRecentFile: (path: string) => void;
   reset: () => void;
 }
@@ -110,6 +112,7 @@ const initialState = {
   activeTabId: null as string | null,
   tabOrder: [] as string[],
   recentFiles: [] as string[],
+  showHiddenFiles: false,
   vimMode: true,
   vimModeState: "normal" as const,
   wrap: false,
@@ -317,6 +320,11 @@ export const useFileEditorSidebarStore = create<FileEditorSidebarState>()(
           draft.relativeLineNumbers = enabled;
         });
       },
+      setShowHiddenFiles: (enabled) => {
+        set((draft) => {
+          draft.showHiddenFiles = enabled;
+        });
+      },
 
       addRecentFile: (path) => {
         set((draft) => {
@@ -339,6 +347,7 @@ export const useFileEditorSidebarStore = create<FileEditorSidebarState>()(
         wrap: state.wrap,
         lineNumbers: state.lineNumbers,
         relativeLineNumbers: state.relativeLineNumbers,
+        showHiddenFiles: state.showHiddenFiles,
       }),
     }
   )


### PR DESCRIPTION
## Summary

- **Show hidden files toggle**: Eye icon button in the file browser toolbar toggles dotfile visibility. Backed by a new `show_hidden` parameter on the `list_directory` backend command. Preference is persisted in localStorage.
- **Editable path bar**: The read-only path in the browser footer is now clickable — type a path and press Enter to navigate directly, Escape to cancel.
- **Quick open file dialog (Cmd+P)**: Fuzzy file search modal using `listWorkspaceFiles`. Also accessible via the "Open File" entry in the command palette (Cmd+K).

## Test plan

- [ ] Open file browser sidebar (Cmd+Shift+E), click Browse
- [ ] Verify hidden files toggle (eye icon) shows/hides dotfiles (`.gitignore`, `.env`, etc.)
- [ ] Verify toggle state persists across browser tab reopens
- [ ] Click the path in the browser footer, type a new path, press Enter — verify navigation
- [ ] Press Escape while editing path — verify it reverts
- [ ] Press Cmd+P — verify quick open dialog opens centered with search input focused
- [ ] Type a filename — verify results appear and can be navigated with arrow keys
- [ ] Press Enter on a result — verify file opens in the editor sidebar
- [ ] Open command palette (Cmd+K), select "Open File" — verify it opens the quick open dialog