### PR TITLE
fix(qbit): explicitly install default rustls CryptoProvider

### DIFF
--- a/backend/crates/qbit/src/main.rs
+++ b/backend/crates/qbit/src/main.rs
@@ -32,6 +32,13 @@ use clap::Parser;
 use qbit_lib::cli::Args;
 
 fn main() {
+    // Install the default rustls CryptoProvider before any TLS usage.
+    // Required since rustls 0.23 no longer auto-selects a backend.
+    rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::ring::default_provider(),
+    )
+    .expect("Failed to install default CryptoProvider");
+
     // Parse CLI arguments to determine mode
     let args = Args::parse();
 


### PR DESCRIPTION
rustls 0.23+ no longer auto-selects a crypto backend, requiring explicit initialization before any TLS usage. Install the ring-based default provider at startup to prevent runtime panics.