### PR TITLE
fix(scroll): auto-scroll reliably when streaming tool calls update

### DIFF
--- a/frontend/store/index.ts
+++ b/frontend/store/index.ts
@@ -393,6 +393,7 @@ interface QbitState extends ContextSlice, GitSlice, NotificationSlice {
   agentStreaming: Record<string, string>;
   streamingBlocks: Record<string, StreamingBlock[]>; // Interleaved text and tool blocks
   streamingTextOffset: Record<string, number>; // Tracks how much text has been assigned to blocks
+  streamingBlockRevision: Record<string, number>; // Increments when blocks are modified in-place (for auto-scroll)
   agentInitialized: Record<string, boolean>;
   isAgentThinking: Record<string, boolean>; // True when waiting for first content from agent
   isAgentResponding: Record<string, boolean>; // True when agent is actively responding (from started to completed)
@@ -650,6 +651,7 @@ export const useStore = create<QbitState>()(
       agentStreaming: {},
       streamingBlocks: {},
       streamingTextOffset: {},
+      streamingBlockRevision: {},
       agentInitialized: {},
       isAgentThinking: {},
       isAgentResponding: {},
@@ -1258,6 +1260,7 @@ export const useStore = create<QbitState>()(
                 break;
               }
             }
+            state.streamingBlockRevision[sessionId] = (state.streamingBlockRevision[sessionId] ?? 0) + 1;
           }
         }),
 
@@ -1320,6 +1323,7 @@ export const useStore = create<QbitState>()(
                 break;
               }
             }
+            state.streamingBlockRevision[sessionId] = (state.streamingBlockRevision[sessionId] ?? 0) + 1;
           }
         }),
 

--- a/frontend/store/selectors/session.ts
+++ b/frontend/store/selectors/session.ts
@@ -39,6 +39,7 @@ export interface SessionState {
   isCompacting: boolean;
   agentStreaming: string;
   streamingTextLength: number;
+  streamingBlockRevision: number;
 }
 
 // Stable empty arrays to avoid creating new references
@@ -65,6 +66,7 @@ interface CacheEntry {
   workingDirectory: string | undefined;
   isCompacting: boolean | undefined;
   agentStreaming: string | undefined;
+  streamingBlockRevision: number | undefined;
   // Computed result
   result: SessionState;
 }
@@ -88,6 +90,7 @@ function getRawSessionInputs(state: ReturnType<typeof useStore.getState>, sessio
     workingDirectory: state.sessions[sessionId]?.workingDirectory,
     isCompacting: state.isCompacting[sessionId],
     agentStreaming: state.agentStreaming[sessionId],
+    streamingBlockRevision: state.streamingBlockRevision[sessionId],
   };
 }
 
@@ -106,7 +109,8 @@ function isCacheValid(cached: CacheEntry, inputs: ReturnType<typeof getRawSessio
     cached.activeToolCalls === inputs.activeToolCalls &&
     cached.workingDirectory === inputs.workingDirectory &&
     cached.isCompacting === inputs.isCompacting &&
-    cached.agentStreaming === inputs.agentStreaming
+    cached.agentStreaming === inputs.agentStreaming &&
+    cached.streamingBlockRevision === inputs.streamingBlockRevision
   );
 }
 
@@ -129,6 +133,7 @@ function createSessionState(inputs: ReturnType<typeof getRawSessionInputs>): Ses
     isCompacting: inputs.isCompacting ?? false,
     agentStreaming,
     streamingTextLength: agentStreaming.length,
+    streamingBlockRevision: inputs.streamingBlockRevision ?? 0,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes Q-167: auto-scroll doesn't always work or scroll the entire way down when new streaming tool call components appear.

**Root causes identified and fixed:**

- **In-place block modifications didn't trigger scroll** — when tool results arrive or streaming command output grows, existing blocks are modified but `streamingBlocks.length` doesn't change, so the auto-scroll effect never fires
- **`isAtBottom` race condition** — content growth from new tool blocks could push scroll position >50px from bottom before the programmatic scroll executed, flipping `isAtBottom` to false and permanently disabling auto-scroll
- **Single RAF timing** — complex tool call components (syntax highlighting, diffs) may not finish layout within one animation frame

**Changes:**

- Add `streamingBlockRevision` counter to the store, incremented on `updateStreamingToolBlock` and `appendToolStreamingOutput`
- Expose counter through session selector and use as auto-scroll effect dependency
- Add `programmaticScrollRef` flag to prevent scroll listener from updating `isAtBottom` during programmatic scrolls
- Use double-RAF in `scrollToBottom` for more reliable layout timing

## Test plan

- [x] All 888 unit tests pass
- [x] 104/104 mock-browser E2E tests pass (12 failures are pre-existing `ERR_CONNECTION_REFUSED` from tests requiring live dev server)
- [ ] Manual: verify auto-scroll works when tool calls complete (status changes from running → completed)
- [ ] Manual: verify auto-scroll works during streaming command output in tool calls
- [ ] Manual: verify scrolling up still disables auto-scroll (user intent preserved)