### PR TITLE
fix: remove unused sessionId parameter from mcp.listTools() call

### DIFF
--- a/frontend/components/UnifiedInput/InputStatusRow.tsx
+++ b/frontend/components/UnifiedInput/InputStatusRow.tsx
@@ -351,7 +351,7 @@ export const InputStatusRow = memo(function InputStatusRow({ sessionId }: InputS
         // Only load tools if we have a valid session
         if (sessionId) {
           try {
-            const tools = await mcp.listTools(sessionId);
+            const tools = await mcp.listTools();
             setMcpTools(tools);
           } catch {
             setMcpTools([]);


### PR DESCRIPTION
## Summary
- Removes the `sessionId` argument from the `mcp.listTools()` call in `InputStatusRow` to match its updated function signature.

## Test plan
- [ ] Verify MCP tools still load correctly in the input status row
- [ ] Confirm no TypeScript errors with `just check`