### PR TITLE
feat(panes): right-click context menu with pane management

### DIFF
--- a/frontend/components/PaneContainer/PaneContextMenu.tsx
+++ b/frontend/components/PaneContainer/PaneContextMenu.tsx
@@ -1,0 +1,74 @@
+import { Columns2, ExternalLink, MousePointerClick, Rows2 } from "lucide-react";
+import { useCallback } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+} from "@/components/ui/context-menu";
+import { usePaneControls } from "@/hooks/usePaneControls";
+import { countLeafPanes } from "@/lib/pane-utils";
+import type { PaneId } from "@/store";
+import { useStore } from "@/store";
+
+interface PaneContextMenuProps {
+  children: React.ReactNode;
+  paneId: PaneId;
+  sessionId: string;
+  tabId: string;
+}
+
+export function PaneContextMenu({ children, paneId, sessionId, tabId }: PaneContextMenuProps) {
+  const startPaneMove = useStore((state) => state.startPaneMove);
+  const movePaneToNewTab = useStore((state) => state.movePaneToNewTab);
+  const paneCount = useStore((state) => {
+    const layout = state.tabLayouts[tabId];
+    return layout ? countLeafPanes(layout.root) : 1;
+  });
+
+  const { handleSplitPane } = usePaneControls(tabId);
+
+  const hasMultiplePanes = paneCount > 1;
+  const canSplit = paneCount < 4;
+
+  const handleMovePane = useCallback(() => {
+    startPaneMove(tabId, paneId, sessionId);
+  }, [tabId, paneId, sessionId, startPaneMove]);
+
+  const handleConvertToTab = useCallback(() => {
+    movePaneToNewTab(tabId, paneId);
+  }, [tabId, paneId, movePaneToNewTab]);
+
+  return (
+    <ContextMenu>
+      {children}
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => handleSplitPane("vertical")} disabled={!canSplit}>
+          <Columns2 className="w-3.5 h-3.5" />
+          Split Vertically
+          <ContextMenuShortcut>⌘D</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => handleSplitPane("horizontal")} disabled={!canSplit}>
+          <Rows2 className="w-3.5 h-3.5" />
+          Split Horizontally
+          <ContextMenuShortcut>⇧⌘D</ContextMenuShortcut>
+        </ContextMenuItem>
+
+        {hasMultiplePanes && (
+          <>
+            <ContextMenuSeparator />
+            <ContextMenuItem onClick={handleMovePane}>
+              <MousePointerClick className="w-3.5 h-3.5" />
+              Move Pane...
+            </ContextMenuItem>
+            <ContextMenuItem onClick={handleConvertToTab}>
+              <ExternalLink className="w-3.5 h-3.5" />
+              Convert to Tab
+            </ContextMenuItem>
+          </>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/frontend/components/PaneContainer/PaneLeaf.tsx
+++ b/frontend/components/PaneContainer/PaneLeaf.tsx
@@ -18,11 +18,14 @@ import React, { lazy, Suspense, useCallback } from "react";
 import { ToolApprovalDialog } from "@/components/AgentChat";
 import { UnifiedInput } from "@/components/UnifiedInput";
 import { UnifiedTimeline } from "@/components/UnifiedTimeline";
+import { ContextMenuTrigger } from "@/components/ui/context-menu";
 import { useTerminalPortalTarget } from "@/hooks/useTerminalPortal";
 import { countLeafPanes } from "@/lib/pane-utils";
 import type { PaneId } from "@/store";
 import { useStore } from "@/store";
 import { usePaneLeafState } from "@/store/selectors/pane-leaf";
+import { PaneContextMenu } from "./PaneContextMenu";
+import { PaneMoveOverlay } from "./PaneMoveOverlay";
 
 // Lazy-load tab-specific components to reduce initial bundle size
 // HomeView (~50KB) and SettingsTabContent (~80KB) are only needed when
@@ -128,7 +131,10 @@ export const PaneLeaf = React.memo(function PaneLeaf({ paneId, sessionId, tabId 
     }
   };
 
-  return (
+  // Only show context menu for terminal tabs
+  const isTerminal = tabType === "terminal" || tabType === undefined;
+
+  const sectionContent = (
     <section
       className="h-full w-full flex flex-col relative overflow-hidden"
       tabIndex={-1}
@@ -145,7 +151,19 @@ export const PaneLeaf = React.memo(function PaneLeaf({ paneId, sessionId, tabId 
           aria-hidden="true"
         />
       )}
+      {/* Move overlay - shown when pane move mode is active */}
+      {isTerminal && <PaneMoveOverlay paneId={paneId} />}
       {renderTabContent()}
     </section>
   );
+
+  if (isTerminal) {
+    return (
+      <PaneContextMenu paneId={paneId} sessionId={sessionId} tabId={tabId}>
+        <ContextMenuTrigger asChild>{sectionContent}</ContextMenuTrigger>
+      </PaneContextMenu>
+    );
+  }
+
+  return sectionContent;
 });

--- a/frontend/components/PaneContainer/PaneMoveOverlay.tsx
+++ b/frontend/components/PaneContainer/PaneMoveOverlay.tsx
@@ -1,0 +1,115 @@
+import { X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { PaneId } from "@/store";
+import { useStore } from "@/store";
+
+interface PaneMoveOverlayProps {
+  paneId: PaneId;
+}
+
+type DropZone = "top" | "right" | "bottom" | "left";
+
+export function PaneMoveOverlay({ paneId }: PaneMoveOverlayProps) {
+  const paneMoveState = useStore((state) => state.paneMoveState);
+  const completePaneMove = useStore((state) => state.completePaneMove);
+  const cancelPaneMove = useStore((state) => state.cancelPaneMove);
+  const [hoveredZone, setHoveredZone] = useState<DropZone | null>(null);
+
+  const isSource = paneMoveState?.sourcePaneId === paneId;
+  const isActive = paneMoveState !== null && !isSource;
+
+  // ESC to cancel
+  useEffect(() => {
+    if (!paneMoveState) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        cancelPaneMove();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [paneMoveState, cancelPaneMove]);
+
+  const handleDrop = useCallback(
+    (zone: DropZone) => {
+      completePaneMove(paneId, zone);
+    },
+    [paneId, completePaneMove]
+  );
+
+  if (!paneMoveState) return null;
+
+  // Source pane gets a dimmed overlay with cancel button
+  if (isSource) {
+    return (
+      <div className="absolute inset-0 z-50 bg-background/60 flex items-center justify-center">
+        <button
+          type="button"
+          onClick={cancelPaneMove}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-muted text-muted-foreground text-xs hover:bg-destructive/20 hover:text-destructive transition-colors"
+        >
+          <X className="w-3 h-3" />
+          Cancel Move
+        </button>
+      </div>
+    );
+  }
+
+  // Target panes get drop zones
+  if (!isActive) return null;
+
+  const zones: { zone: DropZone; clipPath: string; previewClass: string }[] = [
+    {
+      zone: "top",
+      clipPath: "polygon(0 0, 100% 0, 70% 30%, 30% 30%)",
+      previewClass: "inset-0 bottom-1/2",
+    },
+    {
+      zone: "right",
+      clipPath: "polygon(100% 0, 100% 100%, 70% 70%, 70% 30%)",
+      previewClass: "inset-0 left-1/2",
+    },
+    {
+      zone: "bottom",
+      clipPath: "polygon(30% 70%, 70% 70%, 100% 100%, 0 100%)",
+      previewClass: "inset-0 top-1/2",
+    },
+    {
+      zone: "left",
+      clipPath: "polygon(0 0, 30% 30%, 30% 70%, 0 100%)",
+      previewClass: "inset-0 right-1/2",
+    },
+  ];
+
+  return (
+    <div className="absolute inset-0 z-50">
+      {/* Drop zone hit areas */}
+      {zones.map(({ zone, clipPath }) => (
+        /* biome-ignore lint/a11y/useKeyWithClickEvents: drop zones use ESC to cancel and mouse interaction for spatial selection */
+        /* biome-ignore lint/a11y/noStaticElementInteractions: spatial drop zones require mouse-based interaction */
+        <div
+          key={zone}
+          className="absolute inset-0 cursor-pointer"
+          style={{ clipPath }}
+          onMouseEnter={() => setHoveredZone(zone)}
+          onMouseLeave={() => setHoveredZone(null)}
+          onClick={() => handleDrop(zone)}
+        />
+      ))}
+      {/* Preview highlight */}
+      {hoveredZone && (
+        <div
+          className={cn(
+            "absolute pointer-events-none border-2 border-accent bg-accent/15 rounded-sm transition-all duration-100",
+            zones.find((z) => z.zone === hoveredZone)?.previewClass
+          )}
+        />
+      )}
+      {/* Subtle overlay when no zone is hovered */}
+      {!hoveredZone && (
+        <div className="absolute inset-0 pointer-events-none border border-dashed border-muted-foreground/30 rounded-sm" />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add right-click context menu on terminal panes with Split Vertically, Split Horizontally, Move Pane, and Convert to Tab actions
- Move Pane enters an interactive overlay mode where hovering top/right/bottom/left of other panes shows a placement preview, click to confirm
- Convert to Tab extracts a pane into its own independent tab, preserving the terminal session
- Includes `cargo fmt` reformatting for recently added backend test code

## Test plan
- [x] `just check` passes (fmt, biome, clippy, frontend tests, rust tests)
- [x] `just test-e2e` passes (116/116)
- [ ] Right-click a terminal pane to see context menu
- [ ] Split pane via context menu (vertical and horizontal)
- [ ] With 2+ panes: use "Move Pane..." to relocate a pane within the tab
- [ ] With 2+ panes: use "Convert to Tab" to extract a pane into a new tab
- [ ] Verify move overlay shows cancel button on source pane, drop zones on target panes
- [ ] Verify ESC cancels move mode
- [ ] Verify context menu does not appear on Home or Settings tabs