### PR TITLE
feat: proactive token counting with tokenx-rs for better compaction timing

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4472,6 +4472,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tokenx-rs",
  "tokio",
  "tracing",
  "uuid",
@@ -4513,6 +4514,7 @@ dependencies = [
  "rig-core",
  "serde",
  "serde_json",
+ "tokenx-rs",
  "tokio",
  "tracing",
 ]
@@ -7003,6 +7005,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenx-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbbbc43d8b92c18a53092e2195836a3c5c5125e6b477f0bcadb9cea34e48c5b9"
 
 [[package]]
 name = "tokio"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -155,6 +155,9 @@ reqwest = { version = "0.12", features = ["json"] }
 readability = { version = "0.3", default-features = false }
 url = "2.5"
 
+# Token estimation
+tokenx-rs = "0.1"
+
 # Rig core for LLM orchestration
 rig-core = { version = "^0.29.0", features = [] }
 # Rig companion crate for Google Vertex AI (Gemini)

--- a/backend/crates/qbit-ai/Cargo.toml
+++ b/backend/crates/qbit-ai/Cargo.toml
@@ -49,6 +49,7 @@ tracing = { workspace = true }
 dirs = { workspace = true }
 parking_lot = { workspace = true }
 regex = { workspace = true }
+tokenx-rs = { workspace = true }
 
 # LLM integration via rig
 rig-core = { workspace = true }

--- a/backend/crates/qbit-context/Cargo.toml
+++ b/backend/crates/qbit-context/Cargo.toml
@@ -10,3 +10,4 @@ tokio = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }
+tokenx-rs = { workspace = true }

--- a/backend/crates/qbit-context/src/token_budget.rs
+++ b/backend/crates/qbit-context/src/token_budget.rs
@@ -36,9 +36,6 @@ pub const MAX_TOOL_RESPONSE_TOKENS: usize = 25_000;
 /// Default context window size (Claude 3.5 Sonnet)
 pub const DEFAULT_MAX_CONTEXT_TOKENS: usize = 128_000;
 
-/// Average characters per token for rough estimation
-const CHARS_PER_TOKEN: f64 = 4.0;
-
 /// Model-specific context window sizes
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelContextLimits {
@@ -309,11 +306,12 @@ impl TokenBudgetManager {
         stats.reset();
     }
 
-    /// Estimate tokens for text content
+    /// Estimate tokens for text content using tokenx-rs heuristic estimator.
+    ///
+    /// Uses segment-based analysis (96% accuracy vs tiktoken cl100k_base)
+    /// instead of the naive chars/4 approximation.
     pub fn estimate_tokens(text: &str) -> usize {
-        // Simple estimation: ~4 characters per token
-        // More accurate would use tiktoken or similar
-        (text.len() as f64 / CHARS_PER_TOKEN).ceil() as usize
+        tokenx_rs::estimate_token_count(text)
     }
 
     /// Calculate usage percentage (0.0 - 1.0+)


### PR DESCRIPTION
## Summary

- Integrate [tokenx-rs](https://github.com/qbit-ai/tokenx-rs) for token estimation (~96% accuracy vs tiktoken, zero runtime deps)
- Add proactive token counting before each LLM call so compaction triggers before overshooting the context window, not after
- Replace the `chars / 4` heuristic in `TokenBudgetManager::estimate_tokens()` and the `estimate_message_chars` fallback path

## Problem

Compaction decisions relied on provider-reported token counts from the **previous** LLM response. In tool-heavy sessions, context grows via tool results between LLM calls, but the system didn't know about this growth until the next response came back. With many tool calls per iteration, the gap between the stale provider count and actual context size could be significant — potentially overshooting the context window.

## Solution

Count tokens locally before each LLM call using tokenx-rs:

```
BEFORE:  LLM call → response → provider reports tokens → check compaction
AFTER:   estimate tokens locally → check compaction → LLM call → provider validates
```

## Test plan

- [ ] 11 new unit tests covering estimation extraction, compaction state, and end-to-end pipeline
- [ ] All 384 existing tests pass (`cargo test -p qbit-context -p qbit-ai`)
- [ ] `cargo check` passes
- [ ] Verify compaction triggers correctly in a long tool-heavy session