### PR TITLE
fix(test): add missing setQuickOpenDialogOpen mock

### DIFF
--- a/frontend/App.performance.test.tsx
+++ b/frontend/App.performance.test.tsx
@@ -581,6 +581,7 @@ describe("App Keyboard Event Listener Subscription", () => {
         handleNavigatePane: () => {},
         setCommandPaletteOpen: () => {},
         setSidecarPanelOpen: () => {},
+        setQuickOpenDialogOpen: () => {},
       },
     };
 


### PR DESCRIPTION
## Summary
Fixes the App performance test mock context to include the `setQuickOpenDialogOpen` function, keeping it aligned with the `KeyboardHandlerContext` interface.

## Changes
- Added missing `setQuickOpenDialogOpen: () => {}` to the mock context in `App.performance.test.tsx`

## Breaking Changes
None

## Test Plan
- [ ] Run `just test-fe` to verify the performance test passes
- [ ] Confirm no other mock properties are missing

## Release Notes
No user-facing changes. Internal test fix only.

## Checklist
- [x] Tests pass locally
- [x] Conventional commit format followed