### PR TITLE
feat(tabs): add tab reordering, context menu, and convert-to-pane modal

### DIFF
--- a/frontend/store/selectors/tab-bar.ts
+++ b/frontend/store/selectors/tab-bar.ts
@@ -145,19 +145,13 @@ export function selectTabItemState(
  * Memoized selector for the entire TabBar state.
  */
 export function selectTabBarState(state: ReturnType<typeof useStore.getState>): TabBarState {
-  // Only include sessions that are tab roots (have entry in tabLayouts)
-  // Pane sessions should not appear as separate tabs
-  const tabLayoutIds = Object.keys(state.tabLayouts);
-  const sessionIds = tabLayoutIds
-    .filter((id) => state.sessions[id] != null)
-    .sort((a, b) => {
-      // Home tab always first
-      const aType = state.sessions[a]?.tabType;
-      const bType = state.sessions[b]?.tabType;
-      if (aType === "home") return -1;
-      if (bType === "home") return 1;
-      return 0;
-    });
+  // Use explicit tabOrder for ordering (home tab is always at index 0)
+  // Fall back to Object.keys(tabLayouts) for backward compatibility
+  const tabLayoutIds =
+    state.tabOrder.length > 0
+      ? state.tabOrder.filter((id) => state.tabLayouts[id] != null)
+      : Object.keys(state.tabLayouts);
+  const sessionIds = tabLayoutIds.filter((id) => state.sessions[id] != null);
 
   const activeSessionId = state.activeSessionId;
   const homeTabId = state.homeTabId;


### PR DESCRIPTION
## Summary

- Add explicit `tabOrder` array to the Zustand store, ensuring the home tab is always at index 0 and subsequent tabs get sequential indices
- Add right-click context menu on all tabs with Move Left, Move Right, Convert to Pane, Duplicate Tab, and Close Tab options
- Add Convert to Pane modal that lets users merge a tab into another tab as a split pane, with destination tab selection (showing index + title) and placement direction (top/bottom/left/right)

## Test plan

- [x] `just check` passes (fmt, biome lint, vitest, clippy, cargo test)
- [x] `just test-e2e` passes (116 passed, 21 skipped)
- [x] TypeScript compiles with zero errors
- [ ] Manual: verify home tab stays at index 0 after creating/closing tabs
- [ ] Manual: verify Move Left/Right reorders tabs correctly and is disabled at boundaries
- [ ] Manual: verify Convert to Pane modal moves tab content as a split pane into the selected destination