### PR TITLE
build: re-enable sccache and switch to ThinLTO

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,9 +59,6 @@ jobs:
             echo "sccache not available, building without cache wrapper"
           fi
 
-      - name: Disable sccache (temporary)
-        run: echo "RUSTC_WRAPPER=" >> $GITHUB_ENV
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -213,6 +213,6 @@ opt-level = 2
 # Release profile: optimize for runtime performance
 [profile.release]
 opt-level = 3
-lto = true
-codegen-units = 1
+lto = "thin"
+codegen-units = 4
 strip = true


### PR DESCRIPTION
## Summary
- Re-enable sccache in CI check workflow (was temporarily disabled)
- Switch release profile from fat LTO to ThinLTO with 4 codegen-units

## Why
- sccache was explicitly disabled with a "temporary" step, costing significant CI time on every PR check by preventing compilation caching between clippy and nextest passes
- Fat LTO (`lto = true`) with `codegen-units = 1` makes release builds entirely single-threaded during the final optimization/codegen phase. ThinLTO retains ~95% of runtime performance while allowing parallel optimization across modules

## Test plan
- [ ] CI check workflow passes with sccache re-enabled
- [ ] Release build completes successfully with new profile
- [ ] Verify release binary size and runtime performance are acceptable