### PR TITLE
feat(models): add Claude Sonnet 4.6 support

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "qbit"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-ai"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-artifacts"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-benchmarks"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-context"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "rig-core",
  "serde",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-core"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-evals"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-json-repair"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "llm_json",
  "serde_json",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-llm-providers"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-mcp"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-models"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "once_cell",
  "qbit-settings",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-pty"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "dirs",
  "itoa",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-session"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-settings"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-shell-exec"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sidecar"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-skills"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "dirs",
  "serde",
@@ -4725,7 +4725,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-sub-agents"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-swebench"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-synthesis"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-tools"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -4813,14 +4813,14 @@ dependencies = [
 
 [[package]]
 name = "qbit-udiff"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "qbit-web"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "qbit-workflow"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5248,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "rig-anthropic-vertex"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-vertex"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -5326,7 +5326,7 @@ dependencies = [
 
 [[package]]
 name = "rig-zai-sdk"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "bytes",
  "futures",

--- a/backend/crates/qbit-context/src/context_manager.rs
+++ b/backend/crates/qbit-context/src/context_manager.rs
@@ -1111,15 +1111,27 @@ mod compaction_tests {
 
         // Start at 80k (provider count after last LLM call)
         state.update_tokens(80_000);
-        assert!(!manager.should_compact(&state, "claude-3-5-sonnet").should_compact);
+        assert!(
+            !manager
+                .should_compact(&state, "claude-3-5-sonnet")
+                .should_compact
+        );
 
         // After tool result 1: proactive estimate = 100k
         state.update_tokens_estimated(100_000);
-        assert!(!manager.should_compact(&state, "claude-3-5-sonnet").should_compact);
+        assert!(
+            !manager
+                .should_compact(&state, "claude-3-5-sonnet")
+                .should_compact
+        );
 
         // After tool result 2: proactive estimate = 130k
         state.update_tokens_estimated(130_000);
-        assert!(!manager.should_compact(&state, "claude-3-5-sonnet").should_compact);
+        assert!(
+            !manager
+                .should_compact(&state, "claude-3-5-sonnet")
+                .should_compact
+        );
 
         // After tool result 3: proactive estimate = 165k — over threshold
         state.update_tokens_estimated(165_000);

--- a/backend/crates/qbit-context/src/token_budget.rs
+++ b/backend/crates/qbit-context/src/token_budget.rs
@@ -46,6 +46,7 @@ pub struct ModelContextLimits {
     pub claude_4_sonnet: usize,
     pub claude_4_opus: usize,
     pub claude_4_6_opus: usize,
+    pub claude_4_6_sonnet: usize,
     pub claude_4_5_opus: usize,
     pub claude_4_5_sonnet: usize,
     pub claude_4_5_haiku: usize,
@@ -73,6 +74,7 @@ impl Default for ModelContextLimits {
             claude_4_sonnet: 200_000,
             claude_4_opus: 200_000,
             claude_4_6_opus: 1_000_000,
+            claude_4_6_sonnet: 1_000_000,
             claude_4_5_opus: 200_000,
             claude_4_5_sonnet: 200_000,
             claude_4_5_haiku: 200_000,
@@ -158,6 +160,13 @@ impl TokenBudgetConfig {
                 || m.contains("claude-haiku-4.5") =>
             {
                 limits.claude_4_5_haiku
+            }
+            m if m.contains("claude-4-6-sonnet")
+                || m.contains("claude-4.6-sonnet")
+                || m.contains("claude-sonnet-4-6")
+                || m.contains("claude-sonnet-4.6") =>
+            {
+                limits.claude_4_6_sonnet
             }
             m if m.contains("claude-4-sonnet") || m.contains("claude-sonnet-4") => {
                 limits.claude_4_sonnet

--- a/backend/crates/qbit-models/src/capabilities.rs
+++ b/backend/crates/qbit-models/src/capabilities.rs
@@ -91,6 +91,19 @@ impl ModelCapabilities {
         }
     }
 
+    /// Create capabilities for Claude Sonnet 4.6 (1M context beta, 128k output).
+    pub fn anthropic_sonnet_4_6() -> Self {
+        Self {
+            supports_temperature: true,
+            supports_thinking_history: true,
+            supports_vision: true,
+            supports_web_search: true,
+            context_window: 1_000_000,  // 1M context (beta)
+            max_output_tokens: 128_000, // 128k output
+            ..Default::default()
+        }
+    }
+
     /// Create capabilities for Claude Opus 4.6 (1M context beta, 128k output).
     pub fn anthropic_opus_4_6() -> Self {
         Self {

--- a/backend/crates/qbit-models/src/providers.rs
+++ b/backend/crates/qbit-models/src/providers.rs
@@ -19,6 +19,13 @@ pub fn vertex_ai_models() -> Vec<ModelDefinition> {
             aliases: &[],
         },
         ModelDefinition {
+            id: "claude-sonnet-4-6@default",
+            display_name: "Claude Sonnet 4.6",
+            provider: AiProvider::VertexAi,
+            capabilities: ModelCapabilities::anthropic_sonnet_4_6(),
+            aliases: &[],
+        },
+        ModelDefinition {
             id: "claude-opus-4-5@20251101",
             display_name: "Claude Opus 4.5",
             provider: AiProvider::VertexAi,
@@ -48,6 +55,13 @@ pub fn vertex_ai_models() -> Vec<ModelDefinition> {
 /// Direct Anthropic API model definitions.
 pub fn anthropic_models() -> Vec<ModelDefinition> {
     vec![
+        ModelDefinition {
+            id: "claude-sonnet-4-6-20260217",
+            display_name: "Claude Sonnet 4.6",
+            provider: AiProvider::Anthropic,
+            capabilities: ModelCapabilities::anthropic_sonnet_4_6(),
+            aliases: &["claude-sonnet-4-6"],
+        },
         ModelDefinition {
             id: "claude-opus-4-5-20251101",
             display_name: "Claude Opus 4.5",

--- a/backend/crates/qbit-models/src/registry.rs
+++ b/backend/crates/qbit-models/src/registry.rs
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn test_get_models_for_provider() {
         let anthropic_models = get_models_for_provider(AiProvider::Anthropic);
-        assert_eq!(anthropic_models.len(), 3);
+        assert_eq!(anthropic_models.len(), 4);
 
         let openai_models = get_models_for_provider(AiProvider::Openai);
         assert!(openai_models.len() >= 10);

--- a/backend/crates/rig-anthropic-vertex/src/lib.rs
+++ b/backend/crates/rig-anthropic-vertex/src/lib.rs
@@ -40,6 +40,8 @@ pub use types::*;
 pub mod models {
     /// Claude Opus 4.6 - Latest most powerful model
     pub const CLAUDE_OPUS_4_6: &str = "claude-opus-4-6@default";
+    /// Claude Sonnet 4.6 - Latest high-performance Sonnet
+    pub const CLAUDE_SONNET_4_6: &str = "claude-sonnet-4-6@default";
     /// Claude Opus 4.5 - Most powerful model
     pub const CLAUDE_OPUS_4_5: &str = "claude-opus-4-5@20251101";
     /// Claude Sonnet 4.5 - Balanced performance

--- a/frontend/components/Settings/AiSettings.tsx
+++ b/frontend/components/Settings/AiSettings.tsx
@@ -154,6 +154,10 @@ export function AiSettings({
                 }
                 options={[
                   {
+                    value: "claude-sonnet-4-6-20260217",
+                    label: "Claude Sonnet 4.6",
+                  },
+                  {
                     value: "claude-opus-4-5-20251101",
                     label: "Claude Opus 4.5 (Most Capable)",
                   },

--- a/frontend/components/Settings/SubAgentSettings.tsx
+++ b/frontend/components/Settings/SubAgentSettings.tsx
@@ -31,12 +31,14 @@ const PROVIDER_OPTIONS: { value: AiProvider; label: string }[] = [
 // Common models by provider (not exhaustive, users can type custom models)
 const MODEL_SUGGESTIONS: Record<AiProvider, string[]> = {
   vertex_ai: [
+    "claude-sonnet-4-6@default",
     "claude-opus-4-5@20251101",
     "claude-sonnet-4-5@20250929",
     "claude-haiku-4-5@20251001",
   ],
   vertex_gemini: ["gemini-2.5-pro-preview-05-06", "gemini-2.5-flash-preview-04-17"],
   anthropic: [
+    "claude-sonnet-4-6-20260217",
     "claude-opus-4-5-20251101",
     "claude-sonnet-4-5-20250929",
     "claude-haiku-4-5-20251001",

--- a/frontend/lib/ai.ts
+++ b/frontend/lib/ai.ts
@@ -723,6 +723,7 @@ export interface VertexAiConfig {
  */
 export const VERTEX_AI_MODELS = {
   CLAUDE_OPUS_4_6: "claude-opus-4-6@default",
+  CLAUDE_SONNET_4_6: "claude-sonnet-4-6@default",
   CLAUDE_OPUS_4_5: "claude-opus-4-5@20251101",
   CLAUDE_SONNET_4_5: "claude-sonnet-4-5@20250929",
   CLAUDE_HAIKU_4_5: "claude-haiku-4-5@20251001",
@@ -781,6 +782,7 @@ export const OPENAI_MODELS = {
  * Available Claude models via direct Anthropic API.
  */
 export const ANTHROPIC_MODELS = {
+  CLAUDE_SONNET_4_6: "claude-sonnet-4-6-20260217",
   CLAUDE_OPUS_4_5: "claude-opus-4-5-20251101",
   CLAUDE_SONNET_4_5: "claude-sonnet-4-5-20250929",
   CLAUDE_HAIKU_4_5: "claude-haiku-4-5-20251001",

--- a/frontend/lib/models.ts
+++ b/frontend/lib/models.ts
@@ -76,6 +76,7 @@ export const PROVIDER_GROUPS: ProviderGroup[] = [
     providerName: "Anthropic",
     icon: "🔶",
     models: [
+      { id: ANTHROPIC_MODELS.CLAUDE_SONNET_4_6, name: "Claude Sonnet 4.6" },
       { id: ANTHROPIC_MODELS.CLAUDE_OPUS_4_5, name: "Claude Opus 4.5" },
       { id: ANTHROPIC_MODELS.CLAUDE_SONNET_4_5, name: "Claude Sonnet 4.5" },
       { id: ANTHROPIC_MODELS.CLAUDE_HAIKU_4_5, name: "Claude Haiku 4.5" },
@@ -317,6 +318,7 @@ export const PROVIDER_GROUPS: ProviderGroup[] = [
     icon: "🔷",
     models: [
       { id: VERTEX_AI_MODELS.CLAUDE_OPUS_4_6, name: "Claude Opus 4.6" },
+      { id: VERTEX_AI_MODELS.CLAUDE_SONNET_4_6, name: "Claude Sonnet 4.6" },
       { id: VERTEX_AI_MODELS.CLAUDE_OPUS_4_5, name: "Claude Opus 4.5" },
       { id: VERTEX_AI_MODELS.CLAUDE_SONNET_4_5, name: "Claude Sonnet 4.5" },
       { id: VERTEX_AI_MODELS.CLAUDE_HAIKU_4_5, name: "Claude Haiku 4.5" },
@@ -374,6 +376,7 @@ export const PROVIDER_GROUPS_NESTED: ProviderGroupNested[] = [
     providerName: "Anthropic",
     icon: "🔶",
     models: [
+      { id: ANTHROPIC_MODELS.CLAUDE_SONNET_4_6, name: "Claude Sonnet 4.6" },
       { id: ANTHROPIC_MODELS.CLAUDE_OPUS_4_5, name: "Claude Opus 4.5" },
       { id: ANTHROPIC_MODELS.CLAUDE_SONNET_4_5, name: "Claude Sonnet 4.5" },
       { id: ANTHROPIC_MODELS.CLAUDE_HAIKU_4_5, name: "Claude Haiku 4.5" },
@@ -697,6 +700,7 @@ export const PROVIDER_GROUPS_NESTED: ProviderGroupNested[] = [
     icon: "🔷",
     models: [
       { id: VERTEX_AI_MODELS.CLAUDE_OPUS_4_6, name: "Claude Opus 4.6" },
+      { id: VERTEX_AI_MODELS.CLAUDE_SONNET_4_6, name: "Claude Sonnet 4.6" },
       { id: VERTEX_AI_MODELS.CLAUDE_OPUS_4_5, name: "Claude Opus 4.5" },
       { id: VERTEX_AI_MODELS.CLAUDE_SONNET_4_5, name: "Claude Sonnet 4.5" },
       { id: VERTEX_AI_MODELS.CLAUDE_HAIKU_4_5, name: "Claude Haiku 4.5" },


### PR DESCRIPTION
## Summary

- Add Claude Sonnet 4.6 to both the **direct Anthropic API** (`claude-sonnet-4-6-20260217`) and **Google Cloud Vertex AI** (`claude-sonnet-4-6@default`) providers
- Model capabilities: 1M context window (beta), 128K max output tokens
- Fix pre-existing `cargo fmt` formatting issues in `agentic_loop.rs` and `context_manager.rs`
- Fix pre-existing clippy `useless_vec` warning in `agentic_loop.rs`

## Changes

**Backend:**
- `qbit-models/src/providers.rs` — model definitions for Vertex AI and Anthropic
- `qbit-models/src/capabilities.rs` — `anthropic_sonnet_4_6()` capability factory (1M ctx, 128K output)
- `qbit-models/src/registry.rs` — updated test assertion for new model count
- `rig-anthropic-vertex/src/lib.rs` — `CLAUDE_SONNET_4_6` constant
- `qbit-context/src/token_budget.rs` — `claude_4_6_sonnet` field + match arm (1M tokens)
- `qbit-ai/src/agentic_loop.rs` — fmt fixes + clippy fix (`vec![]` → array literal)
- `qbit-context/src/context_manager.rs` — fmt fixes

**Frontend:**
- `frontend/lib/ai.ts` — `VERTEX_AI_MODELS` and `ANTHROPIC_MODELS` constants
- `frontend/lib/models.ts` — `PROVIDER_GROUPS` and `PROVIDER_GROUPS_NESTED` (both Anthropic and Vertex AI sections)
- `frontend/components/Settings/SubAgentSettings.tsx` — `MODEL_SUGGESTIONS` for vertex_ai and anthropic
- `frontend/components/Settings/AiSettings.tsx` — synthesis model dropdown

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p qbit-models` — all tests pass (including updated model count assertion)
- [x] `cargo test -p qbit-context` — all context limit tests pass
- [x] `just test-e2e` — 116 passed, 21 skipped