### PR TITLE
chore: sync Cargo.lock with 0.2.28 release

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "rig-core",
  "serde",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4536,7 +4536,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-mcp"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "dirs",
  "itoa",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "dirs",
  "serde",
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4785,7 +4785,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -4811,14 +4811,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "bytes",
  "futures",


### PR DESCRIPTION
## Summary
Syncs `Cargo.lock` with the version bumps from the 0.2.28 release. The release-please PR bumped all `Cargo.toml` versions but the lockfile wasn't regenerated.

## Changes
- Updated `Cargo.lock` version entries from `0.2.27` to `0.2.28` across all 27 workspace crates

## Breaking Changes
None

## Test Plan
- [ ] CI passes — no functional changes, lockfile only

## Release Notes
No user-facing changes.

## Checklist
- [x] Conventional commit format followed
- [x] No functional changes